### PR TITLE
Revert "Issue 315: Added clamp to ChartCanvas to right justify the chart"

### DIFF
--- a/web/app/components/Exchange/PriceChartD3.jsx
+++ b/web/app/components/Exchange/PriceChartD3.jsx
@@ -347,7 +347,6 @@ class CandleStickChartWithZoomPan extends React.Component {
                 xAccessor={d => d.date} xScaleProvider={discontinuousTimeScaleProvider}
                 xExtents={[filteredData[0].date, filteredData[filteredData.length - 1].date]}
                 type="hybrid"
-                clamp={true}
                 className="ps-child no-overflow Stockcharts__wrapper ps-must-propagate"
                 drawMode={enableTrendLine || enableFib}>
             >


### PR DESCRIPTION
Reverts bitshares/bitshares-ui#322.

Reverted after reading the additional discussion in the issue, will leave open to further changes