### PR TITLE
Fix Issue #732 - Settlement Line Color

### DIFF
--- a/app/components/Exchange/DepthHighChart.jsx
+++ b/app/components/Exchange/DepthHighChart.jsx
@@ -320,8 +320,10 @@ class DepthHighChart extends React.Component {
 
 
 		if (settlementPrice) {
+			const settlementColor = (settlementPrice * power) > utils.format_number(flatAsks[0][0], base.get("precision")) ? askColor : bidColor;
 			config.xAxis.plotLines.push({
-				color: "#7B1616",
+				//color: "#7B1616",
+				color: settlementColor,
 				id: "plot_line",
 				dashStyle: "solid",
 				value: settlementPrice * power,

--- a/app/components/Exchange/DepthHighChart.jsx
+++ b/app/components/Exchange/DepthHighChart.jsx
@@ -320,9 +320,8 @@ class DepthHighChart extends React.Component {
 
 
 		if (settlementPrice) {
-			const settlementColor = (settlementPrice * power) > utils.format_number(flatAsks[0][0], base.get("precision")) ? askColor : bidColor;
+			const settlementColor = (base.has("bitasset")) ? askColor : bidColor;
 			config.xAxis.plotLines.push({
-				//color: "#7B1616",
 				color: settlementColor,
 				id: "plot_line",
 				dashStyle: "solid",


### PR DESCRIPTION
This fixes issue #732 by changing the color of the settlement line if the order book is reversed for a smart coin. 