### PR TITLE
Update counterpart version

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "browser-locale": "^1.0.3",
     "classnames": "^2.2.1",
     "cookies-js": "^1.2.1",
-    "counterpart": "^0.18.3",
+    "counterpart": "^0.18.5",
     "event-emitter": "^0.3.4",
     "file-saver": "^1.3.3",
     "foundation-apps": "git+https://github.com/zurb/foundation-apps.git",


### PR DESCRIPTION
A bug was fixed in counterpart that would make failed language fallback crash the page.