### PR TITLE
Updated apiConfig.js

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -24,6 +24,7 @@ export const settingsAPIs = {
         {url: "wss://eu.openledger.info/ws", location: "Berlin, Germany"},
         {url: "wss://bit.btsabc.org/ws", location: "Hong Kong"},
         {url: "wss://bts.ai.la/ws", location: "Hong Kong"},
+        {url: "wss://bitshares.apasia.tech/ws", location: "Bangkok, Thailand"},
         {url: "wss://bitshares.dacplay.org/ws", location:  "Hangzhou, China"},
         {url: "wss://bitshares-api.wancloud.io/ws", location:  "China"},
         {url: "wss://openledger.hk/ws", location: "Hong Kong"},


### PR DESCRIPTION
[UPDATE] Add Thailand RPC Node to the WS_NODE_LIST
Line 27: {url: "wss://bitshares.apasia.tech/ws", location: "Bangkok, Thailand"},