### PR TITLE
#698 - display quoted price in open orders

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -424,6 +424,7 @@
     "activity": "Activity",
     "eq_value_header": "Value ({asset})",
     "qty": "Qty",
+    "quote": "Quote",
     "total": "Total ({asset})"
   },
   "pagination": {

--- a/app/components/Dashboard/MarketCard.jsx
+++ b/app/components/Dashboard/MarketCard.jsx
@@ -46,8 +46,8 @@ class MarketCard extends React.Component {
     shouldComponentUpdate(np, ns) {
         return (
             this._checkStats(np.marketStats, this.props.marketStats) ||
-            np.base !== this.props.base ||
-            np.quote !== this.props.quote ||
+            np.base.get("id") !== this.props.base.get("id") ||
+            np.quote.get("id") !== this.props.quote.get("id") ||
             ns.imgError !== this.state.imgError
         );
     }

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -10,9 +10,10 @@ import TransitionWrapper from "../Utility/TransitionWrapper";
 import AssetName from "../Utility/AssetName";
 import Icon from "../Icon/Icon";
 import { ChainStore } from "bitsharesjs/es";
-import { LimitOrder, CallOrder } from "common/MarketClasses";
+import { LimitOrder, CallOrder, Price } from "common/MarketClasses";
 const rightAlign = {textAlign: "right"};
 import { EquivalentValueComponent } from "../Utility/EquivalentValueComponent";
+import MarketPrice from "../Utility/MarketPrice";
 
 class TableHeader extends React.Component {
 
@@ -34,6 +35,7 @@ class TableHeader extends React.Component {
             <thead>
                 <tr>
                     <th colSpan="3"><Translate content="account.bts_market" /></th>
+                    {isMyAccount ? <th style={rightAlign}><Translate content="account.quote" /></th> : null}
                     <th style={rightAlign}><Translate content="exchange.price" /></th>
                     <th style={rightAlign}><Translate content="account.qty" /></th>
                     <th style={rightAlign}><Translate content="exchange.total" /></th>
@@ -106,6 +108,9 @@ class OrderRow extends React.Component {
                 <td style={{textAlign: "left", paddingRight: 0, borderLeft: "none"}}>
                     <Link to={`/asset/${base.get("symbol")}`}><AssetName noTip name={base.get("symbol")} /></Link>
                 </td>
+                {isMyAccount ? <td style={{textAlign: "right", paddingLeft: 0}}>
+                  <MarketPrice base={base.get("id")} quote={quote.get("id")} marketId={base.get("symbol")+"_"+quote.get("symbol")} />
+                </td> : null}
                 <td className={tdClass} style={rightAlign}>
                     <PriceText price={order.getPrice()} base={base} quote={quote} />
                     {priceSymbol}

--- a/app/components/Utility/MarketPrice.jsx
+++ b/app/components/Utility/MarketPrice.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import ChainTypes from "../Utility/ChainTypes";
+import BindToChainState from "../Utility/BindToChainState";
+import cnames from "classnames";
+import MarketsActions from "actions/MarketsActions";
+import MarketsStore from "stores/MarketsStore";
+import { connect } from "alt-react";
+import utils from "common/utils";
+import FormattedPrice from "./FormattedPrice";
+
+class MarketPrice extends React.Component {
+
+    static propTypes = {
+        quote: ChainTypes.ChainAsset.isRequired,
+        base: ChainTypes.ChainAsset.isRequired,
+        invert: React.PropTypes.bool
+    };
+
+    static defaultProps = {
+        invert: true
+    };
+
+    constructor() {
+        super();
+
+        this.statsInterval = null;
+    }
+
+    _checkStats(newStats = {close: {}}, oldStats = {close: {}}) {
+        return (
+            newStats.volumeBase !== oldStats.volumeBase ||
+            !utils.are_equal_shallow(newStats.close && newStats.close.base, oldStats.close && oldStats.close.base) ||
+            !utils.are_equal_shallow(newStats.close && newStats.close.quote, oldStats.close && oldStats.close.quote)
+        );
+    }
+
+    shouldComponentUpdate(np) {
+        return (
+            this._checkStats(np.marketStats, this.props.marketStats) ||
+            np.base.get("id") !== this.props.base.get("id") ||
+            np.quote.get("id") !== this.props.quote.get("id")
+        );
+    }
+
+    componentWillMount() {
+        MarketsActions.getMarketStats.defer(this.props.quote, this.props.base);
+        this.statsChecked = new Date();
+        this.statsInterval = setInterval(MarketsActions.getMarketStats.bind(this, this.props.quote, this.props.base), 35 * 1000);
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.statsInterval);
+    }
+
+    render() {
+        let {marketStats, marketStatsInverted} = this.props;
+        let price = marketStats && marketStats.price ? marketStats.price : null;
+        if (!price && marketStatsInverted && marketStatsInverted.price) {
+            price = marketStatsInverted.price.invert();
+        }
+
+        return (
+            <span className={cnames("", this.props.className)}>
+                {price ?
+                    <FormattedPrice
+                        base_amount={price.base.amount} base_asset={price.base.asset_id}
+                        quote_amount={price.quote.amount} quote_asset={price.quote.asset_id}
+                        hide_symbols
+                    />
+                    : "n/a"
+                }
+            </span>
+        );
+    }
+}
+
+MarketPrice = BindToChainState(MarketPrice);
+
+class MarketCardWrapper extends React.Component {
+    render() {
+        return (
+            <MarketPrice {...this.props} />
+        );
+    }
+}
+
+export default connect(MarketCardWrapper, {
+    listenTo() {
+        return [MarketsStore];
+    },
+    getProps(props) {
+        let invertedId = props.marketId.split("_")[1] + "_" + props.marketId.split("_")[0];
+        return {
+            marketStats: MarketsStore.getState().allMarketStats.get(props.marketId),
+            marketStatsInverted: MarketsStore.getState().allMarketStats.get(invertedId)
+        };
+    }
+});


### PR DESCRIPTION
<img width="1437" alt="display-quoted-price" src="https://user-images.githubusercontent.com/632938/33142268-d4a28d5a-cf83-11e7-86ca-d1f18058cfc7.png">

Resolves [issue #698](https://github.com/bitshares/bitshares-ui/issues/698)

@svk31 I added the code you put on staging here, thinking as it's no change it will merge nicely.