### PR TITLE
Use number input with check on decimal value to resolve duplicate decimal issue

### DIFF
--- a/web/app/components/Exchange/BuySell.jsx
+++ b/web/app/components/Exchange/BuySell.jsx
@@ -11,6 +11,7 @@ import AssetName from "../Utility/AssetName";
 import SimpleDepositWithdraw from "../Dashboard/SimpleDepositWithdraw";
 import SimpleDepositBlocktradesBridge from "../Dashboard/SimpleDepositBlocktradesBridge";
 import {Asset} from "common/MarketClasses";
+import ExchangeInput from "./ExchangeInput";
 
 class BuySell extends React.Component {
 
@@ -147,7 +148,7 @@ class BuySell extends React.Component {
                                         <Translate content="exchange.price" />:
                                     </div>
                                     <div className="grid-block small-5 no-margin no-overflow buy-sell-input">
-                                        <input type="number" id="buyPrice" value={price} onChange={priceChange} autoComplete="off" placeholder="0.0"/>
+                                        <ExchangeInput id="buyPrice" value={price} onChange={priceChange} autoComplete="off" placeholder="0.0" />
                                     </div>
                                     <div className="grid-block small-4 no-margin no-overflow buy-sell-box">
                                         <AssetName dataPlace="right" name={base.get("symbol")} />
@@ -161,7 +162,7 @@ class BuySell extends React.Component {
                                         <Translate content="transfer.amount" />:
                                     </div>
                                     <div className="grid-block small-5 no-margin no-overflow buy-sell-input">
-                                        <input type="number" id="buyAmount" value={amount} onChange={amountChange} autoComplete="off" placeholder="0.0"/>
+                                        <ExchangeInput id="buyAmount" value={amount} onChange={amountChange} autoComplete="off" placeholder="0.0"/>
                                     </div>
                                     <div className="grid-block small-4 no-margin no-overflow buy-sell-box">
                                         <AssetName dataPlace="right" name={quote.get("symbol")} />
@@ -173,7 +174,7 @@ class BuySell extends React.Component {
                                         <Translate content="exchange.total" />:
                                     </div>
                                     <div className="grid-block small-5 no-margin no-overflow buy-sell-input">
-                                        <input type="number" id="buyAmount" value={total} onChange={totalChange} autoComplete="off" placeholder="0.0"/>
+                                        <ExchangeInput id="buyAmount" value={total} onChange={totalChange} autoComplete="off" placeholder="0.0"/>
                                     </div>
                                     <div className="grid-block small-4 no-margin no-overflow buy-sell-box">
                                         <AssetName dataPlace="right" name={base.get("symbol")} />

--- a/web/app/components/Exchange/ExchangeInput.jsx
+++ b/web/app/components/Exchange/ExchangeInput.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+class ExchangeInput extends React.Component {
+    constructor(){
+        super();
+    }
+
+    onKeyPress(e){
+        var nextValue = e.target.value + e.key;
+        var decimal = nextValue.match(/\./g);
+        var decimalCount = decimal ? decimal.length : 0;
+        if(e.key === '.' && decimalCount > 1) e.preventDefault();
+
+        if(this.props.onKeyPress) this.props.onKeyPress(e);
+    }
+
+    render(){
+        return <input type="number" {...this.props} onKeyPress={this.onKeyPress.bind(this)} />
+    }
+}
+
+export default ExchangeInput;


### PR DESCRIPTION
Added a component to allow additional logic wrapping the number input type which is being used for buy / sell form.

By checking the next value after key press, this input can prevent duplicate decimals from being added. Resolves [issue #137](https://github.com/bitshares/bitshares-ui/issues/137).