### PR TITLE
Issue 533 - Clear transfer form once completed

### DIFF
--- a/app/components/Transfer/Transfer.jsx
+++ b/app/components/Transfer/Transfer.jsx
@@ -238,6 +238,10 @@ class Transfer extends React.Component {
         this.setState({ propose_account });
     }
 
+    resetForm(){
+        this.setState({memo: '', to_name: '', amount: ''});
+    }
+
     onSubmit(e) {
         e.preventDefault();
         this.setState({error: null});
@@ -253,6 +257,7 @@ class Transfer extends React.Component {
             this.state.propose ? this.state.propose_account : null,
             this.state.feeAsset ? this.state.feeAsset.get("id") : "1.3.0"
         ).then( () => {
+            this.resetForm.call(this);
             TransactionConfirmStore.unlisten(this.onTrxIncluded);
             TransactionConfirmStore.listen(this.onTrxIncluded);
         }).catch( e => {


### PR DESCRIPTION
Resolves #533 

One small note here - if there is a delay in the API response, the form may not clear immediately. It will clear as soon as the user gets the success message, though.