### PR TITLE
Fix Issue #723 - Missing asset name in Translate content 

### DIFF
--- a/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -1205,7 +1205,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                     <tr>
                         <th><Translate content="gateway.deposit" /></th>
                         <th ><Translate content="gateway.balance" /></th>
-                        <th ><Translate content="gateway.deposit_to" /></th>
+                        <th ><Translate content="gateway.deposit_to" asset="asset" /></th>
                     </tr>
                 </thead>;
 

--- a/app/components/DepositWithdraw/openledger/OpenLedgerFiatDepositWithdrawal.jsx
+++ b/app/components/DepositWithdraw/openledger/OpenLedgerFiatDepositWithdrawal.jsx
@@ -185,7 +185,7 @@ class OpenLedgerFiatDepositWithdrawal extends React.Component {
                         <thead>
                         <tr>
                             <th><Translate content="gateway.symbol" /></th>
-                            <th><Translate content="gateway.deposit_to" /></th>
+                            <th><Translate content="gateway.deposit_to" asset="asset" /></th>
                             <th><Translate content="gateway.balance" /></th>
                             <th><Translate content="gateway.withdraw" /></th>
                         </tr>


### PR DESCRIPTION
Fix Issue #723 
Using a translation string without applying the %(asset) parameter. Set `asset` as suggested. 