### PR TITLE
Issue 311 - Allow for hiding user issued assets

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -208,7 +208,8 @@
       "error_precision": "That asset does not have the same precision as %(asset)s",
       "error_invalid": "That asset may not be used",
       "market": "Preferred market pairing",
-      "precision_warning": "Warning: The number of decimals may not be changed after creation"
+      "precision_warning": "Warning: The number of decimals may not be changed after creation",
+      "visible": "Hide asset from search and markets"
     },
     "connections": {
       "known": "Known by",

--- a/app/components/Account/AccountAssetCreate.jsx
+++ b/app/components/Account/AccountAssetCreate.jsx
@@ -251,6 +251,10 @@ class AccountAssetCreate extends React.Component {
                 update.description[value] = e;
                 break;
 
+            case "visible":
+                update.description[value] = !update.description[value];
+                break;
+
             default:
                 update.description[value] = e.target.value;
                 break;
@@ -493,44 +497,59 @@ class AccountAssetCreate extends React.Component {
 
         // Loop over flags
         let flags = [];
+        let getFlag = (key, onClick, isChecked)=>{
+            return <table key={"table_" + key} className="table">
+                <tbody>
+                    <tr>
+                        <td style={{border: "none", width: "80%"}}><Translate content={`account.user_issued_assets.${key}`} />:</td>
+                        <td style={{border: "none"}}>
+                            <div className="switch" style={{marginBottom: "10px"}} onClick={onClick}>
+                                <input type="checkbox" checked={isChecked} />
+                                <label />
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>;
+        };
         for (let key in permissionBooleans) {
             if (permissionBooleans[key] && key !== "charge_market_fee") {
                 flags.push(
-                    <table key={"table_" + key} className="table">
-                        <tbody>
-                            <tr>
-                                <td style={{border: "none", width: "80%"}}><Translate content={`account.user_issued_assets.${key}`} />:</td>
-                                <td style={{border: "none"}}>
-                                    <div className="switch" style={{marginBottom: "10px"}} onClick={this._onFlagChange.bind(this, key)}>
-                                        <input type="checkbox" checked={flagBooleans[key]} />
-                                        <label />
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                )
+                    getFlag(
+                        key,
+                        this._onFlagChange.bind(this, key),
+                        flagBooleans[key]
+                    )
+                );
             }
         }
+
+        flags.push(
+            getFlag(
+                "visible",
+                this._onUpdateDescription.bind(this, "visible"),
+                update.description.visible ? false : (update.description.visible === false ? true : false)
+            )
+        );
 
         // Loop over permissions
         let permissions = [];
         for (let key in permissionBooleans) {
-                permissions.push(
-                    <table key={"table_" + key} className="table">
-                        <tbody>
-                            <tr>
-                                <td style={{border: "none", width: "80%"}}><Translate content={`account.user_issued_assets.${key}`} />:</td>
-                                <td style={{border: "none"}}>
-                                    <div className="switch" style={{marginBottom: "10px"}} onClick={this._onPermissionChange.bind(this, key)}>
-                                        <input type="checkbox" checked={permissionBooleans[key]} onChange={() => {}}/>
-                                        <label />
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                )
+            permissions.push(
+                <table key={"table_" + key} className="table">
+                    <tbody>
+                        <tr>
+                            <td style={{border: "none", width: "80%"}}><Translate content={`account.user_issued_assets.${key}`} />:</td>
+                            <td style={{border: "none"}}>
+                                <div className="switch" style={{marginBottom: "10px"}} onClick={this._onPermissionChange.bind(this, key)}>
+                                    <input type="checkbox" checked={permissionBooleans[key]} onChange={() => {}}/>
+                                    <label />
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            )
         }
 
         return (

--- a/app/components/Account/AccountAssetUpdate.jsx
+++ b/app/components/Account/AccountAssetUpdate.jsx
@@ -438,16 +438,18 @@ class AccountAssetUpdate extends React.Component {
                         </td>
                     </tr>
                 </tbody>
-            </table>
-        }
+            </table>;
+        };
 
         for (let key in originalPermissions) {
             if (originalPermissions[key] && key !== "charge_market_fee") {
                 flags.push(
-                    getFlag(key),
-                    this._onFlagChange.bind(this, key),
-                    flagBooleans[key]
-                )
+                    getFlag(
+                        key,
+                        this._onFlagChange.bind(this, key),
+                        flagBooleans[key]
+                    )
+                );
             }
         }
 

--- a/app/components/Account/AccountAssetUpdate.jsx
+++ b/app/components/Account/AccountAssetUpdate.jsx
@@ -175,6 +175,10 @@ class AccountAssetUpdate extends React.Component {
                 update.description[value] = e;
                 break;
 
+            case "visible":
+                update.description[value] = !update.description[value];
+                break;
+
             default:
                 update.description[value] = e.target.value;
                 break;
@@ -421,25 +425,39 @@ class AccountAssetUpdate extends React.Component {
 
         // Loop over flags
         let flags = [];
+        let getFlag = (key, onClick, isChecked)=>{
+            return <table key={"table_" + key} className="table">
+                <tbody>
+                    <tr>
+                        <td style={{border: "none", width: "80%"}}><Translate content={`account.user_issued_assets.${key}`} />:</td>
+                        <td style={{border: "none"}}>
+                            <div className="switch" style={{marginBottom: "10px"}} onClick={onClick}>
+                                <input type="checkbox" checked={isChecked} />
+                                <label />
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        }
+
         for (let key in originalPermissions) {
             if (originalPermissions[key] && key !== "charge_market_fee") {
                 flags.push(
-                    <table key={"table_" + key} className="table">
-                        <tbody>
-                            <tr>
-                                <td style={{border: "none", width: "80%"}}><Translate content={`account.user_issued_assets.${key}`} />:</td>
-                                <td style={{border: "none"}}>
-                                    <div className="switch" style={{marginBottom: "10px"}} onClick={this._onFlagChange.bind(this, key)}>
-                                        <input type="checkbox" checked={flagBooleans[key]} />
-                                        <label />
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    getFlag(key),
+                    this._onFlagChange.bind(this, key),
+                    flagBooleans[key]
                 )
             }
         }
+
+        flags.push(
+            getFlag(
+                "visible",
+                this._onUpdateDescription.bind(this, "visible"),
+                update.description.visible ? false : (update.description.visible === false ? true : false)
+            )
+        );
 
         // Loop over permissions
         let permissions = [];

--- a/app/components/Exchange/MyMarkets.jsx
+++ b/app/components/Exchange/MyMarkets.jsx
@@ -539,6 +539,15 @@ class MyMarkets extends React.Component {
         if (searchAssets.size) {
             searchAssets
             .filter(a => {
+                try {
+                    if(a.options.description){
+                        let description = JSON.parse(a.options.description);
+                        if("visible" in description){
+                            if(!description.visible) return false;
+                        }
+                    }
+                } catch(e){}
+
                 return (
                     a.symbol.indexOf(lookupQuote) !== -1 &&
                     a.symbol.length >= lookupQuote.length


### PR DESCRIPTION
Resolves [issue #311](https://github.com/bitshares/bitshares-ui/issues/311).

User now has toggle for whether or not the asset should be hidden, which is stored in description:

<img width="1439" alt="iss-311-1" src="https://user-images.githubusercontent.com/632938/30381199-516f6128-9861-11e7-8667-d1428560a82e.png">

Hiding the asset will cause it to be hidden in search / markets:

![iss-311](https://user-images.githubusercontent.com/632938/30381256-766dc37a-9861-11e7-8ec6-c514b0945f76.gif)
