### PR TITLE
Feat #977: Gracefully handle send operation for accounts with 0 BTS

### DIFF
--- a/app/components/Modal/SendModal.jsx
+++ b/app/components/Modal/SendModal.jsx
@@ -11,7 +11,7 @@ import AccountSelector from "../Account/AccountSelector";
 import TransactionConfirmStore from "stores/TransactionConfirmStore";
 import { Asset } from "common/MarketClasses";
 import { debounce, isNaN } from "lodash";
-import { checkFeeStatusAsync, checkBalance, shouldPayFeeWithAsset } from "common/trxHelper";
+import { checkFeeStatusAsync, checkBalance, shouldPayFeeWithAssetAsync } from "common/trxHelper";
 import BalanceComponent from "../Utility/BalanceComponent";
 import AccountActions from "actions/AccountActions";
 import utils from "common/utils";
@@ -316,18 +316,18 @@ export default class SendModal extends React.Component {
                 type: "memo",
                 content: state.memo
             }
-        }).then(({fee, hasBalance, hasPoolBalance}) => {
-            if (shouldPayFeeWithAsset(from_account, fee))
-                this.setState({fee_asset_id: asset_id}, this._updateFee);
-            else
-                this.setState({
-                    feeAmount: fee,
-                    fee_asset_id: fee.asset_id,
-                    hasBalance,
-                    hasPoolBalance,
-                    error: !hasBalance || !hasPoolBalance
-                });
-        });
+        }).then(({fee, hasBalance, hasPoolBalance}) =>
+            shouldPayFeeWithAssetAsync(from_account, fee).then(should => should ?
+                    this.setState({fee_asset_id: asset_id}, this._updateFee)
+                :
+                    this.setState({
+                        feeAmount: fee,
+                        fee_asset_id: fee.asset_id,
+                        hasBalance,
+                        hasPoolBalance,
+                        error: !hasBalance || !hasPoolBalance
+                    }))
+        );
     }
 
     setNestedRef(ref) {

--- a/app/components/Transfer/Transfer.jsx
+++ b/app/components/Transfer/Transfer.jsx
@@ -13,7 +13,7 @@ import { RecentTransactions } from "../Account/RecentTransactions";
 import Immutable from "immutable";
 import {ChainStore} from "bitsharesjs/es";
 import {connect} from "alt-react";
-import { checkFeeStatusAsync, checkBalance, shouldPayFeeWithAsset } from "common/trxHelper";
+import { checkFeeStatusAsync, checkBalance, shouldPayFeeWithAssetAsync } from "common/trxHelper";
 import { debounce, isNaN } from "lodash";
 import classnames from "classnames";
 import { Asset } from "common/MarketClasses";
@@ -175,18 +175,19 @@ class Transfer extends React.Component {
                 content: state.memo
             }
         })
-        .then(({fee, hasBalance, hasPoolBalance}) => {
-            if (shouldPayFeeWithAsset(from_account, fee))
-                this.setState({fee_asset_id: asset_id}, this._updateFee);
-            else
-                this.setState({
-                    feeAmount: fee,
-                    fee_asset_id: fee.asset_id,
-                    hasBalance,
-                    hasPoolBalance,
-                    error: (!hasBalance || !hasPoolBalance)
-                });
-        });
+        .then(({fee, hasBalance, hasPoolBalance}) =>
+            shouldPayFeeWithAssetAsync(from_account, fee).then(should => should ?
+                  this.setState({fee_asset_id: asset_id}, this._updateFee)
+              :
+                  this.setState({
+                      feeAmount: fee,
+                      fee_asset_id: fee.asset_id,
+                      hasBalance,
+                      hasPoolBalance,
+                      error: (!hasBalance || !hasPoolBalance)
+                  })
+            )
+        );
     }
 
     fromChanged(from_name) {

--- a/app/lib/common/trxHelper.js
+++ b/app/lib/common/trxHelper.js
@@ -1,4 +1,4 @@
-import { FetchChain, PrivateKey, Aes, TransactionHelper, ChainTypes, ops } from "bitsharesjs/es";
+import { FetchChain, PrivateKey, Aes, TransactionHelper, ChainTypes, ChainStore, ops } from "bitsharesjs/es";
 import { Price, Asset } from "common/MarketClasses";
 const { operations } = ChainTypes;
 
@@ -186,10 +186,26 @@ function checkBalance(amount, sendAsset, feeAmount, balance) {
     return true;
 }
 
+function shouldPayFeeWithAsset(fromAccount, feeAmount) {
+    if (fromAccount && feeAmount && feeAmount.asset_id === "1.3.0") {
+        const balanceID = fromAccount.getIn([
+            "balances",
+            feeAmount.asset_id
+        ]);
+        const balanceObject = ChainStore.getObject(balanceID);
+        if (balanceObject) {
+            const balance = balanceObject.get("balance");
+            if (balance <= feeAmount.amount) return true;
+        }
+    }
+    return false;
+};
+
 export {
     estimateFee,
     estimateFeeAsync,
     checkFeePoolAsync,
     checkFeeStatusAsync,
-    checkBalance
+    checkBalance,
+    shouldPayFeeWithAsset
 };

--- a/app/lib/common/trxHelper.js
+++ b/app/lib/common/trxHelper.js
@@ -1,4 +1,4 @@
-import { FetchChain, PrivateKey, Aes, TransactionHelper, ChainTypes, ChainStore, ops } from "bitsharesjs/es";
+import { FetchChain, PrivateKey, Aes, TransactionHelper, ChainTypes, ops } from "bitsharesjs/es";
 import { Price, Asset } from "common/MarketClasses";
 const { operations } = ChainTypes;
 
@@ -186,19 +186,19 @@ function checkBalance(amount, sendAsset, feeAmount, balance) {
     return true;
 }
 
-function shouldPayFeeWithAsset(fromAccount, feeAmount) {
+function shouldPayFeeWithAssetAsync(fromAccount, feeAmount) {
     if (fromAccount && feeAmount && feeAmount.asset_id === "1.3.0") {
         const balanceID = fromAccount.getIn([
             "balances",
             feeAmount.asset_id
         ]);
-        const balanceObject = ChainStore.getObject(balanceID);
-        if (balanceObject) {
-            const balance = balanceObject.get("balance");
-            if (balance <= feeAmount.amount) return true;
-        }
+        return FetchChain("getObject", balanceID)
+            .then(balanceObject => {
+                const balance = balanceObject.get("balance");
+                if (balance <= feeAmount.amount) return true;
+            });
     }
-    return false;
+    return new Promise((resolve) => resolve(false));
 };
 
 export {
@@ -207,5 +207,5 @@ export {
     checkFeePoolAsync,
     checkFeeStatusAsync,
     checkBalance,
-    shouldPayFeeWithAsset
+    shouldPayFeeWithAssetAsync
 };


### PR DESCRIPTION
This modifies the `_updateFee` method of `SendModal` and `Transfer` to check the requirements stated in the issue #977.
After fetching the initial fee amount,  if the requirements are met, it changes the `fee_asset_id` to the selected asset and re-updates the fee.