### PR TITLE
Update openledger support info

### DIFF
--- a/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -167,7 +167,7 @@ class BlockTradesGateway extends React.Component {
                             action={this.state.action}
                         />
                         <label className="left-label">Support</label>
-                        <div><Translate content="gateway.support_block" /><br /><br /><a href={"mailto:" + issuer.support}>{issuer.support}</a></div>
+                        <div><Translate content="gateway.support_block" /><br /><br /><a href={(issuer.support.indexOf("@") === -1 ? "" : "mailto:") + issuer.support}>{issuer.support}</a></div>
                     </div>
 
                     {coin && coin.symbol ?

--- a/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -110,7 +110,7 @@ class BlockTradesGateway extends React.Component {
 
         let issuers = {
             blocktrades: {name: "blocktrades", id: "1.2.32567", support: "support@blocktrades.us"},
-            openledger: {name: coin.intermediateAccount, id: "1.2.96397", support: "support@openledger.info"}
+            openledger: {name: coin.intermediateAccount, id: "1.2.96397", support: "https://openledger.freshdesk.com"}
         };
 
         let issuer = issuers[provider];


### PR DESCRIPTION
The email support@openledger.info is no longer checked, they have migraded to freshdesk. Replacing the email address with the link to their support portal.