### PR TITLE
Update borrow modal state reset

### DIFF
--- a/app/components/Modal/BorrowModal.jsx
+++ b/app/components/Modal/BorrowModal.jsx
@@ -95,11 +95,28 @@ class BorrowModalContent extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
+        const { short_amount, collateral, collateral_ratio } = this.state;
+
         if (nextProps.account !== this.props.account ||
             nextProps.hasCallOrders !== this.props.hasCallOrders ||
             nextProps.quote_asset.get("id") !== this.props.quote_asset.get("id")
             ) {
-            this.setState(this._initialState(nextProps));
+
+            let newState = this._initialState(nextProps);
+
+            let revalidate = false;
+            if(short_amount || collateral || collateral_ratio){
+                newState.short_amount = short_amount;
+                newState.collateral = collateral;
+                newState.collateral_ratio = collateral_ratio;
+                revalidate = true;
+            }
+
+            this.setState(newState);
+
+            if(revalidate){
+                this._validateFields(newState);
+            }
         }
     }
 


### PR DESCRIPTION
[Resolves issue #718](https://github.com/bitshares/bitshares-ui/issues/718)

The problem here was that blockchain updates were causing the form state to get totally reset. I changed this to keep the existing user entered values and redo the validation.

@svk31 There may be a cleaner way to do this but this ensures the values are preserved.