### PR TITLE
Missing td, fix price inversion issue for quote

### DIFF
--- a/app/components/Account/AccountOverview.jsx
+++ b/app/components/Account/AccountOverview.jsx
@@ -644,6 +644,7 @@ class AccountOverview extends React.Component {
                                             <td style={{textAlign: "center"}}>{ordersValue}</td>
                                             <td colSpan="1"></td>
                                             {this.props.isMyAccount ? <td></td> : null}
+                                            {this.props.isMyAccount ? <td></td> : null}
                                         </tr>
                                     </tbody>
                                 </AccountOrders>

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -109,7 +109,7 @@ class OrderRow extends React.Component {
                     <Link to={`/asset/${base.get("symbol")}`}><AssetName noTip name={base.get("symbol")} /></Link>
                 </td>
                 {isMyAccount ? <td style={{textAlign: "right", paddingLeft: 0}}>
-                  <MarketPrice base={base.get("id")} quote={quote.get("id")} marketId={base.get("symbol")+"_"+quote.get("symbol")} />
+                  <MarketPrice base={base.get("id")} quote={quote.get("id")} marketId={base.get("symbol")+"_"+quote.get("symbol")} invert={false} />
                 </td> : null}
                 <td className={tdClass} style={rightAlign}>
                     <PriceText price={order.getPrice()} base={base} quote={quote} />

--- a/app/components/Utility/FormattedPrice.jsx
+++ b/app/components/Utility/FormattedPrice.jsx
@@ -92,7 +92,7 @@ class FormattedPrice extends React.Component {
         let {base_asset, base_amount, quote_amount,
           marketDirections, hide_symbols, noPopOver} = this.props;
         const {marketId, first, second} = this.state;
-        let inverted = marketDirections.get(marketId) || this.props.invert;
+        let inverted = (this.props.invert === false) ? false : marketDirections.get(marketId) || this.props.invert;
         if (this.props.force_direction && second.get("symbol") === this.props.force_direction && inverted) {
             inverted = false;
         } else if (this.props.force_direction && first.get("symbol") === this.props.force_direction && !inverted) {

--- a/app/components/Utility/MarketPrice.jsx
+++ b/app/components/Utility/MarketPrice.jsx
@@ -65,7 +65,7 @@ class MarketPriceInner extends MarketStats {
     }
 
     render() {
-        let {marketStats, marketStatsInverted} = this.props;
+        let {marketStats, marketStatsInverted, invert} = this.props;
         let price = marketStats && marketStats.price ? marketStats.price : null;
         if (!price && marketStatsInverted && marketStatsInverted.price) {
             price = marketStatsInverted.price.invert();
@@ -78,6 +78,7 @@ class MarketPriceInner extends MarketStats {
                         base_amount={price.base.amount} base_asset={price.base.asset_id}
                         quote_amount={price.quote.amount} quote_asset={price.quote.asset_id}
                         hide_symbols
+                        invert={invert}
                     />
                     : "n/a"
                 }


### PR DESCRIPTION
Resolves acceptance bugs for [issue 698](https://github.com/bitshares/bitshares-ui/issues/698). Adds missing footer column and resolves price quote inversion issue by allowing to respect invert prop.

<img width="1439" alt="price-inversion" src="https://user-images.githubusercontent.com/632938/33245680-0857bc9e-d2d9-11e7-9833-182cf453037c.png">
