### PR TITLE
iss 496 - ensure tables retain correct height

### DIFF
--- a/app/assets/stylesheets/layout/_page_layout.scss
+++ b/app/assets/stylesheets/layout/_page_layout.scss
@@ -85,3 +85,18 @@ div.bordered-header {
 .table-cell{
   display: table-cell;
 }
+
+.grid-content.app-tables {
+  box-sizing: border-box;
+  padding-bottom: 1.5rem;
+  min-height: 100%;
+  position: relative;
+}
+
+.grid-content.app-tables > .content-block, .grid-content.app-tables > .content-block > .generic-bordered-box, .grid-content.app-tables > .content-block > .generic-bordered-box > .overview-tabs {
+  height: 100%;
+}
+
+.grid-content.app-tables > .content-block {
+  margin-bottom: 0 !important;
+}

--- a/app/components/Account/AccountOverview.jsx
+++ b/app/components/Account/AccountOverview.jsx
@@ -32,6 +32,7 @@ import AccountOrders from "./AccountOrders";
 import cnames from "classnames";
 import TranslateWithLinks from "../Utility/TranslateWithLinks";
 import { checkMarginStatus } from "common/accountHelper";
+import tableHeightHelper from "lib/common/tableHeightHelper";
 
 class AccountOverview extends React.Component {
 
@@ -59,6 +60,9 @@ class AccountOverview extends React.Component {
                 // "OPEN.DASH"
             ]
         };
+
+        this.tableHeightMountInterval = tableHeightHelper.tableHeightMountInterval.bind(this);
+        this.adjustHeightOnChangeTab = tableHeightHelper.adjustHeightOnChangeTab.bind(this);
     }
 
     componentWillMount() {
@@ -77,6 +81,18 @@ class AccountOverview extends React.Component {
 
     componentWillReceiveProps(np) {
         if (np.account !== this.props.account) this._checkMarginStatus(np);
+    }
+
+    componentDidMount(){
+        this.tableHeightMountIntervalInstance = this.tableHeightMountInterval();
+    }
+
+    componentWillUnmount(){
+        clearInterval(this.tableHeightMountIntervalInstance);
+    }
+
+    adjustHeightOnChangeTab(){
+        this.adjustHeightOnChangeTab();
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -494,10 +510,10 @@ class AccountOverview extends React.Component {
         const hiddenSubText = <span style={{visibility: "hidden"}}>H</span>;
 
         return (
-            <div className="grid-content">
+            <div className="grid-content app-tables" ref="appTables">
                 <div className="content-block small-12">
                     <div className="generic-bordered-box">
-                        <Tabs defaultActiveTab={1} segmented={false} setting="overviewTab" className="overview-tabs" tabsClass="account-overview no-padding bordered-header content-block">
+                        <Tabs defaultActiveTab={1} segmented={false} setting="overviewTab" className="overview-tabs" tabsClass="account-overview no-padding bordered-header content-block" onChangeTab={this.adjustHeightOnChangeTab.bind(this)}>
 
                             <Tab disabled className="total-value" title={<span>{counterpart.translate("account.eq_value")}&nbsp;<AssetName name={preferredUnit} noTip /></span>} subText={totalValue}>
 

--- a/app/components/Account/AccountOverview.jsx
+++ b/app/components/Account/AccountOverview.jsx
@@ -91,9 +91,9 @@ class AccountOverview extends React.Component {
         clearInterval(this.tableHeightMountIntervalInstance);
     }
 
-    adjustHeightOnChangeTab(){
-        this.adjustHeightOnChangeTab();
-    }
+    // adjustHeightOnChangeTab(){
+    //     this.adjustHeightOnChangeTab();
+    // }
 
     shouldComponentUpdate(nextProps, nextState) {
         return (

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -436,13 +436,19 @@ class Asset extends React.Component {
         let header = (
           <thead>
             <tr>
-                <th> <Translate content="explorer.asset.price_feed_data.settlement_price"/> –
-                      {this.formattedPrice(settlement_price_header, false, true)}</th>
-                    <th> <Translate content="explorer.asset.price_feed_data.core_exchange_rate"/> –
-                     {this.formattedPrice(core_exchange_rate_header, false, true)} </th>
+                <th style={{textAlign: "left"}}> <Translate content="explorer.asset.price_feed_data.publisher"/> </th>
+                <th>
+                    <Translate content="explorer.asset.price_feed_data.settlement_price"/>
+                    <br />
+                    ({this.formattedPrice(settlement_price_header, false, true)})
+                </th>
+                <th>
+                    <Translate content="explorer.asset.price_feed_data.core_exchange_rate"/>
+                    <br />
+                    ({this.formattedPrice(core_exchange_rate_header, false, true)})
+                </th>
                 <th> <Translate content="explorer.asset.price_feed_data.maintenance_collateral_ratio"/> </th>
                 <th> <Translate content="explorer.asset.price_feed_data.maximum_short_squeeze_ratio"/> </th>
-                <th> <Translate content="explorer.asset.price_feed_data.publisher"/> </th>
                 <th> <Translate content="explorer.asset.price_feed_data.published"/> </th>
             </tr>
             </thead>
@@ -457,12 +463,12 @@ class Asset extends React.Component {
             var maximum_short_squeeze_ratio = '' + feed[1][1].maximum_short_squeeze_ratio/10 + '%';
             rows.push(
                 <tr key={publisher}>
-                    <td>{this.formattedPrice(settlement_price, true)}</td>
-                    <td> {this.formattedPrice(core_exchange_rate, true)} </td>
-                    <td style={{textAlign:"center"}}> {maintenance_collateral_ratio}</td>
-                    <td style={{textAlign:"center"}}> {maximum_short_squeeze_ratio}</td>
                     <td> <LinkToAccountById account={publisher}/> </td>
-                    <td><TimeAgo time={publishDate}/></td>
+                    <td style={{textAlign: "right"}}>{this.formattedPrice(settlement_price, true)}</td>
+                    <td style={{textAlign: "right"}}> {this.formattedPrice(core_exchange_rate, true)} </td>
+                    <td style={{textAlign:"right"}}> {maintenance_collateral_ratio}</td>
+                    <td style={{textAlign:"right"}}> {maximum_short_squeeze_ratio}</td>
+                    <td style={{textAlign: "right"}}><TimeAgo time={publishDate}/></td>
                 </tr>
             );
         }

--- a/app/components/Utility/Tabs.jsx
+++ b/app/components/Utility/Tabs.jsx
@@ -84,6 +84,7 @@ class Tabs extends React.Component {
     }
 
     _changeTab(value) {
+        if (value === this.state.activeTab) return;
         // Persist current tab if desired
         if (this.props.setting) {
             SettingsActions.changeViewSetting({

--- a/app/components/Utility/Tabs.jsx
+++ b/app/components/Utility/Tabs.jsx
@@ -91,6 +91,8 @@ class Tabs extends React.Component {
             });
         }
         this.setState({activeTab: value});
+
+        if(this.props.onChangeTab) this.props.onChangeTab(value);
     }
 
     render() {

--- a/app/lib/common/tableHeightHelper.js
+++ b/app/lib/common/tableHeightHelper.js
@@ -9,11 +9,11 @@ export default {
                 appTables.style.height = `${appTables.clientHeight}px`;
             }
         }.bind(this), 10);
-        
+
         return interval;
     },
     adjustHeightOnChangeTab(){
         let appTables = this.refs.appTables;
-        if (appTables) this.refs.appTables.style.height = 'auto';
+        if (appTables) this.refs.appTables.style.height = "auto";
     }
-}
+};

--- a/app/lib/common/tableHeightHelper.js
+++ b/app/lib/common/tableHeightHelper.js
@@ -1,0 +1,19 @@
+export default {
+    tableHeightMountInterval(){
+        let interval = setInterval(function(){
+            let appTables = this.refs.appTables;
+
+            if(!appTables) return;
+
+            if(parseInt(appTables.style.height) !== appTables.clientHeight){
+                appTables.style.height = `${appTables.clientHeight}px`;
+            }
+        }.bind(this), 100);
+        
+        return interval;
+    },
+    adjustHeightOnChangeTab(){
+        let appTables = this.refs.appTables;
+        if (appTables) this.refs.appTables.style.height = 'auto';
+    }
+}


### PR DESCRIPTION
![bg-extends](https://user-images.githubusercontent.com/632938/31506212-6d59f8f2-af3c-11e7-89e2-547a8deecfab.gif)

This change ensures that tables will always have the correct height, being at least fully extended to the bottom of the container.

To use, add `app-tables` to the `grid-content` container, and import `tableHeightHelper` into the component. There is a JS update that needs to get applied in both an interval and on tab change.

Resolves #496 