### PR TITLE
Issue 315: Added clamp to ChartCanvas to right justify the chart

### DIFF
--- a/web/app/components/Exchange/PriceChartD3.jsx
+++ b/web/app/components/Exchange/PriceChartD3.jsx
@@ -347,6 +347,7 @@ class CandleStickChartWithZoomPan extends React.Component {
                 xAccessor={d => d.date} xScaleProvider={discontinuousTimeScaleProvider}
                 xExtents={[filteredData[0].date, filteredData[filteredData.length - 1].date]}
                 type="hybrid"
+                clamp={true}
                 className="ps-child no-overflow Stockcharts__wrapper ps-must-propagate"
                 drawMode={enableTrendLine || enableFib}>
             >


### PR DESCRIPTION
Clamping the chart makes the right edge display "now", and doesn't allow displaying the blank future. 
Zooming out will pull right to left until the right edge is "now" (If not already) and then continue pulling the history from left to right. 