### PR TITLE
Fix a bunch of UI padding issues (update)

### DIFF
--- a/web/app/assets/stylesheets/components/_account.scss
+++ b/web/app/assets/stylesheets/components/_account.scss
@@ -1,6 +1,5 @@
 .account-left-panel {
     > div.grid-block {
-        padding-top: 1rem;
         border-right: 1px solid $border-color;
     }
   .account-buttons-row .button {

--- a/web/app/assets/stylesheets/components/_help.scss
+++ b/web/app/assets/stylesheets/components/_help.scss
@@ -1,6 +1,5 @@
 .help-content {
     max-width: 600px;
-    padding: 5px;
 }
 .help-content > table {
   width: 100%;

--- a/web/app/assets/stylesheets/layout/_page_layout.scss
+++ b/web/app/assets/stylesheets/layout/_page_layout.scss
@@ -1,5 +1,4 @@
 .page-layout {
-
   > .grid-block {
     border-top: 1px solid transparent;
     border-bottom: 1px solid transparent;
@@ -24,7 +23,6 @@
   .regular-padding {
     padding: 2rem 1.75rem !important;
   }
-
 }
 
 #account-notify {

--- a/web/app/assets/stylesheets/layout/_page_layout.scss
+++ b/web/app/assets/stylesheets/layout/_page_layout.scss
@@ -13,6 +13,7 @@
   }
 
   .main-content {
+    padding-top: 1.5rem;
     background-color: #f3f3f3;
   }
 
@@ -21,7 +22,7 @@
   }
 
   .regular-padding {
-    padding: 1rem 1.75rem 1rem 1.75rem !important;
+    padding: 2rem 1.75rem !important;
   }
 
 }

--- a/web/app/assets/stylesheets/themes/_theme-template.scss
+++ b/web/app/assets/stylesheets/themes/_theme-template.scss
@@ -376,6 +376,8 @@
       border-top: 1px solid $border-color;
     }
     header {
+      margin-left: 0;
+      margin-bottom: 1rem;
       color: $secondary-text-color;
     }
   }
@@ -1079,7 +1081,9 @@
 
   // Settings
   .settings-menu {
+      margin-left: 0;
       > li {
+          padding: .2rem 1rem;
           &:hover {
                 background-color: darken($light-panel-bg-color, 5%);
           }
@@ -1087,7 +1091,6 @@
           &.active {
                 color: $link-text-color;
           }
-
       }
   }
 

--- a/web/app/assets/stylesheets/vendors/_foundation_overrides.scss
+++ b/web/app/assets/stylesheets/vendors/_foundation_overrides.scss
@@ -141,10 +141,13 @@ a {
   }
 }
 
-
-
 code {
   color: inherit;
   background-color: inherit;
   border: none;
+}
+
+// expand the container to fit the maximum width by default
+.grid-container {
+  width: 100%;
 }

--- a/web/app/assets/stylesheets/vendors/_foundation_settings.scss
+++ b/web/app/assets/stylesheets/vendors/_foundation_settings.scss
@@ -233,8 +233,8 @@ $breakpoint-classes: (small medium large xlarge);
 // - - - - - - - - - - - - - - - - - - - -
 
 $container-width: 75rem;
-// $block-padding: $global-padding;
-   $total-columns: 12;
+$block-padding: 1.5rem;
+$total-columns: 12;
 // $block-grid-max-size: 6;
 
 // 6. Accordion

--- a/web/app/components/Account/AccountAssetUpdate.jsx
+++ b/web/app/components/Account/AccountAssetUpdate.jsx
@@ -521,7 +521,7 @@ class AccountAssetUpdate extends React.Component {
                 <div className="grid-content">
                     <h3><Translate content="header.update_asset" />: {symbol}</h3>
 
-                        <Tabs setting="updateAssetTab" style={{maxWidth: "800px"}} contentClass="grid-block shrink small-vertical medium-horizontal">
+                        <Tabs setting="updateAssetTab" contentClass="grid-block shrink small-vertical medium-horizontal">
                             <Tab title="account.user_issued_assets.primary">
                                 <div className="small-12 large-8 grid-content">
                                     <h3><Translate content="account.user_issued_assets.primary" /></h3>

--- a/web/app/components/Account/AccountPage.jsx
+++ b/web/app/components/Account/AccountPage.jsx
@@ -46,7 +46,7 @@ class AccountPage extends React.Component {
                     />
                 </div>
                 <div className="grid-block main-content">
-                    <div className="grid-container" style={{paddingTop: 25}}>
+                    <div className="grid-container">
                     {React.cloneElement(
                         React.Children.only(this.props.children),
                         {

--- a/web/app/components/Account/AccountVesting.jsx
+++ b/web/app/components/Account/AccountVesting.jsx
@@ -124,14 +124,11 @@ class AccountVesting extends React.Component {
 
         return (
             <div className="grid-content" style={{overflowX: "hidden"}}>
-
-                <div className="grid-content">
-                    <Translate content="account.vesting.explain" component="p" />
-                    {!balances.length ? (
-                    <h4 style={{paddingTop: "1rem"}}>
-                        <Translate content={"account.vesting.no_balances"}/>
-                    </h4>) : balances}
-                </div>
+                <Translate content="account.vesting.explain" component="p" />
+                {!balances.length ? (
+                <h4 style={{paddingTop: "1rem"}}>
+                    <Translate content={"account.vesting.no_balances"}/>
+                </h4>) : balances}
             </div>
 );
     }

--- a/web/app/components/Blockchain/Asset.jsx
+++ b/web/app/components/Blockchain/Asset.jsx
@@ -496,29 +496,32 @@ class Asset extends React.Component {
 
         return (
             <div className="grid-block page-layout">
-                <div className="grid-block vertical" style={{overflow:"visible"}}>
-                    <div className="grid-block small-12 shrink" style={{ overflow:"visible"}}>
-                        {this.renderAboutBox(asset)}
-                    </div>
-                    <div className="grid-block small-12 shrink vertical medium-horizontal" style={{ overflow:"visible"}}>
-                        <div className="small-12 medium-6" style={{overflow:"visible"}}>
-                            {this.renderSummary(asset)}
-                        </div>
-                        <div className="small-12 medium-6" style={{overflow:"visible"}}>
-                            {priceFeed ? priceFeed : this.renderPermissions(asset)}
-                        </div>
-                    </div>
-                    <div className="grid-block small-12 shrink vertical medium-horizontal" style={{ overflow:"visible"}}>
-                        <div className="small-12 medium-6" style={{overflow:"visible"}}>
-                            {this.renderFeePool(asset)}
-                        </div>
-                        <div className="small-12 medium-6" style={{overflow:"visible"}}>
-                            {priceFeed ? this.renderPermissions(asset) : null}
-                        </div>
-                    </div>
+                <div className="grid-block main-content vertical" style={{overflow:"visible"}}>
+                    <div className="grid-container">
+                        <div className="grid-content">
+                            <div className="grid-block no-margin small-12 shrink" style={{ overflow:"visible"}}>
+                                {this.renderAboutBox(asset)}
+                            </div>
+                            <div className="grid-block no-margin small-12 shrink vertical medium-horizontal" style={{ overflow:"visible"}}>
+                                <div className="small-12 medium-6" style={{overflow:"visible"}}>
+                                    {this.renderSummary(asset)}
+                                </div>
+                                <div className="small-12 medium-6" style={{overflow:"visible"}}>
+                                  {priceFeed ? priceFeed : this.renderPermissions(asset)}
+                                </div>
+                            </div>
+                            <div className="grid-block no-margin small-12 shrink vertical medium-horizontal" style={{ overflow:"visible"}}>
+                                <div className="small-12 medium-6" style={{overflow:"visible"}}>
+                                    {this.renderFeePool(asset)}
+                                </div>
+                                <div className="small-12 medium-6" style={{overflow:"visible"}}>
+                                    {priceFeed ? this.renderPermissions(asset) : null}
+                                </div>
+                            </div>
 
-                    {priceFeedData}
-
+                            {priceFeedData}
+                        </div>
+                    </div>
                 </div>
             </div>
         );

--- a/web/app/components/Chat/ChatWrapper.jsx
+++ b/web/app/components/Chat/ChatWrapper.jsx
@@ -61,14 +61,10 @@ export default class ChatWrapper extends React.Component {
                         </div>
 
                         <div className="grid-block vertical no-overflow chatbox-content">
-                            <div
-                                className="grid-content"
-                                ref="chatbox"
-                                style={{
-                                    textAlign: "center",
-                                    paddingTop: 120
-                                }}>
-                                <Translate component="p" unsafe content="chat.telegram_link" />
+                            <div className="grid-content v-align" ref="chatbox">
+                                <div className="text-center align-center">
+                                    <Translate component="p" unsafe content="chat.telegram_link" />
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/web/app/components/Explorer/Assets.jsx
+++ b/web/app/components/Explorer/Assets.jsx
@@ -187,7 +187,7 @@ class Assets extends React.Component {
         return (
             <div className="grid-block vertical">
                 <div className="grid-block page-layout">
-                    <div className="grid-block small-12 medium-10 medium-offset-1 main-content vertical">
+                    <div className="grid-block main-content small-12 medium-10 medium-offset-1 main-content vertical">
                         <div className="generic-bordered-box">
                             <Tabs
                                 tabsClass="no-padding bordered-header"
@@ -197,57 +197,69 @@ class Assets extends React.Component {
                             >
                                 <Tab title="explorer.assets.market">
                                     <div className="grid-block shrink">
-                                        <input style={{maxWidth: "500px"}} placeholder={placeholder} type="text" value={this.state.filterMPA} onChange={this._onFilter.bind(this, "filterMPA")}></input>
+                                        <div className="grid-content">
+                                            <input style={{maxWidth: "500px"}} placeholder={placeholder} type="text" value={this.state.filterMPA} onChange={this._onFilter.bind(this, "filterMPA")}></input>
+                                        </div>
                                     </div>
                                     <div className="grid-block" style={{paddingBottom: 20}}>
-                                        <table className="table">
-                                            <thead>
-                                            <tr>
-                                                <th><Translate component="span" content="explorer.assets.symbol" /></th>
-                                                <th><Translate component="span" content="explorer.assets.issuer" /></th>
-                                                <th><Translate component="span" content="markets.supply" /></th>
-                                                <th></th>
-                                            </tr>
-                                            </thead>
+                                        <div className="grid-content">
+                                            <table className="table">
+                                                <thead>
+                                                <tr>
+                                                    <th><Translate component="span" content="explorer.assets.symbol" /></th>
+                                                    <th><Translate component="span" content="explorer.assets.issuer" /></th>
+                                                    <th><Translate component="span" content="markets.supply" /></th>
+                                                    <th></th>
+                                                </tr>
+                                                </thead>
                                                 <tbody>
-                                                    {mia}
+                                                {mia}
                                                 </tbody>
-                                        </table>
+                                            </table>
+                                        </div>
                                     </div>
                                 </Tab>
 
                                 <Tab title="explorer.assets.user">
                                     <div className="grid-block shrink">
-                                        <input style={{maxWidth: "500px"}} placeholder={placeholder} type="text" value={this.state.filterUIA} onChange={this._onFilter.bind(this, "filterUIA")}></input>
+                                        <div className="grid-content">
+                                            <input style={{maxWidth: "500px"}} placeholder={placeholder} type="text" value={this.state.filterUIA} onChange={this._onFilter.bind(this, "filterUIA")}></input>
+                                        </div>
                                     </div>
                                     <div className="grid-block" style={{paddingBottom: 20}}>
-                                        <table className="table">
-                                            <thead>
-                                            <tr>
-                                                <th><Translate component="span" content="explorer.assets.symbol" /></th>
-                                                <th><Translate component="span" content="explorer.assets.issuer" /></th>
-                                                <th><Translate component="span" content="markets.supply" /></th>
-                                                <th></th>
-                                            </tr>
-                                            </thead>
+                                        <div className="grid-content">
+                                            <table className="table">
+                                                <thead>
+                                                <tr>
+                                                    <th><Translate component="span" content="explorer.assets.symbol" /></th>
+                                                    <th><Translate component="span" content="explorer.assets.issuer" /></th>
+                                                    <th><Translate component="span" content="markets.supply" /></th>
+                                                    <th></th>
+                                                </tr>
+                                                </thead>
 
-                                            <tbody>
+                                                <tbody>
                                                 {uia}
-                                            </tbody>
-                                        </table>
+                                                </tbody>
+                                            </table>
+                                        </div>
                                     </div>
                                 </Tab>
 
                                 <Tab title="explorer.assets.prediction">
                                     <div className="grid-block shrink">
-                                        <input style={{maxWidth: "500px"}} placeholder={counterpart.translate("markets.search").toUpperCase()} type="text" value={this.state.filterPM} onChange={this._onFilter.bind(this, "filterPM")}></input>
+                                        <div className="grid-content">
+                                            <input style={{maxWidth: "500px"}} placeholder={counterpart.translate("markets.search").toUpperCase()} type="text" value={this.state.filterPM} onChange={this._onFilter.bind(this, "filterPM")}></input>
+                                        </div>
                                     </div>
                                     <div className="grid-block" style={{paddingBottom: 20}}>
-                                        <table className="table">
-                                            <tbody>
+                                        <div className="grid-content">
+                                            <table className="table">
+                                                <tbody>
                                                 {pm}
-                                            </tbody>
-                                        </table>
+                                                </tbody>
+                                            </table>
+                                        </div>
                                     </div>
                                 </Tab>
                             </Tabs>

--- a/web/app/components/Settings/Settings.jsx
+++ b/web/app/components/Settings/Settings.jsx
@@ -218,7 +218,7 @@ class Settings extends React.Component {
 
         return (
             <div className="grid-block page-layout">
-                <div className="grid-block main-content wrap" style={{marginTop: "1rem"}}>
+                <div className="grid-block main-content wrap">
                     <div className="grid-content large-offset-2 shrink" style={{paddingRight: "4rem"}}>
                         <Translate style={{paddingBottom: 20}} className="bottom-border" component="h4" content="header.settings" />
 

--- a/web/app/components/Utility/HelpContent.jsx
+++ b/web/app/components/Utility/HelpContent.jsx
@@ -15,12 +15,14 @@ function split_into_sections(str) {
     let sections = str.split(/\[#\s?(.+?)\s?\]/);
     if (sections.length === 1) return sections[0];
     if (sections[0].length < 4) sections.splice(0, 1);
-    sections = reduce(sections, (result, n) => {
-        let last = result.length > 0 ? result[result.length-1] : null;
-        if (!last || last.length === 2) { last = [n]; result.push(last); }
-        else last.push(n);
-        return result;
-    }, []);
+
+    for (let i = sections.length - 1; i >= 1; i -= 2) {
+        // remove extra </p> and <p>
+        sections[i] = sections[i].replace(/(^<\/p>|<p>$)/g, '');
+        sections[i - 1] = [sections[i - 1], sections[i]];
+        sections.splice(i, 1);
+    }
+
     return zipObject(sections);
 }
 


### PR DESCRIPTION
@wmbutler @svk31 
Thank you for your comments. This is a follow up PR of #273.  
Feel free to give feedbacks and I'll keep improving this PR.

__Major changes__:
1. expand all `.grid-container` to fit the maximum width (75rem)
2. removed a bunch of inlined padding/margin styles in React
    1. removed the 800px width limit in `AccountAssetUpdate.jsx`
    2. replaced the inline hard-coded CSS in `ChatWrapper.jsx` with foundation presets
3. rewrote the `split_into_sections` function in `HelpContent.jsx` to remove empty `<p></p>`s (which cause extra magin) and made it easier to read
4. re-arranged some misplaced paddings
5. added left/right paddings for the assets/asset page (in mobile screens)
6. fix CSS issues in the settings page (listed in #273)

__Styling suggestions & todos__:
1. only allow padding/margin attached to "layout elements", use as few classes as possible to handle the layout:
      - grid-container
      - grid-content
2. remove padding/margin on "content type specific elements":
      - help-content
      - inlined styles
3. avoid using hard-coded `px`, use `rem` instead
4. put a `.grid-content` inside `.grid-block` before putting actual content (according to the foundation doc)

__Issue screenshots__

Sidebar (just scroll it down): 

<img width="274" alt="screen shot 2017-08-18 at 12 13 17 am" src="https://user-images.githubusercontent.com/31077240/29425146-d535dac0-8347-11e7-8c7f-8c502252c434.png">

Asset page:

<img width="483" alt="screen shot 2017-08-18 at 12 36 17 am" src="https://user-images.githubusercontent.com/31077240/29425147-d538b470-8347-11e7-9555-bc8dfa410cf9.png">

