### PR TITLE
Exchange header tweaks

### DIFF
--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -230,6 +230,11 @@ ul.market-stats {
     letter-spacing: normal;
 }
 
+.label-actions .icon {
+    position: relative;
+    top: 4px;
+}
+
 .stats {
     list-style: none;
     margin: 0px;
@@ -449,13 +454,27 @@ table thead tr th.mymarkets-header {
     fill: #CC9F00 !important;
 }
 
-.grey-star > svg > path {
+.grey-star > svg > path, .shuffle > svg > path {
     fill: #878787 !important;
 }
 
-.shuffle > svg > path {
-    fill: #878787;
+.gold-star:hover > svg > path {
+    fill: lighten(#CC9F00, 10%) !important;
 }
+
+.shuffle:hover > svg > path {
+    fill: lighten(#878787, 20%) !important;
+}
+
+.grey-star:hover > svg > path {
+   fill: #CC9F00 !important;
+}
+
+@media (max-width: 570px) { .hide-order-1 { display: none !important; } }
+@media (max-width: 720px) { .hide-order-2 { display: none !important; } }
+@media (max-width: 880px) { .hide-order-3 { display: none !important; } }
+@media (max-width: 1020px) { .hide-order-4 { display: none !important; } }
+@media (max-width: 1180px) { .hide-order-5 { display: none !important; } }
 
 .no-data {
     position: relative;

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1160,7 +1160,7 @@ $pulsate-red-end
         font-size:18px;
      
         &.is-call {
-                color: $call-color!important;
+            color: $call-color!important;
         }   
         
         &.daily_change {
@@ -1174,8 +1174,9 @@ $pulsate-red-end
     }
     
     .stat-text {
-            font-size:11px;
-            color:gray;
+        margin-top: 3px;
+        font-size: 11px;
+        color: gray;
     }
 
     .buy-sell-box {

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -279,10 +279,8 @@ $pulsate-red-end
 
     }
     
-    .show-for-large {
-        a {
-            color: $light-text-color !important;
-        }
+    .asset-prefix {
+        color: $light-text-color !important;
     }
 
     .transfer-top {

--- a/app/components/Exchange/ExchangeHeader.jsx
+++ b/app/components/Exchange/ExchangeHeader.jsx
@@ -68,11 +68,11 @@ export default class ExchangeHeader extends React.Component {
                         <div className="grid-block shrink">
                             <div style={{padding: "10px"}}>
                                 {!hasPrediction ? (
-                                    <span style={{padding: "0 5px"}}>
+                                    <div style={{padding: "0 5px", fontSize: "18px", marginTop: "1px"}}>
                                         <Link to={`/asset/${quoteSymbol}`} className="asset-prefix"><AssetName name={quoteSymbol} replace={true} /></Link>
                                         <span style={{padding:"0 5px"}}>/</span>
                                         <Link to={`/asset/${baseSymbol}`} className="asset-prefix"><AssetName name={baseSymbol} replace={true} /></Link>
-                                    </span>
+                                    </div>
                                 ) : (
                                     <a className="market-symbol">
                                         <span>{`${quoteSymbol} : ${baseSymbol}`}</span>

--- a/app/components/Exchange/ExchangeHeader.jsx
+++ b/app/components/Exchange/ExchangeHeader.jsx
@@ -110,7 +110,7 @@ export default class ExchangeHeader extends React.Component {
                                     {(volumeBase >= 0) ? <PriceStatWithLabel ignoreColorChange={true} onClick={this.changeVolumeBase.bind(this)} ready={marketReady} decimals={0} volume={true} price={volume24h} className="hide-order-2 clickable" base={volume24hAsset} market={marketID} content="exchange.volume_24"/> : null}
                 
                                     {!hasPrediction && feedPrice ?
-                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.settle_price")} ready={marketReady} className="hide-order-3" price={feedPrice.toReal()} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.settle"/> : null}
+                                        <PriceStatWithLabel ignoreColorChange={true} toolTip={counterpart.translate("tooltip.settle_price")} ready={marketReady} className="hide-order-3" price={feedPrice.toReal()} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.settle"/> : null}
                 
                                     {lowestCallPrice && showCallLimit ?
                                         <PriceStatWithLabel toolTip={counterpart.translate("tooltip.call_limit")} ready={marketReady} className="hide-order-4 is-call" price={lowestCallPrice} quote={quoteAsset} base={baseAsset} market={marketID} content="explorer.block.call_limit"/> : null}

--- a/app/components/Exchange/ExchangeHeader.jsx
+++ b/app/components/Exchange/ExchangeHeader.jsx
@@ -61,53 +61,62 @@ export default class ExchangeHeader extends React.Component {
         
         const volume24h = this.state.volumeShowQuote?volumeQuote:volumeBase;
         const volume24hAsset = this.state.volumeShowQuote?quoteAsset:baseAsset; 
-        
+
         return (
                 <div className="grid-block shrink no-padding overflow-visible top-bar">
                     <div className="grid-block overflow-visible">
-                        <div className="grid-block shrink show-for-large">
+                        <div className="grid-block shrink">
                             <div style={{padding: "10px"}}>
                                 {!hasPrediction ? (
-                                                                <span style={{padding: "0 5px"}}>
-                                                                    <Link to={`/asset/${quoteSymbol}`}><AssetName name={quoteSymbol} replace={true} /></Link>
-                                                                    <Link onClick={() => {
-                                                                                    MarketsActions.switchMarket();
-                                                }} className="market-symbol" to={`/market/${baseSymbol}_${quoteSymbol}`}>
-                                                                    <Icon className="shuffle" name="shuffle"/>
-                                                                    </Link>
-                                                                    <Link to={`/asset/${baseSymbol}`}><AssetName name={baseSymbol} replace={true} /></Link>
-                                                                </span>
-                                                        ) : (
-                                                                <a className="market-symbol">
-                                                                    <span>{`${quoteSymbol} : ${baseSymbol}`}</span>
-                                                                </a>
-                                                        )}
-                                <Translate component="div" style={{padding: "5px 0 0 5px"}} className="stat-text" content="exchange.trading_pair" />
+                                    <span style={{padding: "0 5px"}}>
+                                        <Link to={`/asset/${quoteSymbol}`} className="asset-prefix"><AssetName name={quoteSymbol} replace={true} /></Link>
+                                        <span style={{padding:"0 5px"}}>/</span>
+                                        <Link to={`/asset/${baseSymbol}`} className="asset-prefix"><AssetName name={baseSymbol} replace={true} /></Link>
+                                    </span>
+                                ) : (
+                                    <a className="market-symbol">
+                                        <span>{`${quoteSymbol} : ${baseSymbol}`}</span>
+                                    </a>
+                                )}
+                                <div className="label-actions">
+                                    <Translate component="span" style={{padding: "5px 0 0 5px"}} className="stat-text" content="exchange.trading_pair" />
+                                    <Link onClick={() => {
+                                        MarketsActions.switchMarket();
+                                    }} to={`/market/${baseSymbol}_${quoteSymbol}`}>
+                                        <Icon className="shuffle" name="shuffle"/>
+                                    </Link>
+                                    
+                                    
+                                    <Link onClick={() => { this._addMarket(this.props.quoteAsset.get("symbol"), this.props.baseAsset.get("symbol")); }}>
+                                        <Icon className={starClass} name="fi-star"/>
+                                    </Link>
+                                </div>
                             </div>
                         </div>
                 
                         <div className="grid-block vertical" style={{overflow: "visible"}}>
                             <div className="grid-block wrap market-stats-container">
                                 <ul className="market-stats stats top-stats">
-                                    {latestPrice ? <PriceStatWithLabel ready={marketReady} price={latestPrice.full} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.latest"/> : null}
-                                    <li className={"stressed-stat daily_change " + dayChangeClass}>
+                                    {latestPrice ? <PriceStatWithLabel ignoreColorChange={true} ready={marketReady} price={latestPrice.full} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.latest"/> : null}
+
+                                    <li className={"hide-order-1 stressed-stat daily_change " + dayChangeClass}>
                                         <span>
                                             <b className="value">{marketReady ? dayChangeWithSign : 0}</b>
                                             <span> %</span>
                                         </span>
-                                    <Translate component="div" className="stat-text" content="account.hour_24" />
+                                        <Translate component="div" className="stat-text" content="account.hour_24" />
                                     </li>
                 
-                                    {(volumeBase >= 0) ? <PriceStatWithLabel onClick={this.changeVolumeBase.bind(this)} ready={marketReady} decimals={0} volume={true} price={volume24h} className="column-hide-small clickable" base={volume24hAsset} market={marketID} content="exchange.volume_24"/> : null}
+                                    {(volumeBase >= 0) ? <PriceStatWithLabel ignoreColorChange={true} onClick={this.changeVolumeBase.bind(this)} ready={marketReady} decimals={0} volume={true} price={volume24h} className="hide-order-2 clickable" base={volume24hAsset} market={marketID} content="exchange.volume_24"/> : null}
                 
                                     {!hasPrediction && feedPrice ?
-                                                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.settle_price")} ready={marketReady} className="column-hide-small" price={feedPrice.toReal()} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.settle"/> : null}
+                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.settle_price")} ready={marketReady} className="hide-order-3" price={feedPrice.toReal()} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.settle"/> : null}
                 
                                     {lowestCallPrice && showCallLimit ?
-                                                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.call_limit")} ready={marketReady} className="column-hide-medium is-call" price={lowestCallPrice} quote={quoteAsset} base={baseAsset} market={marketID} content="explorer.block.call_limit"/> : null}
+                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.call_limit")} ready={marketReady} className="hide-order-4 is-call" price={lowestCallPrice} quote={quoteAsset} base={baseAsset} market={marketID} content="explorer.block.call_limit"/> : null}
                 
                                     {feedPrice && showCallLimit ?
-                                                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.margin_price")} ready={marketReady} className="column-hide-medium is-call" price={feedPrice.getSqueezePrice({real: true})} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.squeeze"/> : null}
+                                        <PriceStatWithLabel toolTip={counterpart.translate("tooltip.margin_price")} ready={marketReady} className="hide-order-5 is-call" price={feedPrice.getSqueezePrice({real: true})} quote={quoteAsset} base={baseAsset} market={marketID} content="exchange.squeeze"/> : null}
                                 </ul>
                                 <ul className="market-stats stats top-stats">
                                     <li className="stressed-stat input clickable" style={{padding:"16px"}} onClick={this.props.onToggleCharts}>

--- a/app/components/Exchange/PriceStatWithLabel.jsx
+++ b/app/components/Exchange/PriceStatWithLabel.jsx
@@ -52,12 +52,12 @@ export default class PriceStatWithLabel extends React.Component {
     }
 
     render() {
-        let {base, quote, price, content, ready, volume, toolTip} = this.props;
+        let {base, quote, price, content, ready, volume, toolTip, ignoreColorChange} = this.props;
         let {change,marketChange} = this.state;
         let changeClasses = null;
-        if (!marketChange && change && change !== null) {
+        if (!marketChange && change && change !== null && ignoreColorChange !== true) {
             changeClasses = change > 0 ? "pulsate green" : "pulsate red";
-        }        
+        }
 
         let value = !volume ? utils.price_text(price, quote, base) :
             utils.format_volume(price);

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -346,7 +346,7 @@ class Header extends React.Component {
                         {!!createAccountLink ? <li>
                             <a style={{flexFlow: "row"}} className={cnames({active: active.indexOf("settings") !== -1})} onClick={this._onNavigate.bind(this, "/settings")}>
                                 <Icon size="2x" style={{position: "relative", top: 0, left: -8}} name="cogs"/>
-                                <span><Translate content="header.settings" /></span>
+                                <span className="column-hide-tiny"><Translate content="header.settings" /></span>
                             </a>
                         </li> : null}
                         {/* {enableDepositWithdraw && currentAccount && myAccounts.indexOf(currentAccount) !== -1 ? <li><Link to={"/deposit-withdraw/"} activeClassName="active"><Translate content="account.deposit_withdraw"/></Link></li> : null} */}


### PR DESCRIPTION
- Relocated the shuffle button to be inline with the stat label
- Added star market button to the trading pair stat
- Prevented the latest and 24hr volume stats from changing colour
- On browser window resize, updated the order in which stats are hidden
- Updated header so that the 'create acount' link doesn't wrap so early