### PR TITLE
Resolve Issue #235 - Prevent Auto Return to Top Refresh while Scrolling Down the Open Orders List

### DIFF
--- a/web/app/components/Exchange/OrderBook.jsx
+++ b/web/app/components/Exchange/OrderBook.jsx
@@ -126,7 +126,7 @@ class OrderBook extends React.Component {
         }
 
         // Change of market or direction
-        if (nextProps.base.get('id') !== this.props.base.get('id') || nextProps.quote.get('id') !== this.props.quote.get('id')) {
+        if (nextProps.base.get("id") !== this.props.base.get("id") || nextProps.quote.get("id") !== this.props.quote.get("id")) {
             this.setState({
                 scrollToBottom: true
             });

--- a/web/app/components/Exchange/OrderBook.jsx
+++ b/web/app/components/Exchange/OrderBook.jsx
@@ -126,7 +126,7 @@ class OrderBook extends React.Component {
         }
 
         // Change of market or direction
-        if (nextProps.base !== this.props.base || nextProps.quote !== this.props.quote) {
+        if (nextProps.base.get('id') !== this.props.base.get('id') || nextProps.quote.get('id') !== this.props.quote.get('id')) {
             this.setState({
                 scrollToBottom: true
             });


### PR DESCRIPTION
PR for #235 .

Only change market or direction will scroll to top , if reload order will not scroll to top. 