### PR TITLE
Deduct Hidden Assets from Portolio Total and provide Total for Hidden Assets #1061

### DIFF
--- a/app/components/Account/AccountOverview.jsx
+++ b/app/components/Account/AccountOverview.jsx
@@ -526,12 +526,17 @@ class AccountOverview extends React.Component {
             hiddenBalances = hidden;
         }
 
-        let totalBalanceList = includedBalancesList.concat(hiddenBalancesList);
-
-        let portFolioValue =
+        let portfolioHiddenAssetsBalance =
             <TotalBalanceValue
                 noTip
-                balances={totalBalanceList}
+                balances={hiddenBalancesList}
+                hide_asset
+            />;
+
+        let portfolioActiveAssetsBalance =
+            <TotalBalanceValue
+                noTip
+                balances={includedBalancesList}
                 hide_asset
             />;
         let ordersValue =
@@ -573,7 +578,7 @@ class AccountOverview extends React.Component {
             ]}
         />;
 
-        includedBalances.push(<tr key="portfolio" className="total-value"><td style={{textAlign: "left"}}>{totalValueText}</td><td></td><td className="column-hide-small"></td><td></td><td className="column-hide-small" style={{textAlign: "right"}}>{portFolioValue}</td><td colSpan="9"></td></tr>);
+        includedBalances.push(<tr key="portfolio" className="total-value"><td style={{textAlign: "left"}}>{totalValueText}</td><td></td><td className="column-hide-small"></td><td></td><td className="column-hide-small" style={{textAlign: "right"}}>{portfolioActiveAssetsBalance}</td><td colSpan="9"></td></tr>);
 
         let showAssetPercent = settings.get("showAssetPercent", false);
 
@@ -600,7 +605,7 @@ class AccountOverview extends React.Component {
                     <div className="tabs-container generic-bordered-box">
                         <Tabs defaultActiveTab={0} segmented={false} setting="overviewTab" className="account-tabs" tabsClass="account-overview no-padding bordered-header content-block">
 
-                            <Tab title="account.portfolio" subText={portFolioValue}>
+                            <Tab title="account.portfolio" subText={portfolioActiveAssetsBalance}>
                                 <div className="hide-selector">
                                     <div className={cnames("inline-block", {inactive: showHidden && hiddenBalances.length})} onClick={showHidden ? this._toggleHiddenAssets.bind(this) : () => {}}>
                                         <h4><Translate content="account.hide_hidden" /></h4>

--- a/app/components/Account/AccountOverview.jsx
+++ b/app/components/Account/AccountOverview.jsx
@@ -580,6 +580,8 @@ class AccountOverview extends React.Component {
 
         includedBalances.push(<tr key="portfolio" className="total-value"><td style={{textAlign: "left"}}>{totalValueText}</td><td></td><td className="column-hide-small"></td><td></td><td className="column-hide-small" style={{textAlign: "right"}}>{portfolioActiveAssetsBalance}</td><td colSpan="9"></td></tr>);
 
+        hiddenBalances.push(<tr key="portfolio" className="total-value"><td style={{textAlign: "left"}}>{totalValueText}</td><td></td><td className="column-hide-small"></td><td></td><td className="column-hide-small" style={{textAlign: "right"}}>{portfolioHiddenAssetsBalance}</td><td colSpan="9"></td></tr>);
+
         let showAssetPercent = settings.get("showAssetPercent", false);
 
         // Find the current Openledger coins


### PR DESCRIPTION
**Changes:**
- Update total balance of Portfolio. Now it displays only Active Assets Total Value (Hidden assets excluded)
- Add `Total` for `Hidden` assets like on `Active` tab.

**Tested on MacOS on all media queries:**

- [x] Opera
- [ ] Safari (Wasn't able to test because I cannot login under my wallet-account #1125)
- [x] Chrome
- [x] Firefox

(Beginning from 900px and lower `Total BTS` column excluded from the table and I didn't change it. So Total Value of hidden assets visible only if screen size is bigger than 900px ) 

![ezgif com-optimize](https://user-images.githubusercontent.com/35899973/35920286-c7f4a842-0c17-11e8-8dca-9efcde66eac1.gif)
