### PR TITLE
Display Accounts ID on Accounts Page #1091

### DIFF
--- a/app/components/Dashboard/DashboardAccountsOnly.jsx
+++ b/app/components/Dashboard/DashboardAccountsOnly.jsx
@@ -148,6 +148,7 @@ class Accounts extends React.Component {
                                 <div className="box-content">
                                     <DashboardList
                                         accounts={Immutable.List(names)}
+                                        passwordAccount={passwordAccount}
                                         ignoredAccounts={Immutable.List(ignored)}
                                         width={width}
                                         onToggleIgnored={this._onToggleIgnored.bind(this)}

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -77,6 +77,7 @@ class DashboardList extends React.Component {
 			nextProps.showIgnored !== this.props.showIgnored ||
 			nextProps.locked !== this.props.locked ||
 			nextProps.linkedAccounts !== this.props.linkedAccounts ||
+			nextProps.passwordAccount !== this.props.passwordAccount ||
 			!utils.are_equal_shallow(nextProps.starredAccounts, this.props.starredAccounts) ||
 			!utils.are_equal_shallow(nextState, this.state )
 		);
@@ -131,7 +132,7 @@ class DashboardList extends React.Component {
 
 	_renderList(accounts) {
 
-		const {width, starredAccounts, showMyAccounts} = this.props;
+		const {width, starredAccounts, showMyAccounts, passwordAccount} = this.props;
 		const {dashboardFilter, sortBy, inverseSort} = this.state;
 		let balanceList = Immutable.List();
 
@@ -209,7 +210,7 @@ class DashboardList extends React.Component {
 					});
 				}
 
-				let isMyAccount = AccountStore.isMyAccount(account);
+				let isMyAccount = AccountStore.isMyAccount(account) || accountName === passwordAccount;
 
 				let isStarred = starredAccounts.has(accountName);
 				let starClass = isStarred ? "gold-star" : "grey-star";

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -229,6 +229,9 @@ class DashboardList extends React.Component {
 								<Icon name="minus-circle"/>
 							</td>
 						: null}
+						<td style={{textAlign: "left"}}>
+							{ account.get("id") }
+						</td>
 						<td style={{textAlign: "left", paddingLeft: 10}} onClick={this._goAccount.bind(this, accountName, 0)} className={"clickable" + (isMyAccount ? " my-account" : "")}>
 							<span className={isLTM ? "lifetime" : ""}>{accountName}</span>
 						</td>
@@ -282,6 +285,7 @@ class DashboardList extends React.Component {
 						<tr>
 							<th onClick={this._setSort.bind(this, "star")} className="clickable"><Icon className="grey-star" name="fi-star"/></th>
 							{!showMyAccounts ? <th><Icon name="user"/></th> : null}
+							<th style={{textAlign: "left"}}>ID</th>
 							<th style={{textAlign: "left", paddingLeft: 10}} onClick={this._setSort.bind(this, "name")} className="clickable"><Translate content="header.account" /></th>
 							<th style={{textAlign: "right"}}><Translate content="account.open_orders" /></th>
 							{width >= 750 ? <th style={{textAlign: "right"}}><Translate content="account.as_collateral" /></th> : null}


### PR DESCRIPTION
**Changes**
- Provide ID for Contacts/Accounts tables on `/accounts` page
- Fix check for isMyAccount (it was wrong for login/password accounts so I've added the following check: 
```
let isMyAccount = AccountStore.isMyAccount(account) || accountName === passwordAccount; // password account from AccountStore.getState().passwordAccount
```

@svk31 Please take a look at this fix. I suppose it's fine. I've found this check on another sides of our project. If it's wrong please help me to understand why and what is the right way to check `isMyAccount` for login/password accounts. Because for now `AccountStore.isMyAccount` works only for Wallet accounts.   

The last change fix this: (You see your own account in Contacts expect seeing on Accounts tab)
<img width="1440" alt="screenshot 2018-02-07 18 27 29" src="https://user-images.githubusercontent.com/35899973/35931603-5d6793ae-0c35-11e8-8bee-61b8305df577.png">

To this:

<img width="1440" alt="screenshot 2018-02-07 18 27 24" src="https://user-images.githubusercontent.com/35899973/35931623-6b74e1ae-0c35-11e8-8d92-1015879b8b37.png">

**Tested on MacOS**

- [x] Chrome
- [x] Opera
- [ ] Safari
- [x] Firefox
