### PR TITLE
Show full precision on fee schedule and always show fee in BTS, fix 992

### DIFF
--- a/app/components/Blockchain/Fees.jsx
+++ b/app/components/Blockchain/Fees.jsx
@@ -77,9 +77,9 @@ class FeeGroup extends React.Component {
                 let amount = fee[key]*scale/1e4;
                 let feeTypes = counterpart.translate("transaction.feeTypes");
                 let assetAmount = amount ? <FormattedAsset amount={amount} asset="1.3.0"/> : feeTypes["_none"];
-                let equivalentAmount = amount ? <EquivalentValueComponent fromAsset="1.3.0" fullPrecision={true} amount={amount} toAsset={preferredUnit}/> : feeTypes["_none"];
+                let equivalentAmount = amount ? <EquivalentValueComponent fromAsset="1.3.0" fullPrecision={true} amount={amount} toAsset={preferredUnit} fullDecimals={true}/> : feeTypes["_none"];
                 let assetAmountLTM = amount*0.2 ? <FormattedAsset amount={amount*0.2} asset="1.3.0"/> : feeTypes["_none"];
-                let equivalentAmountLTM = amount*0.2 ? <EquivalentValueComponent fromAsset="1.3.0" fullPrecision={true} amount={amount*0.2} toAsset={preferredUnit}/> : feeTypes["_none"];
+                let equivalentAmountLTM = amount*0.2 ? <EquivalentValueComponent fromAsset="1.3.0" fullPrecision={true} amount={amount*0.2} toAsset={preferredUnit} fullDecimals={true}/> : feeTypes["_none"];
                 let title = null;
 
                 if (!headIncluded) {
@@ -96,8 +96,8 @@ class FeeGroup extends React.Component {
                         <tr key={opId.toString() + key} className={feeTypes[key]==="Annual Membership" ? "linethrough" : ""}>
                             {title}
                             <td>{feeTypes[key]}</td>
-                            <td style={{textAlign: "right"}}>{equivalentAmount}</td>
-                            <td style={{textAlign: "right"}}>{equivalentAmountLTM}</td>
+                            <td style={{textAlign: "right"}}>{assetAmount}{amount !== 0 && preferredUnit !== "BTS" && [" / ", equivalentAmount]}</td>
+                            <td style={{textAlign: "right"}}>{assetAmountLTM}{amount !== 0 && preferredUnit !== "BTS" && [" / ", equivalentAmountLTM]}</td>
                         </tr>
                     );
                 } else {
@@ -106,7 +106,7 @@ class FeeGroup extends React.Component {
                             {title}
                             <td>{feeTypes[key]}</td>
                             <td style={{textAlign: "right"}}>- <sup>*</sup></td>
-                            <td style={{textAlign: "right"}}>{equivalentAmountLTM}</td>
+                            <td style={{textAlign: "right"}}>{assetAmountLTM}{amount !== 0 && preferredUnit !== "BTS" && [" / ", equivalentAmountLTM]}</td>
                         </tr>
                     );
                 }

--- a/app/components/Utility/EquivalentValueComponent.jsx
+++ b/app/components/Utility/EquivalentValueComponent.jsx
@@ -32,6 +32,7 @@ class ValueComponent extends MarketStatsCheck {
         toAsset: "1.3.0",
         fullPrecision: true,
         noDecimals: false,
+        fullDecimals: false,
         hide_asset: false,
         coreAsset: "1.3.0"
     };
@@ -99,7 +100,7 @@ class ValueComponent extends MarketStatsCheck {
             return <div className="tooltip inline-block" data-place="bottom" data-tip={counterpart.translate("tooltip.no_price")} style={{fontSize: "0.9rem"}}><Translate content="account.no_price" /></div>;
         }
 
-        return <FormattedAsset hide_asset={this.props.hide_asset} noPrefix amount={eqValue} asset={toID} decimalOffset={toSymbol.indexOf("BTC") !== -1 ? 4 : this.props.noDecimals ? toAsset.get("precision") : (toAsset.get("precision") - 2)}/>;
+        return <FormattedAsset hide_asset={this.props.hide_asset} noPrefix amount={eqValue} asset={toID} decimalOffset={toSymbol.indexOf("BTC") !== -1 ? 4 : this.props.fullDecimals ? 0 : this.props.noDecimals ? toAsset.get("precision") : (toAsset.get("precision") - 2)}/>;
     }
 }
 ValueComponent = BindToChainState(ValueComponent, {keep_updating: true});


### PR DESCRIPTION
Added a new prop `fullDecimals` in `EquivalentValueComponent`. Defaults to false, when true it will show full precision instead of only 2 decimal digits. 