### PR TITLE
Do redirect to user Portfolio after Login #1068

### DIFF
--- a/app/components/LoginSelector.jsx
+++ b/app/components/LoginSelector.jsx
@@ -30,8 +30,12 @@ class LoginSelector extends React.Component {
     componentDidUpdate() {
         const myAccounts = AccountStore.getMyAccounts();
 
+        // use ChildCount to make sure user is on /create-account page except /create-account/*
+        // to prevent redirect when user just registered and need to make backup of wallet or password
+        const childCount = React.Children.count(this.props.children);
+
         // do redirect to portfolio if user already logged in
-        if(Array.isArray(myAccounts) && myAccounts.length !== 0)
+        if(Array.isArray(myAccounts) && myAccounts.length !== 0 && childCount === 0)
             this.props.router.push("/account/"+this.props.currentAccount);
     }
 

--- a/app/components/LoginSelector.jsx
+++ b/app/components/LoginSelector.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { connect } from "alt-react";
+import AccountStore from "stores/AccountStore";
 import {Link} from "react-router/es";
 import Translate from "react-translate-component";
 import { isIncognito } from "feature_detect";
@@ -13,7 +15,7 @@ const FlagImage = ({flag, width = 50, height = 50}) => {
      return <img height={height} width={width} src={`${__BASE_URL__}language-dropdown/${flag.toUpperCase()}.png`} />;
 };
 
-export default class LoginSelector extends React.Component {
+class LoginSelector extends React.Component {
 
     constructor(props){
         super(props);
@@ -23,6 +25,14 @@ export default class LoginSelector extends React.Component {
             locales: SettingsStore.getState().defaults.locale,
             currentLocale: SettingsStore.getState().settings.get("locale")
         };
+    }
+
+    componentDidUpdate() {
+        const myAccounts = AccountStore.getMyAccounts();
+
+        // do redirect to portfolio if user already logged in
+        if(Array.isArray(myAccounts) && myAccounts.length !== 0)
+            this.props.router.push("/account/"+this.props.currentAccount);
     }
 
     componentWillMount(){
@@ -138,3 +148,14 @@ export default class LoginSelector extends React.Component {
         );
     }
 }
+
+export default connect(LoginSelector, {
+    listenTo() {
+        return [AccountStore];
+    },
+    getProps() {
+        return {
+            currentAccount: AccountStore.getState().currentAccount || AccountStore.getState().passwordAccount,
+        };
+    }
+});


### PR DESCRIPTION
The bug was if user do Login on `/create-account` page except `/` (home) after Login he stays on this page and see `Welcome to Bitshares` message except be redirected to dashboard 

<img width="560" alt="screenshot 2018-01-31 01 51 29" src="https://user-images.githubusercontent.com/7770343/35472919-46990452-0378-11e8-9422-72aab8fde7a1.png">


Tested on Mac:
- Chrome
- Firefox
- Safari
- Opera

Redirect was tested by the following use cases:
- [x] if user not logged in he shouldn't be redirected
- [x] if user logged in and stay on `/create-account` page he should be redirected
- [x] if user logged in and stay on `/create-account/*` page he shouldn't be redirected because after registration user already logged in but he should see messages about wallet/password backup