### PR TITLE
Resolve quote not updating issue

### DIFF
--- a/app/components/Utility/MarketPrice.jsx
+++ b/app/components/Utility/MarketPrice.jsx
@@ -34,7 +34,7 @@ class MarketStats extends React.Component {
     componentWillMount() {
         MarketsActions.getMarketStats.defer(this.props.quote, this.props.base);
         this.statsChecked = new Date();
-        this.statsInterval = setInterval(MarketsActions.getMarketStats.bind(this, this.props.quote, this.props.base), 35 * 1000);
+        this.statsInterval = setInterval(MarketsActions.getMarketStats.bind(this, this.props.quote, this.props.base), 1000);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
There seems to be a timing issue with updating market stats which is resulting in the bug reported by @wmbutler on issue #698 with price quote not updating when base / quote are switched. The following PR seems to fix it sometimes but I am seeing inconsistent behavior. Seems like a deeper issue.