### PR TITLE
Fix a bunch of UI padding issues

### DIFF
--- a/web/app/assets/stylesheets/components/_help.scss
+++ b/web/app/assets/stylesheets/components/_help.scss
@@ -1,6 +1,5 @@
 .help-content {
-    max-width: 600px;
-    padding: 5px;
+  margin: 0 .5rem;
 }
 .help-content > table {
   width: 100%;

--- a/web/app/assets/stylesheets/layout/_page_layout.scss
+++ b/web/app/assets/stylesheets/layout/_page_layout.scss
@@ -82,3 +82,9 @@ div.bordered-header {
       font-size: 1.125rem;
   }
 }
+
+.grid-container {
+  margin: 0 1rem;
+  max-width: 800px;
+}
+

--- a/web/app/assets/stylesheets/themes/_theme-template.scss
+++ b/web/app/assets/stylesheets/themes/_theme-template.scss
@@ -376,6 +376,8 @@
       border-top: 1px solid $border-color;
     }
     header {
+      margin-left: 0;
+      margin-bottom: 1rem;
       color: $secondary-text-color;
     }
   }
@@ -1076,7 +1078,9 @@
 
   // Settings
   .settings-menu {
+      margin-left: 0;
       > li {
+          padding: 0 1rem;
           &:hover {
                 background-color: darken($light-panel-bg-color, 5%);
           }

--- a/web/app/components/Account/AccountAssetCreate.jsx
+++ b/web/app/components/Account/AccountAssetCreate.jsx
@@ -536,7 +536,7 @@ class AccountAssetCreate extends React.Component {
             <div className="grid-block">
                 <div className="grid-content">
                     <h3><Translate content="header.create_asset" /></h3>
-                    <Tabs setting="createAssetTab" style={{maxWidth: "800px"}} contentClass="grid-block shrink small-vertical medium-horizontal">
+                    <Tabs setting="createAssetTab" contentClass="grid-block shrink small-vertical medium-horizontal">
 
                         <Tab title="account.user_issued_assets.primary">
                             <div className="small-12 grid-content">

--- a/web/app/components/Account/AccountAssetUpdate.jsx
+++ b/web/app/components/Account/AccountAssetUpdate.jsx
@@ -521,7 +521,7 @@ class AccountAssetUpdate extends React.Component {
                 <div className="grid-content">
                     <h3><Translate content="header.update_asset" />: {symbol}</h3>
 
-                        <Tabs setting="updateAssetTab" style={{maxWidth: "800px"}} contentClass="grid-block shrink small-vertical medium-horizontal">
+                        <Tabs setting="updateAssetTab" contentClass="grid-block shrink small-vertical medium-horizontal">
                             <Tab title="account.user_issued_assets.primary">
                                 <div className="small-12 large-8 grid-content">
                                     <h3><Translate content="account.user_issued_assets.primary" /></h3>

--- a/web/app/components/Account/AccountOverview.jsx
+++ b/web/app/components/Account/AccountOverview.jsx
@@ -201,7 +201,7 @@ class AccountOverview extends React.Component {
                 );
             }
             balances.push(
-                <tr key={asset.get("symbol")} style={{maxWidth: "100rem"}}>
+                <tr key={asset.get("symbol")}>
                     <td style={{textAlign: "right"}}>
                         {hasBalance || hasOnOrder ? <BalanceComponent balance={balance} assetInfo={assetInfoLinks}/> : null}
                     </td>

--- a/web/app/components/Account/AccountPermissions.jsx
+++ b/web/app/components/Account/AccountPermissions.jsx
@@ -246,7 +246,7 @@ class AccountPermissions extends React.Component {
                     <Tabs setting="permissionsTabs" tabsClass="no-padding bordered-header" contentClass="grid-content no-overflow no-padding">
 
                     <Tab title="account.perm.active">
-                            <HelpContent style={{maxWidth: "800px"}} path="components/AccountPermActive" />
+                            <HelpContent path="components/AccountPermActive" />
                             <form className="threshold">
                                 <label className="horizontal"><Translate content="account.perm.threshold"/> &nbsp; &nbsp;
                                     <input type="number" placeholder="0" size="5"
@@ -292,7 +292,7 @@ class AccountPermissions extends React.Component {
                     </Tab>
 
                     <Tab title="account.perm.owner">
-                            <HelpContent style={{maxWidth: "800px"}} path="components/AccountPermOwner" />
+                            <HelpContent path="components/AccountPermOwner" />
                             <form className="threshold">
                                 <label className="horizontal"><Translate content="account.perm.threshold"/> &nbsp; &nbsp;
                                     <input type="number" placeholder="0" size="5"
@@ -320,7 +320,7 @@ class AccountPermissions extends React.Component {
                     </Tab>
 
                     <Tab title="account.perm.memo_key">
-                        <HelpContent style={{maxWidth: "800px"}} path="components/AccountPermMemo" />
+                        <HelpContent path="components/AccountPermMemo" />
                         <PubKeyInput
                             ref="memo_key"
                             value={this.state.memo_key}

--- a/web/app/components/Account/AccountPermissionsMigrate.jsx
+++ b/web/app/components/Account/AccountPermissionsMigrate.jsx
@@ -64,10 +64,10 @@ export default class AccountPermissionsMigrate extends React.Component {
 
         return (
                 <div>
-                    <p style={{maxWidth: "800px"}}><Translate content="account.perm.password_model_1" /></p>
+                    <p><Translate content="account.perm.password_model_1" /></p>
 
-                    <p style={{maxWidth: "800px"}}><Translate content="wallet.password_model_1" /></p>
-                    <p style={{maxWidth: "800px"}}><Translate unsafe content="wallet.password_model_2" /></p>
+                    <p><Translate content="wallet.password_model_1" /></p>
+                    <p><Translate unsafe content="wallet.password_model_2" /></p>
 
                     <div className="divider" />
 
@@ -112,7 +112,7 @@ export default class AccountPermissionsMigrate extends React.Component {
                         </tbody>
                     </table>
 
-                    {memoInUse ? <p style={{maxWidth: "800px", paddingTop: 10}} className="has-error"><Translate content="account.perm.memo_warning" /></p> : null}
+                    {memoInUse ? <p style={{paddingTop: 10}} className="has-error"><Translate content="account.perm.memo_warning" /></p> : null}
 
 
                 </div>

--- a/web/app/components/Account/AccountSelector.jsx
+++ b/web/app/components/Account/AccountSelector.jsx
@@ -131,6 +131,7 @@ class AccountSelector extends React.Component {
                                     onChange={this.onInputChanged.bind(this)}
                                     onKeyDown={this.onKeyDown.bind(this)}
                                     tabIndex={this.props.tabIndex}
+                                    style={{margin: '0 .5rem'}}
                                 />
                                 {this.props.dropDownContent ? <div className="form-label select floating-dropdown">
                                     <FloatingDropdown

--- a/web/app/components/Account/AccountVoting.jsx
+++ b/web/app/components/Account/AccountVoting.jsx
@@ -468,7 +468,7 @@ class AccountVoting extends React.Component {
 
         return (
             <div className="grid-content">
-                <HelpContent style={{maxWidth: "800px"}} path="components/AccountVoting" />
+                <HelpContent path="components/AccountVoting" />
 
                 <div className="content-block">
                     <button className={cnames(publish_buttons_class, {success: this.isChanged()})} onClick={this.onPublish} tabIndex={4}>
@@ -483,7 +483,7 @@ class AccountVoting extends React.Component {
 
                         <Tab title="account.votes.proxy_short">
                             <div className="content-block">
-                                <HelpContent style={{maxWidth: "800px"}} path="components/AccountVotingProxy" />
+                                <HelpContent path="components/AccountVotingProxy" />
                                 <AccountVotingProxy
                                     ref="voting_proxy"
                                     existingProxy={this.props.account.getIn(["options", "voting_account"])}
@@ -496,7 +496,7 @@ class AccountVoting extends React.Component {
 
                         <Tab title="explorer.witnesses.title">
                             <div className={cnames("content-block", {disabled : proxy_is_set})}>
-                                <HelpContent style={{maxWidth: "800px"}} path="components/AccountVotingWitnesses" />
+                                <HelpContent path="components/AccountVotingWitnesses" />
                                 <AccountsList
                                     type="witness"
                                     label="account.votes.add_witness_label"
@@ -526,7 +526,7 @@ class AccountVoting extends React.Component {
 
                         <Tab title="explorer.committee_members.title">
                             <div className={cnames("content-block", {disabled : proxy_is_set})}>
-                                <HelpContent style={{maxWidth: "800px"}} path="components/AccountVotingCommittee" />
+                                <HelpContent path="components/AccountVotingCommittee" />
                                 <AccountsList
                                     type="committee"
                                     label="account.votes.add_committee_label"
@@ -557,7 +557,7 @@ class AccountVoting extends React.Component {
                         <Tab title="account.votes.workers_short">
 
                             <div className={cnames("content-block")}>
-                                <HelpContent style={{maxWidth: "800px"}} path="components/AccountVotingWorkers" />
+                                <HelpContent path="components/AccountVotingWorkers" />
 
                                 <div style={{paddingBottom: 20}}>
                                     <Link to="/create-worker"><div className="button">Create a new worker</div></Link>

--- a/web/app/components/Account/AccountVotingProxy.jsx
+++ b/web/app/components/Account/AccountVotingProxy.jsx
@@ -141,7 +141,7 @@ class AccountVotingProxy extends React.Component {
         });
 
         return (
-            <div className="content-block" style={{maxWidth: "600px"}}>
+            <div className="content-block">
                 {isDisabled ? null :<Translate component="h3" content="account.votes.proxy_short" />}
                 {isDisabled ? <div>
                     <p>

--- a/web/app/components/Utility/HelpContent.jsx
+++ b/web/app/components/Utility/HelpContent.jsx
@@ -15,12 +15,17 @@ function split_into_sections(str) {
     let sections = str.split(/\[#\s?(.+?)\s?\]/);
     if (sections.length === 1) return sections[0];
     if (sections[0].length < 4) sections.splice(0, 1);
+
     sections = reduce(sections, (result, n) => {
         let last = result.length > 0 ? result[result.length-1] : null;
         if (!last || last.length === 2) { last = [n]; result.push(last); }
-        else last.push(n);
+        else {
+          // remove the useless `</p>` before the section=
+          last.push(n.replace(/^<\/p>\n/, '').replace(/<p>$/, ''));
+        }
         return result;
     }, []);
+
     return zipObject(sections);
 }
 


### PR DESCRIPTION
Changes:

Left justify the main body block ([from here](https://github.com/bitshares/bitshares-ui/issues/254#issuecomment-322764255)) which improved the experience in wide screens.
Fixed a bunch of UI margin/padding issues, cleaned up some hard coded CSS. Fixed #254.

---

Details:

Fixed #254:

![image](https://user-images.githubusercontent.com/31077240/29382967-fa7589ac-8293-11e7-93a6-2ddb1c13a148.png)

Other UI padding issue screenshots (which have been fixed in this PR):

1. Extra spacing: 

![image](https://user-images.githubusercontent.com/31077240/29382958-ef16d188-8293-11e7-93e3-a1d2371249db.png)

2. Wrong hovering highlighting area:

![image](https://user-images.githubusercontent.com/31077240/29382947-eac7cc2c-8293-11e7-9ca3-7f5cc4394b61.png)

3. Misaligned label:

![image](https://user-images.githubusercontent.com/31077240/29382989-1b50bc1e-8294-11e7-9df4-be81345615f2.png)

4. No spacing between the input and button:

![image](https://user-images.githubusercontent.com/31077240/29383035-4f2c95ee-8294-11e7-9419-78afb8c17c98.png)
