### PR TITLE
160 - ensure that vesting balances are updated when hot switching accounts

### DIFF
--- a/web/app/components/Account/AccountVesting.jsx
+++ b/web/app/components/Account/AccountVesting.jsx
@@ -97,8 +97,21 @@ class AccountVesting extends React.Component {
     }
 
     componentWillMount() {
+        this.retrieveVestingBalances.call(this, this.props.account.get("id"));
+    }
+
+    componentWillUpdate(nextProps){
+        let newId = nextProps.account.get("id");
+        let oldId = this.props.account.get("id");
+
+        if(newId !== oldId){
+            this.retrieveVestingBalances.call(this, newId);
+        }
+    }
+
+    retrieveVestingBalances(accountId){
         Apis.instance().db_api().exec("get_vesting_balances", [
-            this.props.account.get("id")
+            accountId
         ]).then(vbs => {
             this.setState({vbs});
         }).catch(err => {


### PR DESCRIPTION
This PR resolves [issue 160](https://github.com/bitshares/bitshares-ui/issues/160). This issue was caused by component not triggering updates on account changes.

Vesting balances now update as expected.

![issue-160](https://user-images.githubusercontent.com/632938/29440368-c86d0362-8389-11e7-94ce-0e88dcafbac3.gif)
