### PR TITLE
Fix position of propose from on transaction confirmation #1071

### DIFF
--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -365,6 +365,11 @@ select.bts-select {
     appearance: menulist;
 }
 
+select.bts-select.full-width {
+  width: 100%;
+  max-width: 100%;
+}
+
 .windows select.bts-select {
     height: 2.35em;
 }

--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -184,7 +184,7 @@ class TransactionConfirm extends React.Component {
 
                     {/* P R O P O S E   F R O M */}
                     {this.props.propose ?
-                    <div className="full-width-content form-group">
+                    <div className="grid-content full-width-content form-group">
                         <label><Translate content="account.propose_from" /></label>
                         <AccountSelect
                             account_names={AccountStore.getMyAccounts()}

--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -187,6 +187,7 @@ class TransactionConfirm extends React.Component {
                     <div className="grid-content full-width-content form-group">
                         <label><Translate content="account.propose_from" /></label>
                         <AccountSelect
+                            className="full-width"
                             account_names={AccountStore.getMyAccounts()}
                             onChange={this.onProposeAccount.bind(this)}
                         />

--- a/app/components/Forms/AccountSelect.jsx
+++ b/app/components/Forms/AccountSelect.jsx
@@ -9,7 +9,8 @@ export default class AccountSelect extends React.Component {
         onChange: React.PropTypes.func,
         placeholder: React.PropTypes.string,
         center: React.PropTypes.bool,
-        tabIndex: React.PropTypes.number
+        tabIndex: React.PropTypes.number,
+        className: React.PropTypes.string
         //defaultAccount: React.PropTypes.string
     };
 
@@ -55,7 +56,7 @@ export default class AccountSelect extends React.Component {
                 ref='account-selector'
                 key={selected_account}
                 defaultValue={selected_account}
-                className="form-control account-select bts-select"
+                className={"form-control account-select bts-select " + (this.props.className || "")}
                 onChange={this._onAccountChange.bind(this)}
                 style={this.props.center?{margin: '0 auto'}:null}
                 tabIndex={this.props.tabIndex}


### PR DESCRIPTION
Before: 
<img width="560" alt="screenshot 2018-01-31 01 51 29" src="https://user-images.githubusercontent.com/35899973/35599493-45a18b74-0629-11e8-8dbc-1f099e3c8e81.png">

After: 
<img width="560" alt="screenshot 2018-01-31 01 48 30" src="https://user-images.githubusercontent.com/35899973/35599457-220cc7f0-0629-11e8-86b3-3993c86630ce.png">

Changes: 
- Fix position and width of propose
- Provide an additional `full-width` class for bts-select
- Provide an ability to apply className for AccountSelect component

Tested on MacOS (all media queries):
- Chrome
- Firefox
- Opera
- Safari