### PR TITLE
139 - Ensure proxy props changing updates component state

### DIFF
--- a/web/app/components/Account/AccountVotingProxy.jsx
+++ b/web/app/components/Account/AccountVotingProxy.jsx
@@ -58,6 +58,22 @@ class AccountVotingProxy extends React.Component {
     //     }
     // }
 
+    /*
+    * Ensure that state is cleared when new proxy props are passed down
+    */
+    componentWillUpdate(nextProps){
+        let newProxy = nextProps.existingProxy.get("name");
+        let oldProxy = this.props.existingProxy.get("name");
+
+        if(newProxy !== oldProxy){
+            if(newProxy === "proxy-to-self"){
+              this.setState({current_proxy_input: "", new_proxy_account: null});
+            } else {
+                this.setState({current_proxy_input: newProxy, new_proxy_account: null});
+            }
+        }
+    }
+
     onResetProxy() {
         const defaultInput = this.props.existingProxy.get("id") === "1.2.5" ? "" : this.props.existingProxy.get("name");
         this.setState({


### PR DESCRIPTION
This PR resolves [139](https://github.com/bitshares/bitshares-ui/issues/139) by ensuring that state is updated when the store passes new props down the the proxy component.

![issue-139](https://user-images.githubusercontent.com/632938/29439845-2498645a-8386-11e7-93fa-d9b23d570ba5.gif)
