### PR TITLE
Fix #938: Add white background to qrcode

### DIFF
--- a/app/components/Modal/QrcodeModal.jsx
+++ b/app/components/Modal/QrcodeModal.jsx
@@ -71,7 +71,9 @@ class QrcodeModal extends React.Component {
                         <div className="form-group">
                             {this.state.isShowQrcode ?
                                 <section style={pos}>
-                                    <QRCode size={256} value={this.state.keyString}/>
+                                    <span style={{background: "#fff", padding: ".75rem", display: "inline-block"}}>
+                                        <QRCode size={256} value={this.state.keyString}/>
+                                    </span>
                                 </section>
                                 :
                                 <section>


### PR DESCRIPTION
Fix #938: Add white background to qrcode
![image](https://user-images.githubusercontent.com/2197479/34523033-9d2f5984-f0d0-11e7-90f8-94e707ffbc7c.png)
