### PR TITLE
Resolve issue 163 (text cut off in some drop downs)

### DIFF
--- a/web/app/App.jsx
+++ b/web/app/App.jsx
@@ -239,6 +239,17 @@ class Root extends React.Component {
         location: React.PropTypes.object
     }
 
+    componentDidMount(){
+        //Detect OS for platform specific fixes
+        if(navigator.platform.indexOf('Win') > -1){
+            var main = document.getElementById('content');
+            var windowsClass = 'windows';
+            if(main.className.indexOf('windows') === -1){
+                main.className = main.className + (main.className.length ? ' ' : '') + windowsClass;
+            }
+        }
+    }
+
     getChildContext() {
         return {
             router: this.props.router,

--- a/web/app/assets/stylesheets/_shame.scss
+++ b/web/app/assets/stylesheets/_shame.scss
@@ -359,6 +359,10 @@ select.bts-select {
     appearance: menulist;
 }
 
+.windows select.bts-select {
+    height: 2.35em;
+}
+
 @media screen and (min-width: 900px) {
     .column-show-small {
         display: none !important;


### PR DESCRIPTION
Resolves [issue 163](https://github.com/bitshares/bitshares-ui/issues/163) by adding a windows specific selector for increasing select height.

Before:

<img width="690" alt="transfer-cut-off" src="https://user-images.githubusercontent.com/632938/29289056-bbe51638-8100-11e7-9cf4-eae6f912155d.png">

After:

<img width="655" alt="transfer-cut-off-fixed" src="https://user-images.githubusercontent.com/632938/29289062-c0e23af8-8100-11e7-9740-c68ad5f67bdd.png">

Follow up with issue reporter after fix is merged  to ensure the fix was sufficient (I think it should be).

