### PR TITLE
Hide unsupported gateway deposit/withdrawal coin types

### DIFF
--- a/web/app/actions/GatewayActions.js
+++ b/web/app/actions/GatewayActions.js
@@ -1,5 +1,6 @@
 import alt from "alt-instance";
 import { fetchCoins, fetchBridgeCoins, getBackedCoins, getActiveWallets } from "common/blockTradesMethods";
+import {blockTradesAPIs} from "api/apiConfig";
 
 let inProgress = {};
 
@@ -11,13 +12,14 @@ class GatewayActions {
             return (dispatch) => {
                 Promise.all([
                     fetchCoins(url),
+                    fetchBridgeCoins(blockTradesAPIs.BASE_OL),
                     getActiveWallets(url)
                 ]).then(result => {
                     delete inProgress["fetchCoins_" + backer];
-                    let [coins, wallets] = result;
+                    let [coins, tradingPairs, wallets] = result;
                     dispatch({
                         coins: coins,
-                        backedCoins: getBackedCoins({allCoins: coins, backer: backer}).filter(a => {
+                        backedCoins: getBackedCoins({allCoins: coins, tradingPairs: tradingPairs, backer: backer}).filter(a => {
                             return wallets.indexOf(a.walletType) !== -1;
                         }),
                         backer
@@ -35,7 +37,7 @@ class GatewayActions {
             return (dispatch) => {
                 Promise.all([
                     fetchCoins(url),
-                    fetchBridgeCoins(url),
+                    fetchBridgeCoins(blockTradesAPIs.BASE),
                     getActiveWallets(url)
                 ]).then(result => {
                     delete inProgress["fetchBridgeCoins"];

--- a/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -90,7 +90,7 @@ class BlockTradesGateway extends React.Component {
             if (!a || !a.symbol) {
                 return false;
             } else {
-                return true;
+                return action === "deposit" ? a.depositAllowed : a.withdrawalAllowed;
             }
         });
 
@@ -109,7 +109,7 @@ class BlockTradesGateway extends React.Component {
 
         let issuers = {
             blocktrades: {name: "blocktrades", id: "1.2.32567", support: "support@blocktrades.us"},
-            openledger: {name: "openledger-wallet", id: "1.2.96397", support: "opensupport@blocktrades.us"}
+            openledger: {name: "openledger-wallet", id: "1.2.96397", support: "support@openledger.info"}
         };
 
         let issuer = issuers[provider];

--- a/web/lib/common/blockTradesMethods.js
+++ b/web/lib/common/blockTradesMethods.js
@@ -10,7 +10,8 @@ export function fetchCoins(url = (blockTradesAPIs.BASE_OL + blockTradesAPIs.COIN
     });
 }
 
-export function fetchBridgeCoins(url = (blockTradesAPIs.BASE + blockTradesAPIs.TRADING_PAIRS)) {
+export function fetchBridgeCoins(baseurl = (blockTradesAPIs.BASE)) {
+    let url = baseurl + blockTradesAPIs.TRADING_PAIRS;
     return fetch(url, {method: "get", headers: new Headers({"Accept": "application/json"})}).then(reply => reply.json().then(result => {
         return result;
     })).catch(err => {
@@ -74,18 +75,31 @@ export function requestDepositAddress({inputCoinType, outputCoinType, outputAddr
     });
 }
 
-export function getBackedCoins({allCoins, backer}) {
+export function getBackedCoins({allCoins, tradingPairs, backer}) {
     let coins_by_type = {};
     allCoins.forEach(coin_type => coins_by_type[coin_type.coinType] = coin_type);
+
+    let allowed_outputs_by_input = {};
+    tradingPairs.forEach(pair => {
+        if (!allowed_outputs_by_input[pair.inputCoinType])
+            allowed_outputs_by_input[pair.inputCoinType] = {};
+        allowed_outputs_by_input[pair.inputCoinType][pair.outputCoinType] = true;
+    });
+
     let blocktradesBackedCoins = [];
     allCoins.forEach(coin_type => {
         if (coin_type.walletSymbol.startsWith(backer + ".") && coin_type.backingCoinType && coins_by_type[coin_type.backingCoinType]) {
+            let isDepositAllowed = allowed_outputs_by_input[coin_type.backingCoinType] && allowed_outputs_by_input[coin_type.backingCoinType][coin_type.coinType];
+            let isWithdrawalAllowed = allowed_outputs_by_input[coin_type.coinType] && allowed_outputs_by_input[coin_type.coinType][coin_type.backingCoinType];
+
             blocktradesBackedCoins.push({
                 name: coins_by_type[coin_type.backingCoinType].name,
                 walletType: coins_by_type[coin_type.backingCoinType].walletType,
                 backingCoinType: coins_by_type[coin_type.backingCoinType].walletSymbol,
                 symbol: coin_type.walletSymbol,
-                supportsMemos: coins_by_type[coin_type.backingCoinType].supportsOutputMemos
+                supportsMemos: coins_by_type[coin_type.backingCoinType].supportsOutputMemos,
+                depositAllowed: isDepositAllowed,
+                withdrawalAllowed: isWithdrawalAllowed
             });
         }});
     return blocktradesBackedCoins;


### PR DESCRIPTION
In the gateway deposit/withdraw drop-downs, don't show coin types the
gateway has disabled (important during OPEN.NSR -> OPEN.NUSHARES
transition).
Update the support email for OpenLedger gateway.