### PR TITLE
Feat #972: Joined vertical order book

### DIFF
--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -133,6 +133,10 @@ button, .button {
   @include RobotoRegular;
 }
 
+.vertical-order-table-cell {
+  @include RobotoRegular;
+}
+
 .table.dashboard-table {
     > thead > tr > th {
         @include RobotoRegular;

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -143,10 +143,12 @@ form.order-form {
         font-weight: bold;
     }
     .no-orders {
-        text-align: center;
+        text-align: center !important;
         margin-left: auto;
         margin-right: auto;
-        padding-top: 3em;
+        &.padtop {
+            padding-top: 1em;
+        }
     }
     .cell {
         display: table-cell;
@@ -195,6 +197,7 @@ form.order-form {
     }
     .top-header {
       text-align: right;
+      height: 31px;
     }
 }
 

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -131,17 +131,70 @@ form.order-form {
             padding-bottom: 8px !important;
         }
     }
+    .transition-container {
+      display: table-row-group;
+    }
     > .table-container {
         flex-grow: 1;
         width: 100%;
         position: relative;
     }
-    > .spread {
-        flex-shrink: 1;
-        width: 100%;
-        padding: 0.25rem 0 0.25rem 0;
-        border-top: 1px solid #777;
-        border-bottom: 1px solid #777;
+    .my-order {
+        font-weight: bold;
+    }
+    .no-orders {
+        text-align: center;
+        margin-left: auto;
+        margin-right: auto;
+        padding-top: 3em;
+    }
+    .cell {
+        display: table-cell;
+        font-size: 12px;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        vertical-align: middle;
+        text-align: right;
+        &.header-cell {
+          padding-top: 0;
+          padding-bottom: 0;
+        }
+        $scrollBarSpacePadding: 15px;
+        &.left, &.right {
+          padding-left: $scrollBarSpacePadding;
+          padding-right: $scrollBarSpacePadding;
+        }
+        .text-center.spread {
+            color: grey;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            width: 100%;
+            .lock-unlock {
+              margin-left: auto;
+              margin-right: auto;
+            }
+            .left {
+                padding-left: $scrollBarSpacePadding;
+            }
+            .right {
+                padding-right: $scrollBarSpacePadding;
+            }
+        }
+    }
+    .bottom-header {
+      width: 100%;
+      height: 2rem;
+      .button.outline {
+        border-left: none
+      }
+    }
+    .order-table-container {
+       width: 100%;
+       height: calc(100% - 32px);
+    }
+    .top-header {
+      text-align: right;
     }
 }
 

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -150,6 +150,12 @@ form.order-form {
             padding-top: 1em;
         }
     }
+    .ps-scrollbar-y-rail {
+        width: 10px !important;
+        .ps-scrollbar-y {
+          width: 6px !important;
+        }
+    }
     .cell {
         display: table-cell;
         font-size: 12px;

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -258,7 +258,6 @@ $pulsate-red-end
             border-top-color: $bg-color;
             border-bottom-color: $bg-color;
             background-color: $panel-bg-color; //lighten($bg-color, 4%);
-
         }
 
         .left-column-2 {
@@ -1061,7 +1060,7 @@ $pulsate-red-end
     //   @include RobotoLight;
     // }
 
-    td.orderHistoryBid {
+    .orderHistoryBid {
 
         > span.price-integer, > span > span.price-integer, > span.formatted-price > span {
             font-weight: bold;
@@ -1076,7 +1075,7 @@ $pulsate-red-end
 
     }
 
-    td.orderHistoryAsk  {
+    .orderHistoryAsk  {
         > span.price-integer, > span > span.price-integer, > span.formatted-price > span {
             font-weight: bold;
             color: $ask-color;
@@ -1088,7 +1087,7 @@ $pulsate-red-end
         }
     }
 
-    td.orderHistoryCall {
+    .orderHistoryCall {
         > span.price-integer, > span > span.price-integer, > span.formatted-price > span {
             font-weight: bold;
             color: $call-color;
@@ -1100,14 +1099,15 @@ $pulsate-red-end
         }
     }
 
-    table.order-table > tbody, tbody.orderbook {
-        > tr.my-order > td {
-            font-weight: bold;
-            color: $info-color;
-            > span.price-integer, > span > span.price-integer, > span >span.price-decimal {
-                color: $info-color;
-                opacity: 1;
-            }
+    .order-table .my-order {
+        > .vertical-order-table-cell, > td {
+          font-weight: bold;
+          color: $info-color;
+        }
+
+        span.price-integer, span.price-decimal {
+            color: $info-color !important;
+            opacity: 1;
         }
     }
 
@@ -1121,6 +1121,9 @@ $pulsate-red-end
 
     .orderbook-latest-price {
         > div {
+            $orderbook-center-horizontal-margin: 5px;
+            margin-top: $orderbook-center-horizontal-margin;
+            margin-bottom: $orderbook-center-horizontal-margin;
             background-color: $panel-bg-color !important;
             border-bottom: 1px solid grey !important;
             border-top: 1px solid grey !important;
@@ -1130,9 +1133,43 @@ $pulsate-red-end
         }
     }
 
+    .sticky-table .sticky-table-column, .sticky-table .sticky-table-header, .sticky-table .sticky-table-corner {
+        @include color($primary-text-color, $bg-color);
+    }
+
+    .left-order-book {
+      background-color: $bg-color;
+
+      .spread .spread-value {
+        color: $primary-text-color;
+      }
+    }
+
+    .sticky-table-header {
+        width: 100%;
+        height: 32px;
+        border-bottom: 1px solid grey;
+
+        .sticky-table-container {
+            height: 100%;
+            width: 100%;
+        }
+
+        #sticky-header-row {
+            background-color: $panel-bg-color;
+        }
+
+        .sticky-table-row  {
+            width: 100%;
+            background-color: $bg-color;
+
+            &.order-row:hover {
+              background-color: $panel-bg-color;
+            }
+        }
+    }
 
     .order-table {
-
         > tbody > tr:nth-of-type(even) {
             background-color: $row-accent-color;
         }
@@ -1209,7 +1246,7 @@ $pulsate-red-end
     }
 
     .header-sub-title {
-        font-size: 80%;
+        font-size: 11px;
         color: $light-text-color;
     }
 

--- a/app/assets/stylesheets/vendors/_perfect-scrollbar.scss
+++ b/app/assets/stylesheets/vendors/_perfect-scrollbar.scss
@@ -67,7 +67,7 @@
     transition: background-color .2s linear, opacity .2s linear;
     right: 0;
     /* there must be 'right' for ps-scrollbar-y-rail */
-    width: 10px !important; }
+    width: 15px; }
     .ps-container > .ps-scrollbar-y-rail > .ps-scrollbar-y {
       position: absolute;
       /* please don't change 'position' */
@@ -83,7 +83,7 @@
       transition: background-color .2s linear, height .2s linear, width .2s ease-in-out, border-radius .2s ease-in-out, -webkit-border-radius .2s ease-in-out, -moz-border-radius .2s ease-in-out;
       right: 2px;
       /* there must be 'right' for ps-scrollbar-y */
-      width: 6px !important; }
+      width: 6px; }
     .ps-container > .ps-scrollbar-y-rail:hover > .ps-scrollbar-y, .ps-container > .ps-scrollbar-y-rail:active > .ps-scrollbar-y {
       width: 11px; }
   .ps-container:hover.ps-in-scrolling.ps-x > .ps-scrollbar-x-rail {

--- a/app/assets/stylesheets/vendors/_perfect-scrollbar.scss
+++ b/app/assets/stylesheets/vendors/_perfect-scrollbar.scss
@@ -67,7 +67,7 @@
     transition: background-color .2s linear, opacity .2s linear;
     right: 0;
     /* there must be 'right' for ps-scrollbar-y-rail */
-    width: 15px; }
+    width: 10px !important; }
     .ps-container > .ps-scrollbar-y-rail > .ps-scrollbar-y {
       position: absolute;
       /* please don't change 'position' */
@@ -83,7 +83,7 @@
       transition: background-color .2s linear, height .2s linear, width .2s ease-in-out, border-radius .2s ease-in-out, -webkit-border-radius .2s ease-in-out, -moz-border-radius .2s ease-in-out;
       right: 2px;
       /* there must be 'right' for ps-scrollbar-y */
-      width: 6px; }
+      width: 6px !important; }
     .ps-container > .ps-scrollbar-y-rail:hover > .ps-scrollbar-y, .ps-container > .ps-scrollbar-y-rail:active > .ps-scrollbar-y {
       width: 11px; }
   .ps-container:hover.ps-in-scrolling.ps-x > .ps-scrollbar-x-rail {

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -462,16 +462,26 @@ class OrderBook extends React.Component {
                                 component="div"
                                 transitionName="newrow"
                             >
-                              {askRows}
+                                {askRows.length > 0
+                                    ? askRows
+                                    : (noOrders || <div className="sticky-table-row">
+                                          <td className="cell no-orders padtop" colSpan="3">
+                                              No asks
+                                          </td>
+                                      </div>)}
                             </TransitionWrapper>
                             <div className="sticky-table-row" ref="center_text">
-                              {noOrders ? <td colSpan={3} className="no-orders">No orders</td> :
+                              {noOrders ? <td colSpan={3} className="no-orders padtop">No orders</td> :
                                 <td className="cell center-cell" colSpan="3">
                                     <div className="orderbook-latest-price">
                                         <div className="text-center spread">
-                                            {(!!spread) && <span className="clickable left" onClick={this.toggleSpreadValue}>Spread <span className="spread-value">{spread}</span></span>}
+                                            {(!!spread) && <span className="clickable left" onClick={this.toggleSpreadValue}>
+                                                Spread <span className="spread-value">{spread}</span>
+                                            </span>}
                                             <Icon className="lock-unlock clickable" onClick={this.toggleAutoScroll} name={this.state.autoScroll ? "locked" : "unlocked"} />
-                                            {(!!this.props.latest) && <span className="right">Latest <span className={this.props.changeClass}><PriceText preFormattedPrice={this.props.latest} /></span></span>}
+                                            {(!!this.props.latest) && <span className="right">
+                                                Latest <span className={this.props.changeClass}><PriceText preFormattedPrice={this.props.latest} /></span>
+                                            </span>}
                                         </div>
                                     </div>
                                 </td>
@@ -483,7 +493,13 @@ class OrderBook extends React.Component {
                                 component="div"
                                 transitionName="newrow"
                             >
-                                {bidRows}
+                                {bidRows.length > 0
+                                    ? bidRows
+                                    : (noOrders || <div className="sticky-table-row">
+                                          <td className="cell no-orders" colSpan="3">
+                                              No bids
+                                          </td>
+                                      </div>)}
                             </TransitionWrapper>
                         </StickyTable>
                     </div>

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -156,10 +156,13 @@ class OrderBook extends React.Component {
         }
     }
 
+    queryStickyTable = (query) => this.refs.vertical_sticky_table.table.querySelector(query)
+
+    verticalScrollBar = () => this.queryStickyTable("#y-scrollbar");
+
     componentDidMount() {
         if (!this.props.horizontal) {
-            const scrollbar = document.getElementById("y-scrollbar");
-            Ps.initialize(scrollbar);
+            Ps.initialize(this.verticalScrollBar());
             this.centerVerticalScrollBar();
         } else {
             let bidsContainer = this.refs.hor_bids;
@@ -172,7 +175,7 @@ class OrderBook extends React.Component {
 
     centerVerticalScrollBar() {
         if (!this.props.horizontal && this.state.autoScroll) {
-            const scrollableContainer = document.getElementById("sticky-table-y-wrapper");
+            const scrollableContainer = this.queryStickyTable("#sticky-table-y-wrapper");
             const centerTextContainer = this.refs.center_text;
             const centeringOffset = 21;
             const scrollTo = centerTextContainer.offsetTop - (elemHeight(scrollableContainer) / 2) + centeringOffset;
@@ -183,8 +186,7 @@ class OrderBook extends React.Component {
 
     psUpdate() {
         if (!this.props.horizontal) {
-            const scrollbar = document.getElementById("y-scrollbar");
-            Ps.update(scrollbar);
+            Ps.update(this.verticalScrollBar());
             this.centerVerticalScrollBar();
         } else {
             let bidsContainer = this.refs.hor_bids;
@@ -441,8 +443,8 @@ class OrderBook extends React.Component {
             // Vertical orderbook
             return (
                 <div className="left-order-book no-padding no-overflow">
-                    <div className="order-table-container" ref="vertical_sticky_table">
-                        <StickyTable stickyColumnCount={0} className="order-table table">
+                    <div className="order-table-container">
+                        <StickyTable stickyColumnCount={0} className="order-table table"  ref="vertical_sticky_table">
                             <div className="sticky-table-row top-header">
                                 <div className="cell header-cell left">
                                     <span className="header-sub-title"><AssetName name={baseSymbol} /></span>

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -140,6 +140,10 @@ class OrderBook extends React.Component {
             }
 
             if (this.refs.vert_bids) this.refs.vert_bids.scrollTop = 0;
+
+            if (!this.props.horizontal) {
+                this.setState({autoScroll: true});
+            }
         }
 
         if (

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -466,7 +466,7 @@ class OrderBook extends React.Component {
                             </TransitionWrapper>
                             <div className="sticky-table-row" ref="center_text">
                               {noOrders ? <td colSpan={3} className="no-orders">No orders</td> :
-                                <td className="cell vertical-order-table-center-cell center-cell" colSpan="3">
+                                <td className="cell center-cell" colSpan="3">
                                     <div className="orderbook-latest-price">
                                         <div className="text-center spread">
                                             {(!!spread) && <span className="clickable left" onClick={this.toggleSpreadValue}>Spread <span className="spread-value">{spread}</span></span>}

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -8,6 +8,9 @@ import classnames from "classnames";
 import PriceText from "../Utility/PriceText";
 import TransitionWrapper from "../Utility/TransitionWrapper";
 import AssetName from "../Utility/AssetName";
+import { StickyTable } from "react-sticky-table";
+import Icon from "../Icon/Icon";
+import "react-sticky-table/dist/react-sticky-table.css";
 
 class OrderBookRowVertical extends React.Component {
 
@@ -28,16 +31,23 @@ class OrderBookRowVertical extends React.Component {
 
         let price = <PriceText price={order.getPrice()} quote={quote} base={base} />;
         return (
-            <tr onClick={this.props.onClick} className={classnames({"final-row": final}, {"my-order": order.isMine(this.props.currentAccount)})}>
-                <td>{utils.format_number(order[isBid ? "amountForSale" : "amountToReceive"]().getAmount({real: true}), base.get("precision"))}</td>
-                <td>{utils.format_number(order[isBid ? "amountToReceive" : "amountForSale"]().getAmount({real: true}), quote.get("precision"))}</td>
-                <td className={integerClass}>
+            <div onClick={this.props.onClick} className={classnames("sticky-table-row order-row", {"final-row": final}, {"my-order": order.isMine(this.props.currentAccount)})}>
+                <div className="cell left">
+                    {utils.format_number(order[isBid ? "amountForSale" : "amountToReceive"]().getAmount({real: true}), base.get("precision"))}
+                </div>
+                <div className="cell">
+                    {utils.format_number(order[isBid ? "amountToReceive" : "amountForSale"]().getAmount({real: true}), quote.get("precision"))}
+                </div>
+                <div className={`cell ${integerClass} right`}>
                     {price}
-                </td>
-            </tr>
+                </div>
+            </div>
         );
     }
 }
+
+const elemHeight = (elem) => elem.getBoundingClientRect().height;
+
 
 class OrderBookRowHorizontal extends React.Component {
     shouldComponentUpdate(np) {
@@ -91,14 +101,12 @@ class OrderBook extends React.Component {
     constructor(props) {
         super();
         this.state = {
-            scrollToBottom: true,
             flip: props.flipOrderBook,
             showAllBids: false,
             showAllAsks: false,
-            rowCount: 20
+            rowCount: 20,
+            autoScroll: true
         };
-
-        this._updateHeight = this._updateHeight.bind(this);
     }
 
     // shouldComponentUpdate(nextProps, nextState) {
@@ -118,17 +126,8 @@ class OrderBook extends React.Component {
     // }
 
     componentWillReceiveProps(nextProps) {
-        if (!nextProps.marketReady) {
-            this.setState({
-                scrollToBottom: true
-            });
-        }
-
         // Change of market or direction
         if (nextProps.base.get("id") !== this.props.base.get("id") || nextProps.quote.get("id") !== this.props.quote.get("id")) {
-            this.setState({
-                scrollToBottom: true
-            });
 
             if (this.refs.askTransition) {
                 this.refs.askTransition.resetAnimation();
@@ -153,41 +152,11 @@ class OrderBook extends React.Component {
         }
     }
 
-    _updateHeight() {
-        if (!this.props.horizontal) {
-            let containerHeight = this.refs.orderbook_container.offsetHeight;
-            let priceHeight = this.refs.center_text.offsetHeight;
-            let asksHeight = this.refs.asksWrapper.offsetHeight;
-
-            let newAsksHeight = Math.floor((containerHeight - priceHeight) / 2);
-            let newBidsHeight = containerHeight - priceHeight - asksHeight - 2;
-            if (newAsksHeight !== this.state.vertAsksHeight || newBidsHeight !== this.state.vertBidsHeight) {
-                this.setState({
-                    vertAsksHeight: newAsksHeight,
-                    vertBidsHeight: newBidsHeight
-                }, this.psUpdate);
-            }
-
-        }
-    }
-
-    componentWillMount() {
-        window.addEventListener("resize", this._updateHeight, {capture: false, passive: true});
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener("resize", this._updateHeight);
-    }
-
     componentDidMount() {
-
         if (!this.props.horizontal) {
-            this._updateHeight();
-
-            let asksContainer = this.refs.vert_asks;
-            Ps.initialize(asksContainer);
-            let bidsContainer = this.refs.vert_bids;
-            Ps.initialize(bidsContainer);
+            const scrollbar = document.getElementById("y-scrollbar");
+            Ps.initialize(scrollbar);
+            this.centerVerticalScrollBar();
         } else {
             let bidsContainer = this.refs.hor_bids;
             Ps.initialize(bidsContainer);
@@ -195,41 +164,29 @@ class OrderBook extends React.Component {
             Ps.initialize(asksContainer);
         }
 
+    }
+
+    centerVerticalScrollBar() {
+        if (!this.props.horizontal && this.state.autoScroll) {
+            const scrollableContainer = document.getElementById("sticky-table-y-wrapper");
+            const centerTextContainer = this.refs.center_text;
+            const centeringOffset = 21;
+            const scrollTo = centerTextContainer.offsetTop - (elemHeight(scrollableContainer) / 2) + centeringOffset;
+
+            this.setState({ownScroll: true}, () => scrollableContainer.scrollTop = scrollTo);
+        }
     }
 
     psUpdate() {
         if (!this.props.horizontal) {
-            let asksContainer = this.refs.vert_asks;
-            Ps.update(asksContainer);
-            if (this.state.scrollToBottom) {
-                asksContainer.scrollTop = asksContainer.scrollHeight;
-            };
-            let bidsContainer = this.refs.vert_bids;
-            Ps.update(bidsContainer);
+            const scrollbar = document.getElementById("y-scrollbar");
+            Ps.update(scrollbar);
+            this.centerVerticalScrollBar();
         } else {
             let bidsContainer = this.refs.hor_bids;
             Ps.update(bidsContainer);
             let asksContainer = this.refs.hor_asks;
             Ps.update(asksContainer);
-        }
-    }
-
-    componentDidUpdate() {
-        this._updateHeight();
-    }
-
-    _onBidScroll(e) {
-
-        if (e.target.scrollTop < (e.target.scrollHeight - this.state.vertAsksHeight)) {
-            if (this.state.scrollToBottom) {
-                this.setState({
-                    scrollToBottom: false
-                });
-            }
-        } else {
-            this.setState({
-                scrollToBottom: false
-            });
         }
     }
 
@@ -262,11 +219,27 @@ class OrderBook extends React.Component {
         }
     }
 
+    toggleSpreadValue = () => {
+        this.setState({displaySpreadAsPercentage: !this.state.displaySpreadAsPercentage});
+    }
+
+    toggleAutoScroll = () => {
+        const newState = {autoScroll: !this.state.autoScroll};
+        if (newState.autoScroll)
+            this.setState(newState, this.centerVerticalScrollBar);
+        else
+            this.setState(newState);
+    }
+
     render() {
         let {combinedBids, combinedAsks, highestBid, lowestAsk, quote, base,
             totalAsks, totalBids, quoteSymbol, baseSymbol, horizontal} = this.props;
-        let {showAllAsks, showAllBids, rowCount} = this.state;
-
+        let {showAllAsks, showAllBids, rowCount, displaySpreadAsPercentage} = this.state;
+        const noOrders = (!lowestAsk.sell_price) && (!highestBid.sell_price);
+        const hasAskAndBids = !!(lowestAsk.sell_price && highestBid.sell_price)
+        const spread = hasAskAndBids && (displaySpreadAsPercentage ?
+          `${(100 * (lowestAsk._real_price / highestBid._real_price - 1)).toFixed(2)}%`
+          : <PriceText price={lowestAsk._real_price - highestBid._real_price} base={base} quote={quote}/>);
         let bidRows = null, askRows = null;
         if(base && quote) {
             bidRows = combinedBids
@@ -464,65 +437,51 @@ class OrderBook extends React.Component {
             // Vertical orderbook
             return (
                 <div className="left-order-book no-padding no-overflow">
-                    <div className="grid-block shrink left-orderbook-header" style={{paddingRight: 15, zIndex: 10}}>
-                        <table className="table expand order-table table-hover text-right">
-                            <thead>
-                                <tr>
-                                    <th style={{paddingBottom: 8, textAlign: "right", "borderBottomColor": "#777"}}>
-                                        <span className="header-sub-title"><AssetName name={baseSymbol} /></span>
-                                    </th>
-                                    <th style={{paddingBottom: 8, textAlign: "right", "borderBottomColor": "#777"}}>
-                                        <span className="header-sub-title"><AssetName name={quoteSymbol} /></span>
-                                    </th>
-                                    <th style={{paddingBottom: 8, textAlign: "right", "borderBottomColor": "#777"}}>
-                                        <Translate className="header-sub-title" content="exchange.price" />
-                                    </th>
-                                </tr>
-                            </thead>
-                        </table>
-                    </div>
-                    <div className="grid-block vertical no-padding" ref="orderbook_container" style={{width: "100%"}}>
-                            <div id="asksWrapper" style={{overflow:"hidden"}} ref="asksWrapper">
-                                <div onScroll={this._onBidScroll.bind(this)} className="grid-block" ref="vert_asks" style={{overflow: "hidden", maxHeight: this.state.vertAsksHeight || 300}}>
-                                    <div style={{paddingRight: 10, width: "100%", height: "100%", display: "table-cell", verticalAlign: "bottom"}}>
-                                        <table style={{position: "relative", bottom: 0}} className="table order-table table-hover text-right">
-                                            <TransitionWrapper
-                                                ref="askTransition"
-                                                className="ps-container clickable"
-                                                component="tbody"
-                                                transitionName="newrow"
-                                            >
-                                                {askRows}
-                                            </TransitionWrapper>
-                                        </table>
-                                    </div>
+                    <div className="order-table-container" ref="vertical_sticky_table">
+                        <StickyTable stickyColumnCount={0} className="order-table table">
+                            <div className="sticky-table-row top-header">
+                                <div className="cell header-cell left">
+                                    <span className="header-sub-title"><AssetName name={baseSymbol} /></span>
+                                </div>
+                                <div className="cell header-cell">
+                                    <span className="header-sub-title"><AssetName name={quoteSymbol} /></span>
+                                </div>
+                                <div className="cell header-cell right">
+                                    <Translate className="header-sub-title" content="exchange.price" />
                                 </div>
                             </div>
-                            <div ref="center_text" style={{minHeight: 35}}>
-                                    <div key="spread" className="orderbook-latest-price" ref="centerRow">
+                            <TransitionWrapper
+                                ref="askTransition"
+                                className="transition-container clickable"
+                                component="div"
+                                transitionName="newrow"
+                            >
+                              {askRows}
+                            </TransitionWrapper>
+                            <div className="sticky-table-row" ref="center_text">
+                              {noOrders ? <td colSpan={3} className="no-orders">No orders</td> :
+                                <td className="cell vertical-order-table-center-cell center-cell" colSpan="3">
+                                    <div className="orderbook-latest-price">
                                         <div className="text-center spread">
-                                            {this.props.latest ? <span className={this.props.changeClass}><PriceText preFormattedPrice={this.props.latest} /> <AssetName name={baseSymbol} />/<AssetName name={quoteSymbol} /></span> : null}
+                                            {(!!spread) && <span className="clickable left" onClick={this.toggleSpreadValue}>Spread <span className="spread-value">{spread}</span></span>}
+                                            <Icon className="lock-unlock clickable" onClick={this.toggleAutoScroll} name={this.state.autoScroll ? "locked" : "unlocked"} />
+                                            {(!!this.props.latest) && <span className="right">Latest <span className={this.props.changeClass}><PriceText preFormattedPrice={this.props.latest} /></span></span>}
                                         </div>
                                     </div>
+                                </td>
+                              }
                             </div>
-                            <div id="bidsWrapper" style={{overflow:"hidden"}}>
-                                <div className="grid-block" ref="vert_bids" style={{overflow: "hidden", height: this.state.vertBidsHeight || 300}}>
-                                <div style={{paddingRight: 10, width: "100%", height: "100%", display: "table-cell", verticalAlign: "top"}}>
-                                    <table className="table order-table table-hover text-right">
-                                        <TransitionWrapper
-                                            ref="bidTransition"
-                                            className="ps-container clickable"
-                                            component="tbody"
-                                            transitionName="newrow"
-                                        >
-                                            {bidRows}
-                                        </TransitionWrapper>
-                                    </table>
-                                </div>
-                                </div>
-                            </div>
+                            <TransitionWrapper
+                                ref="bidTransition"
+                                className="transition-container clickable"
+                                component="div"
+                                transitionName="newrow"
+                            >
+                                {bidRows}
+                            </TransitionWrapper>
+                        </StickyTable>
                     </div>
-                    <div style={{width: "100%"}} className="v-align no-padding align-center grid-block footer shrink bottom-header">
+                    <div className="v-align no-padding align-center grid-block footer shrink bottom-header">
                         <div onClick={this.props.moveOrderBook} className="button small outline horizontal-button">
                             <Translate content="exchange.horizontal" />
                         </div>

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "node-libs-browser": "^1.0.0",
     "node-sass": "^4.5.3",
     "postcss-loader": "^0.8.2",
+    "react-sticky-table": "^1.2.0",
     "remarkable-loader": "^0.2.1",
     "sass-loader": "^6.0.6",
     "script-loader": "^0.6.1",


### PR DESCRIPTION
Screenshots [here](https://github.com/bitshares/bitshares-ui/issues/972#issuecomment-361022310)

This adds a new dependency, [react-sticky-table](https://github.com/henrybuilt/react-sticky-table). 
I would have had to re-implement pretty much the same thing without it.

I took the liberty to add two feature not requested in #972 :
+ A lock button that is on by default to maintain the order book centered as it gets updated.
+ The ability to click on the spread to display a percentage