### PR TITLE
Fix error thrown when settlePrice had same base and quote (#927)

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -94,6 +94,13 @@ class Asset extends React.Component {
                 sqr = 1000;
             }
 
+            if (settlePrice.toJS) {
+                let settlePriceToJS = settlePrice.toJS();
+                if (settlePriceToJS.base.asset_id == settlePriceToJS.quote.asset_id) {
+                    return null;
+                }
+            }
+
             try {
                 const feedPrice = new FeedPrice({
                     priceObject: settlePrice,


### PR DESCRIPTION
If the settlePrice on the view for showing an asset had the same base and quote the console would throw an error.