### PR TITLE
#630 removed padding from Dashboard and Voting

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -784,7 +784,7 @@
       "missed": "Blocks missed"
     },
     "committee_members": {
-      "title": "Committee members",
+      "title": "Committee",
       "active": "Total number of active committee members"
     },
     "committee_member": {

--- a/app/assets/stylesheets/components/_account.scss
+++ b/app/assets/stylesheets/components/_account.scss
@@ -164,11 +164,12 @@ div.overview-tabs {
     }
 
     div.hide-selector {
-        padding-left: 5px;
+        padding-left: 12px;
+        padding-bottom: 17px;
     }
 
     > div.tab-content {
-        padding: 20px;
+        padding-top: 20px;
     }
 
     &.with-buttons ul.account-overview > li:not(.total-value) > a {

--- a/app/assets/stylesheets/layout/_page_layout.scss
+++ b/app/assets/stylesheets/layout/_page_layout.scss
@@ -3,7 +3,7 @@
     border-top: 1px solid transparent;
     border-bottom: 1px solid transparent;
     > .grid-content, > .grid-block {
-      padding: 10px;
+      padding: 0px;
     }
   }
 
@@ -12,7 +12,7 @@
   }
 
   .main-content {
-    padding-top: 1.5rem;
+    padding-top: 0px ;
     background-color: #f3f3f3;
   }
 
@@ -75,7 +75,7 @@ div.bordered-header {
 
 .block-content-header {
   font-size: 1.4375rem;
-  padding: 0.5rem 0;
+  padding: 1.5rem 0;
 
   @include breakpoint(small only) {
       font-size: 1.125rem;
@@ -88,7 +88,7 @@ div.bordered-header {
 
 .grid-content.app-tables {
   box-sizing: border-box;
-  padding-bottom: 1.5rem;
+  padding: 0px;
   min-height: 100%;
   position: relative;
 }


### PR DESCRIPTION
Took padding out of the new tables in an effort to get closer to the final look for #630. My commit brought the padding in for the new voting screen and the dashboard, but it created some issues on the various explorer pages. Nothing serious, but they do need to be looked at before this is released.