### PR TITLE
Fix Issue #722 - Set more theme specific API Status colors.

### DIFF
--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1398,6 +1398,12 @@ $account-background
         color: darken($warning-color, 15%);
     }
 
+    .api-status {
+        .low { color: $bid-color; }
+        .medium { color: $call-color; }
+        .high { color: $ask-color }
+    }
+
     .footer {
         div.footer-status {
             > span.success {

--- a/app/components/Settings/AccessSettings.jsx
+++ b/app/components/Settings/AccessSettings.jsx
@@ -43,20 +43,17 @@ class ApiNode extends React.Component {
         const { allowActivation, allowRemoval, automatic, autoActive, name, url, displayUrl, ping, up } = props;
 
         let color;
-        let green = "#00FF00";
-        let yellow = "yellow";
-        let red = "red";
         let latencyKey;
 
         if(ping < 400) {
-            color = green;
+            color = "low";
             latencyKey = "low_latency";
         }
         else if(ping >= 400 && ping < 800) {
-            color = yellow;
+            color = "medium";
             latencyKey = "medium_latency";
         } else {
-            color = red;
+            color = "high";
             latencyKey = "high_latency";
         }
         /*
@@ -66,9 +63,9 @@ class ApiNode extends React.Component {
         const isTestnet = url === testnetAPI.url;
 
         var Status =  (isTestnet && !ping) ? null : <div className="api-status" style={{position: "absolute", textAlign: "right", right: "1em", top: "0.5em"}}>
-         <Translate style={{color: up ? green : red, marginBottom: 0}} component="h3" content={"settings." + (up ? "node_up" : "node_down")} />
-          {up && <span style={{color}}><Translate content={`settings.${latencyKey}`} /></span>}
-          {!up && <span style={{color: "red"}}>__</span>}
+         <Translate className={up ? "low" : "high"} style={{marginBottom: 0}} component="h3" content={"settings." + (up ? "node_up" : "node_down")} />
+          {up && <span className={color}><Translate content={`settings.${latencyKey}`} /></span>}
+          {!up && <span className="high">__</span>}
         </div>;
 
         return <div


### PR DESCRIPTION
Sets the API status colors to a more theme specific color.
Using the Ask, Bid and Call colors for the current theme.