### PR TITLE
Iss 484 - Reset backup store when wallet is changed

### DIFF
--- a/app/components/Wallet/WalletManager.jsx
+++ b/app/components/Wallet/WalletManager.jsx
@@ -2,6 +2,7 @@ import React, {Component} from "react";
 import {Link} from "react-router/es";
 import { connect } from "alt-react";
 import WalletActions from "actions/WalletActions";
+import BackupActions from "actions/BackupActions";
 import WalletManagerStore from "stores/WalletManagerStore";
 import Translate from "react-translate-component";
 import cname from "classnames";
@@ -237,6 +238,7 @@ class ChangeActiveWallet extends Component {
 
     onConfirm() {
         WalletActions.setWallet(this.state.current_wallet);
+        BackupActions.reset();
         // if (window.electron) {
         //     window.location.hash = "";
         //     window.remote.getCurrentWindow().reload();


### PR DESCRIPTION
Resolves #484 

The reported behavior was because backup store was not being reset when wallet changed. This puts backup in pristine state when user change wallets.