### PR TITLE
Resolve Issue 47 - Ensure primary asset shows up in balance calculations

### DIFF
--- a/web/app/components/Utility/TotalBalanceValue.jsx
+++ b/web/app/components/Utility/TotalBalanceValue.jsx
@@ -192,7 +192,7 @@ class TotalValue extends React.Component {
         balances.forEach(balance => {
             let fromAsset = assets[balance.asset_id];
             if (fromAsset) {
-                let eqValue = this._convertValue(balance.amount, fromAsset, toAsset, marketStats, coreAsset);
+                let eqValue = fromAsset !== toAsset ? this._convertValue(balance.amount, fromAsset, toAsset, marketStats, coreAsset) : balance.amount;
                 totalValue += eqValue;
                 assetValues = this._assetValues(assetValues, eqValue, fromAsset.get("id"));
             }

--- a/web/app/components/Utility/TotalBalanceValue.jsx
+++ b/web/app/components/Utility/TotalBalanceValue.jsx
@@ -190,15 +190,11 @@ class TotalValue extends React.Component {
 
         // Balance value
         balances.forEach(balance => {
-            if (balance.asset_id === toAsset.get("id")) {
-                totalValue += balance.amount;
-            } else {
-                let fromAsset = assets[balance.asset_id];
-                if (fromAsset) {
-                    let eqValue = this._convertValue(balance.amount, fromAsset, toAsset, marketStats, coreAsset);
-                    totalValue += eqValue;
-                    assetValues = this._assetValues(assetValues, eqValue, fromAsset.get("id"));
-                }
+            let fromAsset = assets[balance.asset_id];
+            if (fromAsset) {
+                let eqValue = this._convertValue(balance.amount, fromAsset, toAsset, marketStats, coreAsset);
+                totalValue += eqValue;
+                assetValues = this._assetValues(assetValues, eqValue, fromAsset.get("id"));
             }
         });
 


### PR DESCRIPTION
Resolves [issue 47](https://github.com/bitshares/bitshares-ui/issues/47).

The problem was the loop was skipping setting assetValues (used to display the drop down values) for the primary asset.

I just removed the if condition. Here is screenshot showing correct values:

![asset-value-calc](https://user-images.githubusercontent.com/632938/29287159-1d4291e6-80fa-11e7-9915-4ef7042ef5a5.png)
