### PR TITLE
Remove poloniex from "known scams"

### DIFF
--- a/web/lib/common/account_utils.js
+++ b/web/lib/common/account_utils.js
@@ -90,7 +90,6 @@ export default class AccountUtils {
             "poloniexwallett",
             "poloniexwall-t",
             "poloniexwalle",
-            "poloniex",
             "poloneix"
         ];
 


### PR DESCRIPTION
Looks like poloniex isn't scam account. More: https://bitsharestalk.org/index.php/topic,24266.0/topicseen.html