### PR TITLE
776 add force settlement offset and delay to asset page

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -785,7 +785,9 @@
         "settlement_price": "Settlement price",
         "maintenance_collateral_ratio": "Maintenance collateral ratio (MCR)",
         "maximum_short_squeeze_ratio": "Maximum short squeeze ratio (MSSR)",
-        "global_settlement_price" : "Global settlement price"
+        "global_settlement_price" : "Global settlement price",
+        "settlement_delay" : "Settlement delay",
+        "force_settlement_offset" : "Force settlement offset"
       },
       "fee_pool": {
         "title": "Fee Pool",

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -12,6 +12,7 @@ import HelpContent from "../Utility/HelpContent";
 import Icon from "../Icon/Icon";
 import assetUtils from "common/asset_utils";
 import utils from "common/utils";
+import FormattedTime from "../Utility/FormattedTime";
 import {ChainStore} from "bitsharesjs/es";
 import {Apis} from "bitsharesjs-ws";
 import { Tabs, Tab } from "../Utility/Tabs";
@@ -342,10 +343,15 @@ class Asset extends React.Component {
             return ( <div header= {title} /> );
         var currentFeed = bitAsset.current_feed;
 
+        console.log("force settlement delay: " + bitAsset.options.force_settlement_delay_sec);
+        console.log("force settlement offset: " + bitAsset.options.force_settlement_offset_percent);
+
+        let settlementDelay = bitAsset.options.force_settlement_delay_sec;
+        let settlementOffset = bitAsset.options.force_settlement_offset_percent;
+
         var globalSettlementPrice = this.getGlobalSettlementPrice();
-        // this would be faster, but a bug prevents us from doing this
-        // since sometimes the call price is incorrect
-        //var globalSettlementPrice = this.getGlobalSettlementPriceFromSorted(sortedCallOrders);
+     
+        
 
         return (
             <div className="asset-card no-padding">
@@ -372,6 +378,18 @@ class Asset extends React.Component {
                         <tr>
                             <td> <Translate content="explorer.asset.price_feed.global_settlement_price"/> </td>
                             <td> {globalSettlementPrice} </td>
+                        </tr>
+
+                        <br /><br />
+
+                        <tr>
+                             <td> <Translate content="explorer.asset.price_feed.settlement_delay"/> </td>
+                             <td> <FormattedTime time={settlementDelay} /> </td>
+                       </tr>
+
+                        <tr>
+                              <td> <Translate content="explorer.asset.price_feed.force_settlement_offset"/> </td>
+                              <td> {settlementOffset/100}% </td>
                         </tr>
 
                     </tbody>
@@ -513,10 +531,6 @@ class Asset extends React.Component {
     // 's collateral no longer enough to back the debt
     // he/she owes. If the feed price goes above this,
     // then
-
-    // DOESN'T WORK - for reason if js sees that sortedcallorders
-    // is indexed, then it screws up the type system and
-    // sets the array to empty
     getGlobalSettlementPriceFromSorted(sortedCallOrders) {
         console.log("global settlement sorted called");
         // first get the least collateralized short position
@@ -559,9 +573,6 @@ class Asset extends React.Component {
             call_orders = this.state.callOrders;
         }
 
-        console.log("call orders");
-        console.log(call_orders);
-
         // first get the least collateralized short position
         var leastColShort = null;
         var leastColShortRatio = null;
@@ -589,11 +600,8 @@ class Asset extends React.Component {
         // Rearranging, this means that the CR is 1 iff
         // feed_price == collateral / debt
         let debt = leastColShort.amountToReceive().getAmount();
-        console.log("debt " + debt);
         let collateral = leastColShort.getCollateral().getAmount();
-        console.log("collateral: " + collateral);
         let globalSettlementPrice = collateral / debt;
-        console.log("doom price unformat: " + globalSettlementPrice);
 
         return (<FormattedPrice
                 base_amount={collateral}

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -351,8 +351,6 @@ class Asset extends React.Component {
 
         var globalSettlementPrice = this.getGlobalSettlementPrice();
      
-        
-
         return (
             <div className="asset-card no-padding">
                 <div className="card-divider">{title}</div>
@@ -377,7 +375,7 @@ class Asset extends React.Component {
 
                         <tr>
                             <td> <Translate content="explorer.asset.price_feed.global_settlement_price"/> </td>
-                            <td> {globalSettlementPrice} </td>
+                            <td> {globalSettlementPrice ? globalSettlementPrice : "-"} </td>
                         </tr>
 
                         <br /><br />

--- a/app/components/Utility/FormattedTime.jsx
+++ b/app/components/Utility/FormattedTime.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+// a class to display time nicely when given seconds 
+// for example, display 
+
+// expects the number of seconds as a property
+
+class FormattedTime extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {time : props.time};
+    }
+
+    // given an integer seconds as an argument, 
+    // return the number of hours
+    getHours(secs) {
+        console.log("get hours called with: " + secs);
+        return secs / 3600;
+    }
+
+    render() {
+        return (
+            <div>
+                {this.getHours(this.state.time)}h
+            </div>
+        );
+    }
+}
+
+export default FormattedTime;


### PR DESCRIPTION
For issue https://github.com/bitshares/bitshares-ui/issues/766

Adds settlement offset and delay to the assets page in a manner similar to cryptofresh. As a small fix, also adds a dash to the global settlement price when the asset has black swanned. 