### PR TITLE
Iss 390 - Price Entry Field Ignores '.' Character When Overwriting Selected Number

### DIFF
--- a/app/components/Exchange/ExchangeInput.jsx
+++ b/app/components/Exchange/ExchangeInput.jsx
@@ -5,17 +5,48 @@ class ExchangeInput extends React.Component {
         super();
     }
 
+    getSelection(){
+        try {
+            var text = '';
+            if (window.getSelection) {
+                text = window.getSelection();
+            } else if (document.getSelection) {
+                text = document.getSelection();
+            } else if (document.selection) {
+                text = document.selection.createRange().text;
+            }
+
+            return text.toString();
+        } catch(e){
+            return '';
+        }
+    }
+
+    isNumeric(obj){
+        return !isNaN(obj - parseFloat(obj));
+    }
+
     onKeyPress(e){
         var nextValue = e.target.value + e.key;
         var decimal = nextValue.match(/\./g);
         var decimalCount = decimal ? decimal.length : 0;
-        if(e.key === '.' && decimalCount > 1) e.preventDefault();
+        let trailingCut = nextValue.substr(0, nextValue.length-1);
+        let selection = this.getSelection();
+
+        if(e.key === '.'){
+            if(decimalCount == 2 && selection == trailingCut){ // clearing selected text
+            } else if(decimalCount > 1){
+                e.preventDefault();
+            }
+        } else if(!this.isNumeric(e.key)){
+            e.preventDefault();
+        }
 
         if(this.props.onKeyPress) this.props.onKeyPress(e);
     }
 
     render(){
-        return <input type="number" {...this.props} onKeyPress={this.onKeyPress.bind(this)} />
+        return <input type="text" {...this.props} onKeyPress={this.onKeyPress.bind(this)} />
     }
 }
 


### PR DESCRIPTION
Resolves [issue #390](https://github.com/bitshares/bitshares-ui/issues/390). 

I had previously implemented a special input to handle exchange inputs so that I could make sure only one decimal was allowed. This behavior was occurring because of that fix, so I extended the special input further. I needed to do away with the number input type, use a text input, and just discard any inputs that were not numeric or ".".

![iss-390](https://user-images.githubusercontent.com/632938/30347958-5db03856-97d3-11e7-8d14-148f01ab843f.gif)
