### PR TITLE
Add `scroll_length` property to FloatingDropdown and AmountSelector

### DIFF
--- a/app/components/Modal/SendModal.jsx
+++ b/app/components/Modal/SendModal.jsx
@@ -485,6 +485,7 @@ export default class SendModal extends React.Component {
                                             display_balance={balance_fee}
                                             tabIndex={tabIndex++}
                                             error={this.state.hasPoolBalance === false ? "transfer.errors.insufficient" : null}
+                                            scroll_length={2}
                                         />
                                     </div>
                                     {/* <div className="small-6" style={{display: "inline-block", paddingLeft: "2rem"}}>

--- a/app/components/Utility/AmountSelector.jsx
+++ b/app/components/Utility/AmountSelector.jsx
@@ -12,7 +12,8 @@ class AssetSelector extends React.Component {
     static propTypes = {
         assets: ChainTypes.ChainAssetsList,
         value: React.PropTypes.string, // asset id
-        onChange: React.PropTypes.func
+        onChange: React.PropTypes.func,
+        scroll_length: React.PropTypes.number
     };
 
     render() {
@@ -24,6 +25,7 @@ class AssetSelector extends React.Component {
             singleEntry={this.props.assets[0] ? <FormattedAsset asset={this.props.assets[0].get("id")} amount={0} hide_amount={true}/> : null}
             value={this.props.value}
             onChange={this.props.onChange}
+            scroll_length={this.props.scroll_length}
         />;
     }
 }
@@ -40,7 +42,8 @@ class AmountSelector extends React.Component {
         placeholder: React.PropTypes.string,
         onChange: React.PropTypes.func.isRequired,
         tabIndex: React.PropTypes.number,
-        error: React.PropTypes.string
+        error: React.PropTypes.string,
+        scroll_length: React.PropTypes.number
     };
 
     static defaultProps = {
@@ -91,6 +94,7 @@ class AmountSelector extends React.Component {
                             value={this.props.asset.get("symbol")}
                             assets={Immutable.List(this.props.assets)}
                             onChange={this.onAssetChange.bind(this)}
+                            scroll_length={this.props.scroll_length}
                         />
                     </div>
                 </div>

--- a/app/components/Utility/FloatingDropdown.jsx
+++ b/app/components/Utility/FloatingDropdown.jsx
@@ -3,7 +3,16 @@ import utils from "common/utils";
 
 class Dropdown extends React.Component {
 
+    static propTypes = {
+        scroll_length: React.PropTypes.number
+    }
+
+    static defaultProps = {
+        scroll_length: 9
+    }
+
     constructor(props) {
+        const scroll_length = props.scroll_length;
         super(props);
         this.state = {
             active: false
@@ -101,7 +110,7 @@ class Dropdown extends React.Component {
             return (
                 <div onClick={this._toggleDropdown.bind(this)} className={"dropdown-wrapper" + (active ? " active" : "")  + (this.props.upperCase ? " upper-case" : "")}>
                     <div style={{paddingRight: 15}}>{value ? value : <span className="hidden">A</span>}</div>
-                    <ul className="dropdown" style={{overflow: entries.length > 9 ? "auto": "hidden"}}>
+                    <ul className="dropdown" style={{overflow: entries.length > this.props.scroll_length ? "auto": "hidden"}}>
                         {options}
                     </ul>
                 </div>


### PR DESCRIPTION
So the SendModal dialog 'Fee' and 'Quantity' dropdowns don't hide items beyond the second.

This fixes #893.

As a note, this could probably be simplified by just setting `style="scroll: auto"` on the `FloatingDropdown` component.  However, the current behaviour was explicitly added in 4ac20478 so I erred on the side of caution.