### PR TITLE
Fix development server issue due to hot-reload rewriting

### DIFF
--- a/app/idb-helper.js
+++ b/app/idb-helper.js
@@ -109,12 +109,16 @@ export default idb_helper = {
 
 class ChainEvent {
     constructor(existing_on_event, callback, request) {
+        // Assigning the constructor arguments to work around hot-reload
+        // rewriting breaking the scope of this.event
+        this.existing_on_event = existing_on_event
+        this.callback = callback
         this.event = (event)=> {
             if(event.target.error)
                 console.error("---- transaction error ---->", event.target.error);
             //event.request = request
-            callback(event);
-            if(existing_on_event) existing_on_event(event);
+            this.callback(event);
+            if(this.existing_on_event) this.existing_on_event(event);
         };
     }
 }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "react-dom": "^15.6.1",
     "react-foundation-apps": "git+https://github.com/valzav/react-foundation-apps.git",
     "react-highcharts": "^12.0.0",
-    "react-hot-loader": "^3.0.0-beta.6",
+    "react-hot-loader": "^3.0.0",
     "react-interpolate-component": "^0.10.0",
     "react-intl": "^2.2.2",
     "react-json-inspector": "^7.0.0",


### PR DESCRIPTION
Running a hot-reload server with `npm start` causes a JS exception due to how react-hot-reload rewrites the function defined within the `ChainEvent` constructor, changing it's scope. Here's what it ends up with currently, so fails when `callback(event)` is hit:
```
var ChainEvent = function () {
    function ChainEvent(existing_on_event, callback, request) {
        var _this = this;

        _classCallCheck(this, ChainEvent);

        this.event = function () {
            return _this.__event__REACT_HOT_LOADER__.apply(_this, arguments);
        };
    }

    _createClass(ChainEvent, [{
        key: "__event__REACT_HOT_LOADER__",
        value: function __event__REACT_HOT_LOADER__(event) {
            if (event.target.error) console.error("---- transaction error ---->", event.target.error);
            //event.request = request
            callback(event);
            if (existing_on_event) existing_on_event(event);
        }
    }]);

    return ChainEvent;
}();
```