### PR TITLE
Resolve Issue #66

### DIFF
--- a/web/app/components/Exchange/MarketHistory.jsx
+++ b/web/app/components/Exchange/MarketHistory.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import ReactDOM from "react-dom";
 import {PropTypes} from "react";
 import {Link} from "react-router/es";
 import Immutable from "immutable";
@@ -55,7 +54,7 @@ class MarketHistory extends React.Component {
         });
 
         // Ensure that focus goes back to top of scrollable container when tab is changed
-        let historyNode = ReactDOM.findDOMNode(this.refs.history);
+        let historyNode = this.refs.history;
         historyNode.scrollTop = 0;
         Ps.update(historyNode);
     }

--- a/web/app/components/Exchange/MarketHistory.jsx
+++ b/web/app/components/Exchange/MarketHistory.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import {PropTypes} from "react";
 import {Link} from "react-router/es";
 import Immutable from "immutable";
@@ -52,6 +53,11 @@ class MarketHistory extends React.Component {
         this.setState({
             activeTab: tab
         });
+
+        // Ensure that focus goes back to top of scrollable container when tab is changed
+        let historyNode = ReactDOM.findDOMNode(this.refs.history);
+        historyNode.scrollTop = 0;
+        Ps.update(historyNode);
     }
 
     render() {


### PR DESCRIPTION
PR for #66.
This shows the bug identified by users:

![issue-66-verification](https://user-images.githubusercontent.com/632938/29291571-9e187a56-8109-11e7-89d3-37b227c5d152.gif)

This shows the fix:

![issue-66-fixed](https://user-images.githubusercontent.com/632938/29291584-a3a53d60-8109-11e7-9345-fe599d7c6e26.gif)

The solution was to have the scroll bar library being used scroll back to the top of the container on tab change.
