### PR TITLE
Feature: Accounts dropdown 1028

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -118,15 +118,8 @@ div.header-right-menu {
 div.account-drop-down div.dropdown-wrapper {
     padding: 0;
 
-    div.hamburger {
-        position: absolute;
-        right: 12px;
-        top: 22px;
-    }
-
     > li {
         list-style: none;
-        min-width: 200px;
         > div.table-cell {
             padding: 15px 5px 14px 5px;
             text-align: center;
@@ -148,6 +141,26 @@ div.account-drop-down div.dropdown-wrapper {
         }
     }
 }
+
+div.account-drop-down div.account-dropdown-wrapper {
+  > li {
+    min-width: 200px;
+    > div.table-cell {
+      height: 64px;
+    }
+  }
+}
+
+div.account-drop-down div.menu-dropdown-wrapper {
+  > li {
+    width: 64.55px;
+
+    > div.table-cell {
+      padding: 23px 5px 24px 5px;
+    }
+  }
+}
+
 ul.dropdown.header-menu {
     transition: padding 0s, height 3s linear;
     border: none;

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -144,7 +144,6 @@ div.account-drop-down div.dropdown-wrapper {
 
 div.account-drop-down div.account-dropdown-wrapper {
   > li {
-    min-width: 200px;
     > div.table-cell {
       height: 64px;
     }

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -146,6 +146,8 @@ div.account-drop-down div.account-dropdown-wrapper {
   > li {
     > div.table-cell {
       height: 64px;
+      padding-left: 10px;
+      padding-right: 10px;
     }
   }
 }

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -156,6 +156,7 @@ div.account-drop-down div.menu-dropdown-wrapper {
     width: 64.55px;
 
     > div.table-cell {
+      height: 64px;
       padding: 23px 5px 24px 5px;
     }
   }

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -338,6 +338,7 @@ $pulsate-red-end
         }
 
         div.header-right-lock {
+            cursor: pointer;
             padding: 1rem .25rem;
             &:hover {
                 background-color: $bg-color;

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -355,6 +355,16 @@ $pulsate-red-end
             }
         }
 
+        div.dropdown-wrapper.hover-transparent {
+          &:hover {
+            background-color: transparent;
+          }
+        }
+
+        div.dropdown-wrapper.cursor-default {
+          cursor: default;
+        }
+
         div.dropdown-wrapper.active {
             transition: background-color 0s;
             background-color: $bg-color;

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -392,7 +392,7 @@ class Header extends React.Component {
                                             </div>
                                         </div>
                                     </li>
-                                    <ul className="dropdown header-menu" style={{left: 0, top: 63, maxHeight: !this.state.dropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
+                                    <ul className="dropdown header-menu" style={{left: -200, top: 64, maxHeight: !this.state.dropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
                                         <li className="divider" onClick={this._toggleLock.bind(this)}>
                                             <div className="table-cell"><Icon size="2x" name="power" /></div>
                                             <div className="table-cell"><Translate content={`header.${this.props.locked ? "unlock_short" : "lock_short"}`} /></div>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -42,7 +42,8 @@ class Header extends React.Component {
     constructor(props, context) {
         super();
         this.state = {
-            active: context.location.pathname
+            active: context.location.pathname,
+            accountsListDropdownActive: false
         };
 
         this.unlisten = null;
@@ -91,6 +92,7 @@ class Header extends React.Component {
             nextProps.currentLocale !== this.props.currentLocale ||
             nextState.active !== this.state.active ||
             nextState.dropdownActive !== this.state.dropdownActive ||
+            nextState.accountsListDropdownActive !== this.state.accountsListDropdownActive ||
             nextProps.height !== this.props.height
         );
     }
@@ -360,15 +362,34 @@ class Header extends React.Component {
                                 <div key="padlock" style={{paddingBottom: 15}} className="header-right-lock show-for-medium" onClick={this._toggleLock.bind(this)}>
                                     <Icon className="lock-unlock" style={{margin: "0 0.5rem"}} size="2x" name={this.props.locked ? "locked" : "unlocked"} />
                                 </div>,
+                                <div key="account-dropdown" className={cnames("dropdown-wrapper", {active: this.state.accountsListDropdownActive})}>
+                                    <li style={{display: "flex"}}>
+                                        <div onClick={() => {this.setState({accountsListDropdownActive: !this.state.accountsListDropdownActive});}} className="table-cell" style={{flex: 1}}>
+                                            <div style={{lineHeight: "initial", display: "inline-block", paddingRight: 20}}>
+                                                <span>{currentAccount}</span>
+                                                {walletBalance}
+                                            </div>
+
+                                        </div>
+                                    </li>
+
+                                    <ul className="dropdown header-menu" style={{left: 0, top: 63, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
+
+                                        <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
+                                            <div className="table-cell"><Icon size="2x" name="folder" /></div>
+                                            <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
+                                        </li>
+
+                                        {accountsList}
+                                    </ul>
+
+                                </div>,
                                 <div key="dropdown" className={cnames("dropdown-wrapper", {active: this.state.dropdownActive})}>
                                     <li style={{display: "flex"}}>
                                         <div onClick={() => {this.setState({dropdownActive: !this.state.dropdownActive});}} className="table-cell" style={{flex: 1}}>
                                             <div style={{lineHeight: "initial", display: "inline-block", paddingRight: 20}}>
-                                                <span>{currentAccount}</span>
-                                                {walletBalance}
                                                 <div className="hamburger">{hamburger}</div>
                                             </div>
-
                                         </div>
                                     </li>
                                     <ul className="dropdown header-menu" style={{left: 0, top: 63, maxHeight: !this.state.dropdownActive ? 0 : maxHeight, overflowY: "auto"}}>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -48,6 +48,8 @@ class Header extends React.Component {
 
         this.unlisten = null;
         this._closeDropdown = this._closeDropdown.bind(this);
+        this._closeMenuDropdown = this._closeMenuDropdown.bind(this);
+        this._closeAccountsListDropdown = this._closeAccountsListDropdown.bind(this);
         this.onBodyClick = this.onBodyClick.bind(this);
     }
 
@@ -141,8 +143,21 @@ class Header extends React.Component {
         this._closeDropdown();
     }
 
+    _closeAccountsListDropdown() {
+        this.setState({
+            accountsListDropdownActive: false
+        });
+    }
+
+    _closeMenuDropdown() {
+        this.setState({
+            dropdownActive: false,
+        });
+    }
+
     _closeDropdown() {
-        this.setState({dropdownActive: false});
+        this._closeMenuDropdown();
+        this._closeAccountsListDropdown();
     }
 
     _onGoBack(e) {

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -330,6 +330,7 @@ class Header extends React.Component {
             if (tradingAccounts.length >= 1) {
                 accountsList = tradingAccounts
                 .sort()
+                .filter((name) => name !== currentAccount)
                 .map((name) => {
                     return (
                         <li className={cnames({active: active.replace("/account/", "").indexOf(name) === 0})} onClick={this._accountClickHandler.bind(this, name)} key={name}>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -362,7 +362,7 @@ class Header extends React.Component {
                                 <div key="padlock" style={{paddingBottom: 15}} className="header-right-lock show-for-medium" onClick={this._toggleLock.bind(this)}>
                                     <Icon className="lock-unlock" style={{margin: "0 0.5rem"}} size="2x" name={this.props.locked ? "locked" : "unlocked"} />
                                 </div>,
-                                <div key="account-dropdown" className={cnames("dropdown-wrapper", {active: this.state.accountsListDropdownActive})}>
+                                <div key="account-dropdown" className={cnames("account-dropdown-wrapper dropdown-wrapper", {active: this.state.accountsListDropdownActive})}>
                                     <li style={{display: "flex"}}>
                                         <div onClick={() => {this.setState({accountsListDropdownActive: !this.state.accountsListDropdownActive});}} className="table-cell" style={{flex: 1}}>
                                             <div style={{lineHeight: "initial", display: "inline-block", paddingRight: 20}}>
@@ -384,10 +384,10 @@ class Header extends React.Component {
                                     </ul>
 
                                 </div>,
-                                <div key="dropdown" className={cnames("dropdown-wrapper", {active: this.state.dropdownActive})}>
+                                <div key="dropdown" className={cnames("menu-dropdown-wrapper dropdown-wrapper", {active: this.state.dropdownActive})}>
                                     <li style={{display: "flex"}}>
                                         <div onClick={() => {this.setState({dropdownActive: !this.state.dropdownActive});}} className="table-cell" style={{flex: 1}}>
-                                            <div style={{lineHeight: "initial", display: "inline-block", paddingRight: 20}}>
+                                            <div>
                                                 <div className="hamburger">{hamburger}</div>
                                             </div>
                                         </div>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -420,7 +420,7 @@ class Header extends React.Component {
 
                                     { hasLocalWallet && (
 
-                                        <ul className="dropdown header-menu" style={{left: 0, top: 63, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
+                                        <ul className="dropdown header-menu" style={{left: 0, top: 64, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
 
                                             <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
                                                 <div className="table-cell"><Icon size="2x" name="folder" /></div>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -466,8 +466,6 @@ class Header extends React.Component {
                                             <div className="table-cell"><Icon size="2x" name="folder" /></div>
                                             <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
                                         </li>
-
-                                        {accountsList}
                                     </ul>
                                 </div>]
                             }

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -47,6 +47,8 @@ class Header extends React.Component {
         };
 
         this.unlisten = null;
+        this._toggleAccountDropdownMenu = this._toggleAccountDropdownMenu.bind(this);
+        this._toggleDropdownMenu = this._toggleDropdownMenu.bind(this);
         this._closeDropdown = this._closeDropdown.bind(this);
         this._closeMenuDropdown = this._closeMenuDropdown.bind(this);
         this._closeAccountsListDropdown = this._closeAccountsListDropdown.bind(this);
@@ -198,6 +200,26 @@ class Header extends React.Component {
     //     this.context.router.push(`/account/${account}/overview`);
     // }
 
+    _toggleAccountDropdownMenu() {
+
+        // prevent state toggling if user cannot have multiple accounts
+
+        const hasLocalWallet = !!WalletDb.getWallet();
+
+        if (!hasLocalWallet)
+            return false;
+
+        this.setState({
+            accountsListDropdownActive: !this.state.accountsListDropdownActive
+        });
+    }
+
+    _toggleDropdownMenu() {
+        this.setState({
+            dropdownActive: !this.state.dropdownActive
+        });
+    }
+
     onBodyClick(e) {
         let el = e.target;
         let insideMenuDropdown = false;
@@ -321,6 +343,7 @@ class Header extends React.Component {
 
         let hamburger = this.state.dropdownActive ? <Icon className="icon-14px" name="hamburger-x" /> : <Icon className="icon-14px" name="hamburger" />;
 
+        const hasLocalWallet = !!WalletDb.getWallet();
         return (
             <div className="header menu-group primary">
                 {/*<div className="show-for-small-only">
@@ -384,9 +407,9 @@ class Header extends React.Component {
                                 <div key="padlock" style={{paddingBottom: 15}} className="header-right-lock show-for-medium" onClick={this._toggleLock.bind(this)}>
                                     <Icon className="lock-unlock" style={{margin: "0 0.5rem"}} size="2x" name={this.props.locked ? "locked" : "unlocked"} />
                                 </div>,
-                                <div key="account-dropdown" className={cnames("account-dropdown-wrapper dropdown-wrapper", {active: this.state.accountsListDropdownActive})}>
+                                <div key="account-dropdown" className={cnames("account-dropdown-wrapper dropdown-wrapper", {active: this.state.accountsListDropdownActive, "hover-transparent": !hasLocalWallet, "cursor-default": !hasLocalWallet})}>
                                     <li style={{display: "flex"}}>
-                                        <div onClick={() => {this.setState({accountsListDropdownActive: !this.state.accountsListDropdownActive});}} className="table-cell" style={{flex: 1}}>
+                                        <div onClick={this._toggleAccountDropdownMenu} className="table-cell" style={{flex: 1}}>
                                             <div style={{lineHeight: "initial", display: "inline-block", paddingRight: 20}}>
                                                 <span>{currentAccount}</span>
                                                 {walletBalance}
@@ -395,20 +418,23 @@ class Header extends React.Component {
                                         </div>
                                     </li>
 
-                                    <ul className="dropdown header-menu" style={{left: 0, top: 63, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
+                                    { hasLocalWallet && (
 
-                                        <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
-                                            <div className="table-cell"><Icon size="2x" name="folder" /></div>
-                                            <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
-                                        </li>
+                                        <ul className="dropdown header-menu" style={{left: 0, top: 63, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
 
-                                        {accountsList}
-                                    </ul>
+                                            <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
+                                                <div className="table-cell"><Icon size="2x" name="folder" /></div>
+                                                <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
+                                            </li>
 
+                                            {accountsList}
+                                        </ul>
+
+                                    )}
                                 </div>,
                                 <div key="dropdown" className={cnames("menu-dropdown-wrapper dropdown-wrapper", {active: this.state.dropdownActive})}>
                                     <li style={{display: "flex"}}>
-                                        <div onClick={() => {this.setState({dropdownActive: !this.state.dropdownActive});}} className="table-cell" style={{flex: 1}}>
+                                        <div onClick={this._toggleDropdownMenu} className="table-cell" style={{flex: 1}}>
                                             <div>
                                                 <div className="hamburger">{hamburger}</div>
                                             </div>

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -200,17 +200,24 @@ class Header extends React.Component {
 
     onBodyClick(e) {
         let el = e.target;
-        let insideDropdown = false;
+        let insideMenuDropdown = false;
+        let insideAccountDropdown = false;
 
         do {
-            if(el.classList && el.classList.contains("dropdown-wrapper")) {
-                insideDropdown = true;
+            if(el.classList && el.classList.contains("account-dropdown-wrapper")) {
+                insideAccountDropdown = true;
+                break;
+            }
+
+            if(el.classList && el.classList.contains("menu-dropdown-wrapper")) {
+                insideMenuDropdown = true;
                 break;
             }
 
         } while ((el = el.parentNode));
 
-        if(!insideDropdown) this._closeDropdown();
+        if(!insideAccountDropdown) this._closeAccountsListDropdown();
+        if(!insideMenuDropdown) this._closeMenuDropdown();
     }
 
     _onLinkAccount() {

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -531,10 +531,12 @@ class Header extends React.Component {
                                             <div className="table-cell"><Translate content="account.permissions" /></div>
                                         </li>
 
-                                        <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
-                                            <div className="table-cell"><Icon size="2x" name="folder" /></div>
-                                            <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
-                                        </li>
+                                        { !hasLocalWallet && (
+                                            <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
+                                                <div className="table-cell"><Icon size="2x" name="folder" /></div>
+                                                <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
+                                            </li>
+                                        )}
                                     </ul>
                                 </div>]
                             }


### PR DESCRIPTION
Wallet account:

![gif-acc-multiple](https://user-images.githubusercontent.com/35899973/35536405-15622eba-0547-11e8-8dfb-d8c653b3c098.gif)

Login/pass account:

![gif-acc-base](https://user-images.githubusercontent.com/35899973/35536416-208879f2-0547-11e8-9be4-7c166c862662.gif)

**Changes**
- Add additional dropdown with Accounts list and Account link if user is on Wallet Account mode
- Remove Accounts list from hamburger menu
- Remove Account link if user in Wallet Account mode
- Fix height of hamburger block (floating pixel)
- Increase paddings of user account name block to make it looks better
- UPD: Remove current account from accounts list

**Tested on MacOS in all media queries **
- Chrome
- Opera
- Firefox
- Safari

Btw: I'm new on bitshares-ui so I'm open for advices because I'm going to do a lot of work in future. 

Btw 2: If make window size is small the name and hamburger jumps on the next line and partially disappear. I have posted an issue about that: #1083 