### PR TITLE
Responsive on boarding for #1082

### DIFF
--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -192,6 +192,12 @@ table > tbody > tr.control-row > td {
   border-radius: 0px;
 }
 
+@media screen and (max-width: 640px) {
+  .modal {
+    background: #2a2a2a!important;
+  }
+}
+
 div.modal {
   overflow: visible !important;
 }

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -357,3 +357,8 @@ a.button span {
 .market-button {
   margin: 1rem 0;
 }
+
+input[type=text].input-button {
+  border-top-right-radius: 0!important;
+  border-bottom-right-radius: 0!important;
+}

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -20,7 +20,7 @@
         border-bottom: none;
     }
   padding-left: 0 !important;
-  min-height: 64px;
+  // min-height: 64px;
   // text-transform: uppercase;
   .menu-bar > li {
 
@@ -41,7 +41,7 @@
   }
 
   div.account-drop-down div.total-value {
-      text-align: left;
+      text-align: right;
       font-size: 80%;
       line-height: initial;
   }
@@ -193,4 +193,26 @@ ul.dropdown.header-menu {
             }
         }
     }
+}
+
+.account-summary {
+  text-align: right;
+  line-height: initial;
+  display: inline-block;
+
+  .icon {
+    margin-right: 5px;
+  }
+
+  svg path {
+    fill: #fff;
+  }
+}
+
+.account-name .icon {
+  margin-right: 5px;
+}
+
+.active-account {
+  padding-right: 20px;
 }

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -347,7 +347,7 @@ $pulsate-red-end
         div.dropdown-wrapper {
             > li {
                 div.hamburger > .icon > svg rect {
-                    fill: $account-dimmed;
+                    fill: $bs-blue;
                 }
             }
             &:hover {
@@ -431,7 +431,7 @@ $pulsate-red-end
             }
             > span { @include RobotoMedium; }
         }
-        svg > path { fill: $secondary-text-color; }
+        svg > path { fill: #fff; }
         // svg:hover > path { fill: $primary-text-color; }
     }
 
@@ -1710,4 +1710,92 @@ $pulsate-red-end
 }
 .market-filter-input:not(:valid) ~ .clear-text {
     display: none;
+}
+
+.header-container {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    height: 64px;
+    background-color: #3f3f3f;
+
+    .menu-bar {
+        overflow: visible;
+    }
+
+    .logo {
+        padding-top: .7rem;
+        padding-bottom: .8rem;
+    }
+
+    .dropdown-wrapper:after {
+        display: none;
+    }
+
+    .menu-dropdown-wrapper {
+        height: 65px;
+        width: 65px;
+        text-align: center;
+        border-radius: 0;
+
+        &.active {
+            background: #2a2a2a;
+        }
+
+        .hamburger .icon {
+            position: relative;
+            top: 12px;
+        }
+    }
+
+    .dropdown.header-menu {
+        top: 65px;
+        background-color: #2a2a2a!important;
+
+        li.divider {
+            border-bottom: 1px solid #323131!important;
+        }
+
+        > li:hover {
+            background-color: #6a6a6a;
+        }
+    }
+
+    .hamburger svg rect, .hamburger-x svg rect {
+        fill: $bs-blue;
+    }
+
+    .total-value {
+        color: #7ed321;
+        text-align: right;
+        font-size: 80%;
+        line-height: normal;
+    }
+}
+
+.local-wallet-menu {
+    // top: 50px!important;
+
+    .table-cell {
+        display: inline-block;
+    }
+}
+
+.app-menu {
+  flex: 0;
+}
+
+.truncated {
+  flex: 1;
+  min-width: 0; /* or some value */
+  .text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: right;
+  }
+}
+
+#unlock_wallet_modal2 .close-button {
+    color: $bs-blue;
 }

--- a/app/components/Account/CreateAccountPassword.jsx
+++ b/app/components/Account/CreateAccountPassword.jsx
@@ -206,11 +206,11 @@ class CreateAccountPassword extends React.Component {
                         noLabel
                     />
 
-                <section>
+                <section className="form-group">
                     <label className="left-label"><Translate content="wallet.generated" />&nbsp;&nbsp;<span className="tooltip" data-html={true} data-tip={counterpart.translate("tooltip.generate")}><Icon name="question-circle" /></span></label>
                     <div style={{paddingBottom: "0.5rem"}}>
                         <span className="inline-label">
-                            <input style={{maxWidth: "calc(30rem - 48px)", fontSize: "80%"}} disabled value={this.state.generatedPassword} type="text"/>
+                            <input style={{maxWidth: "calc(30rem - 48px)", fontSize: "80%"}} disabled value={this.state.generatedPassword} type="text" className="input-button"/>
                             <CopyButton
                                 text={this.state.generatedPassword}
                                 tip="tooltip.copy_password"

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -802,7 +802,7 @@ class Asset extends React.Component {
             <div className="grid-container">
                 <div className="grid-block page-layout">
                     <div className="grid-block main-content wrap regular-padding">
-                        <div className="grid-block small-up-1">
+                        <div className="grid-block small-up-1" style={{width:"100%"}}>
                             {this.renderAboutBox(asset)}
                         </div>
                         <div className="grid-block small-up-1 medium-up-2">

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -290,8 +290,7 @@ class Header extends React.Component {
 
         let dashboard = (
             <a
-                style={{padding: "12px 1.75rem"}}
-                className={cnames({active: active === "/" || (active.indexOf("dashboard") !== -1 && active.indexOf("account") === -1)})}
+                className={cnames("logo", {active: active === "/" || (active.indexOf("dashboard") !== -1 && active.indexOf("account") === -1)})}
                 onClick={this._onNavigate.bind(this, "/dashboard")}
             >
                 <img style={{margin: 0, height: 40}} src={logo} />
@@ -346,214 +345,203 @@ class Header extends React.Component {
 
         const hasLocalWallet = !!WalletDb.getWallet();
         return (
-            <div className="header menu-group primary">
-                {/*<div className="show-for-small-only">
-                    <ul className="primary menu-bar title">
-                        <li><a href onClick={this._triggerMenu}><Icon className="icon-32px" name="menu"/></a></li>
-                    </ul>
-                </div>*/}
-                {__ELECTRON__ ? <div className="grid-block show-for-medium shrink electron-navigation">
-                    <ul className="menu-bar">
-                        <li>
-                            <div style={{marginLeft: "1rem", height: "3rem"}}>
-                                <div style={{marginTop: "0.5rem"}} onClick={this._onGoBack.bind(this)} className="button outline small">{"<"}</div>
-                            </div>
-                    </li>
-                        <li>
-                            <div style={{height: "3rem", marginLeft: "0.5rem", marginRight: "0.75rem"}}>
-                                <div style={{marginTop: "0.5rem"}} onClick={this._onGoForward.bind(this)} className="button outline small">></div>
-                            </div>
-                        </li>
-                    </ul>
-                </div> : null}
-                <div className="grid-block">
-                    <ul className="menu-bar">
-                        <li>{dashboard}</li>
-                        {!currentAccount || !!createAccountLink ? null :
-                        <li>
-                            <Link style={{flexFlow: "row"}} to={`/account/${currentAccount}`} className={cnames({active: active.indexOf("account/") !== -1 && active.indexOf("/account/") !== -1})}>
-                                <Icon size="1_5x" style={{position: "relative", top: -2, left: -8}} name="dashboard"/>
-                                <Translate className="column-hide-small" content="header.dashboard" />
-                            </Link>
-                        </li>}
-                        <li className="column-hide-small">{tradeLink}</li>
-                        {/* {currentAccount || myAccounts.length ? <li><a className={cnames({active: active.indexOf("transfer") !== -1})} onClick={this._onNavigate.bind(this, "/transfer")}><Translate component="span" content="header.payments" /></a></li> : null} */}
-                        <li className="column-hide-small">
-                            <a style={{flexFlow: "row"}} className={cnames({active: active.indexOf("explorer") !== -1})} onClick={this._onNavigate.bind(this, "/explorer/blocks")}>
-                                <Icon size="2x" style={{position: "relative", top: 0, left: -8}} name="server"/>
-                                <Translate component="span" content="header.explorer" />
-                            </a>
-                        </li>
-                        {!!createAccountLink ? null : <li className="column-hide-small">
-                            <a style={{flexFlow: "row"}} onClick={this._showSend.bind(this)}>
-                                <Icon size="1_5x" style={{position: "relative", top: 0, left: -8}} name="transfer"/>
-                                <span><Translate content="header.payments" /></span>
-                            </a>
-                        </li>}
-
-                        {!!createAccountLink ? <li>
-                            <a style={{flexFlow: "row"}} className={cnames({active: active.indexOf("settings") !== -1})} onClick={this._onNavigate.bind(this, "/settings")}>
-                                <Icon size="2x" style={{position: "relative", top: 0, left: -8}} name="cogs"/>
-                                <span className="column-hide-tiny"><Translate content="header.settings" /></span>
-                            </a>
-                        </li> : null}
-                        {/* {enableDepositWithdraw && currentAccount && myAccounts.indexOf(currentAccount) !== -1 ? <li><Link to={"/deposit-withdraw/"} activeClassName="active"><Translate content="account.deposit_withdraw"/></Link></li> : null} */}
-                    </ul>
-                </div>
-                <div className="grid-block shrink">
-                    <div className="grp-menu-items-group header-right-menu">
-
-                        <div className="grp-menu-item overflow-visible account-drop-down">
-                                {createAccountLink ? createAccountLink : [
-                                <div key="padlock" style={{paddingBottom: 15}} className="header-right-lock show-for-medium" onClick={this._toggleLock.bind(this)}>
-                                    <Icon className="lock-unlock" style={{margin: "0 0.5rem"}} size="2x" name={this.props.locked ? "locked" : "unlocked"} />
-                                </div>,
-                                <div key="account-dropdown" className={cnames("account-dropdown-wrapper dropdown-wrapper", {active: this.state.accountsListDropdownActive, "hover-transparent": !hasLocalWallet, "cursor-default": !hasLocalWallet})}>
-                                    <li style={{display: "flex"}}>
-                                        <div onClick={this._toggleAccountDropdownMenu} className="table-cell" style={{flex: 1}}>
-                                            <div style={{lineHeight: "initial", display: "inline-block", paddingRight: 20}}>
-                                                <span>{currentAccount}</span>
-                                                {walletBalance}
-                                            </div>
-
-                                        </div>
-                                    </li>
-
-                                    { hasLocalWallet && (
-
-                                        <ul className="dropdown header-menu" style={{left: 0, top: 64, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
-
-                                            <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
-                                                <div className="table-cell"><Icon size="2x" name="folder" /></div>
-                                                <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
-                                            </li>
-
-                                            {accountsList}
-                                        </ul>
-
-                                    )}
-                                </div>,
-                                <div key="dropdown" className={cnames("menu-dropdown-wrapper dropdown-wrapper", {active: this.state.dropdownActive})}>
-                                    <li style={{display: "flex"}}>
-                                        <div onClick={this._toggleDropdownMenu} className="table-cell" style={{flex: 1}}>
-                                            <div>
-                                                <div className="hamburger">{hamburger}</div>
-                                            </div>
-                                        </div>
-                                    </li>
-                                    <ul className="dropdown header-menu" style={{left: -200, top: 64, maxHeight: !this.state.dropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
-                                        <li className="divider" onClick={this._toggleLock.bind(this)}>
-                                            <div className="table-cell"><Icon size="2x" name="power" /></div>
-                                            <div className="table-cell"><Translate content={`header.${this.props.locked ? "unlock_short" : "lock_short"}`} /></div>
-                                        </li>
-
-                                        {!isMyAccount ? <li className="divider" onClick={this[isContact ? "_onUnLinkAccount" : "_onLinkAccount"].bind(this)}>
-                                            <div className="table-cell"><Icon size="2x" name={`${isContact ? "minus" : "plus"}-circle`} /></div>
-                                            <div className="table-cell"><Translate content={`account.${isContact ? "unfollow" : "follow"}`} /></div>
-                                        </li> : null}
-
-                                        <li className={cnames({active: active.indexOf("/market/") !== -1}, "column-show-small")} onClick={this._onNavigate.bind(this, tradeUrl)}>
-                                            <div className="table-cell"><Icon size="2x" name="trade" /></div>
-                                            <div className="table-cell"><Translate content="header.exchange" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/explorer") !== -1}, "column-show-small")} onClick={this._onNavigate.bind(this, "/explorer/blocks")}>
-                                            <div className="table-cell"><Icon size="2x" name="server" /></div>
-                                            <div className="table-cell"><Translate content="header.explorer" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/transfer") !== -1}, {disabled: !isMyAccount})} onClick={!isMyAccount ? () => {} : this._onNavigate.bind(this, "/transfer")}>
-                                            <div className="table-cell"><Icon size="2x" name="transfer" /></div>
-                                            <div className="table-cell"><Translate content="header.payments_legacy" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/deposit-withdraw") !== -1}, {disabled: !enableDepositWithdraw})} onClick={!enableDepositWithdraw ? () => {} : this._onNavigate.bind(this, "/deposit-withdraw")}>
-                                            <div className="table-cell"><Icon size="2x" name="deposit" /></div>
-                                            <div className="table-cell"><Translate content="gateway.deposit" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/deposit-withdraw") !== -1}, {disabled: !enableDepositWithdraw})} onClick={!enableDepositWithdraw ? () => {} : this._showDeposit.bind(this)}>
-                                            <div className="table-cell"><Icon size="2x" name="deposit" /></div>
-                                            <div className="table-cell"><Translate content="modal.deposit.submit_beta" /></div>
-                                        </li>
-
-                                        <li className={cnames("divider", {active: active.indexOf("/deposit-withdraw") !== -1}, {disabled: !enableDepositWithdraw})} onClick={!enableDepositWithdraw ? () => {} : this._onNavigate.bind(this, "/deposit-withdraw")}>
-                                            <div className="table-cell"><Icon size="2x" name="withdraw" /></div>
-                                            <div className="table-cell"><Translate content="modal.withdraw.submit" /></div>
-                                        </li>
 
 
-                                        <li className={cnames({active: active.indexOf("/settings") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/settings")}>
-                                            <div className="table-cell"><Icon size="2x" name="cogs" /></div>
-                                            <div className="table-cell"><Translate content="header.settings" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/news") !== -1})} onClick={this._onNavigate.bind(this, "/news")}>
-                                            <div className="table-cell"><Icon size="2x" name="news" /></div>
-                                            <div className="table-cell"><Translate content="news.news" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/help/introduction/bitshares") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/help/introduction/bitshares")}>
-                                            <div className="table-cell"><Icon size="2x" name="question-circle" /></div>
-                                            <div className="table-cell"><Translate content="header.help" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/voting") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/voting`)}>
-                                            <div className="table-cell"><Icon size="2x" name="thumbs-up" /></div>
-                                            <div className="table-cell"><Translate content="account.voting" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/assets") !== -1 && active.indexOf("/account/") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/assets`)}>
-                                            <div className="table-cell"><Icon size="2x" name="assets" /></div>
-                                            <div className="table-cell"><Translate content="explorer.assets.title" /></div>
-                                        </li>
-                                        <li className={cnames({active: active.indexOf("/signedmessages") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/signedmessages`)}>
-                                            <div className="table-cell"><Icon size="2x" name="text" /></div>
-                                            <div className="table-cell"><Translate content="account.signedmessages.menuitem" /></div>
-                                        </li>
-
-                                        <li className={cnames({active: active.indexOf("/member-stats") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/member-stats`)}>
-                                            <div className="table-cell"><Icon size="2x" name="text" /></div>
-                                            <div className="table-cell"><Translate content="account.member.stats" /></div>
-                                        </li>
-
-                                        {isMyAccount ? <li className={cnames({active: active.indexOf("/vesting") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/vesting`)}>
-                                            <div className="table-cell"><Icon size="2x" name="hourglass" /></div>
-                                            <div className="table-cell"><Translate content="account.vesting.title" /></div>
-                                        </li> : null}
-
-                                        <li className={cnames({active: active.indexOf("/whitelist") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/whitelist`)}>
-                                            <div className="table-cell"><Icon size="2x" name="list" /></div>
-                                            <div className="table-cell"><Translate content="account.whitelist.title" /></div>
-                                        </li>
-
-                                        <li className={cnames("divider", {active: active.indexOf("/permissions") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/permissions`)}>
-                                            <div className="table-cell"><Icon size="2x" name="warning" /></div>
-                                            <div className="table-cell"><Translate content="account.permissions" /></div>
-                                        </li>
-
-                                        { !hasLocalWallet && (
-                                            <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
-                                                <div className="table-cell"><Icon size="2x" name="folder" /></div>
-                                                <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
-                                            </li>
-                                        )}
-                                    </ul>
-                                </div>]
-                            }
+<div className="header-container" style={{minHeight:"64px"}}>
+    <div>
+        <div className="header menu-group primary" style={{flexWrap:"nowrap", justifyContent:"none"}}>
+            {__ELECTRON__ ? <div className="grid-block show-for-medium shrink electron-navigation">
+                <ul className="menu-bar">
+                    <li>
+                        <div style={{marginLeft: "1rem", height: "3rem"}}>
+                            <div style={{marginTop: "0.5rem"}} onClick={this._onGoBack.bind(this)} className="button outline small">{"<"}</div>
                         </div>
-                    </div>
-                </div>
-                {/* Send modal */}
-                <SendModal id="send_modal_header" ref="send_modal" from_name={currentAccount} />
-                {/* Deposit modal */}
-                <DepositModal
-                    ref="deposit_modal_new"
-                    modalId="deposit_modal_new"
-                    account={currentAccount}
-                    backedCoins={this.props.backedCoins}
-                />
-            </div>
+                    </li>
+                    <li>
+                        <div style={{height: "3rem", marginLeft: "0.5rem", marginRight: "0.75rem"}}>
+                            <div style={{marginTop: "0.5rem"}} onClick={this._onGoForward.bind(this)} className="button outline small">></div>
+                        </div>
+                    </li>
+                </ul>
+            </div> : null}
+
+            <ul className="menu-bar">
+                <li>{dashboard}</li>
+                {!currentAccount || !!createAccountLink ? null :
+                <li>
+                    <Link style={{flexFlow: "row"}} to={`/account/${currentAccount}`} className={cnames({active: active.indexOf("account/") !== -1 && active.indexOf("/account/") !== -1}) + " column-hide-small"}>
+                        <Icon size="1_5x" style={{position: "relative", top: -2, left: -8}} name="dashboard"/>
+                        <Translate content="header.dashboard" />
+                    </Link>
+                </li>}
+                <li className="column-hide-small">{tradeLink}</li>
+                <li className="column-hide-small">
+                    <a style={{flexFlow: "row"}} className={cnames({active: active.indexOf("explorer") !== -1})} onClick={this._onNavigate.bind(this, "/explorer/blocks")}>
+                        <Icon size="2x" style={{position: "relative", top: 0, left: -8}} name="server"/>
+                        <Translate component="span" content="header.explorer" />
+                    </a>
+                </li>
+                {!!createAccountLink ? null : <li className="column-hide-small">
+                    <a style={{flexFlow: "row"}} onClick={this._showSend.bind(this)}>
+                        <Icon size="1_5x" style={{position: "relative", top: 0, left: -8}} name="transfer"/>
+                        <span><Translate content="header.payments" /></span>
+                    </a>
+                </li>}
+            </ul>
+
+            <SendModal id="send_modal_header"
+                ref="send_modal"
+                from_name={currentAccount} />
+
+            <DepositModal
+                ref="deposit_modal_new"
+                modalId="deposit_modal_new"
+                account={currentAccount}
+                backedCoins={this.props.backedCoins} />
+        </div>
+    </div>
+
+    <div onClick={this._toggleAccountDropdownMenu} className="truncated active-account">
+        <div className="text account-name">
+            { this.props.currentAccount == null ? null :
+                <span>
+                    {this.props.locked ? <Icon className="icon-14px" name="locked"/> : <Icon className="icon-14px" name="unlocked"/>}
+                </span>
+            }
+            {currentAccount}
+        </div>
+        {walletBalance}
+
+        {hasLocalWallet && (
+            <ul className="dropdown header-menu local-wallet-menu" style={{right: 0, maxHeight: !this.state.accountsListDropdownActive ? 0 : maxHeight, overflowY: "auto", position:"absolute",width:"200px"}}>
+                <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
+                    <div className="table-cell"><Icon size="2x" name="folder" /></div>
+                    <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
+                </li>
+                {accountsList}
+            </ul>
+        )}
+    </div>
+
+    <div className="app-menu">
+        <div key="dropdown" className={cnames("menu-dropdown-wrapper dropdown-wrapper", {active: this.state.dropdownActive})} onClick={this._toggleDropdownMenu}>
+            <div className="hamburger">{hamburger}</div>
+            <ul className="dropdown header-menu" style={{left: -200, top: 64, maxHeight: !this.state.dropdownActive ? 0 : maxHeight, overflowY: "auto"}}>
+                <li className="divider" onClick={this._toggleLock.bind(this)}>
+                    <div className="table-cell"><Icon size="2x" name="power" /></div>
+                    <div className="table-cell"><Translate content={`header.${this.props.locked ? "unlock_short" : "lock_short"}`} /></div>
+                </li>
+
+                {this.props.locked ? [
+                    <li className={cnames({active: active.indexOf("/create-account/password") !== -1})} onClick={this._onNavigate.bind(this, "/create-account/password")}>
+                        <div className="table-cell"><Icon size="2x" name="user" /></div>
+                        <div className="table-cell"><Translate content="header.create_account" /></div>
+                    </li>
+                ] : null}
+
+                {!this.props.locked ? [
+                    <li className={cnames({active: active.indexOf("/account") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}`)}>
+                        <div className="table-cell"><Icon size="2x" name="dashboard" /></div>
+                        <div className="table-cell"><Translate content="header.dashboard" /></div>
+                    </li>
+                ] : null}
+
+                {!isMyAccount ? <li className="divider" onClick={this[isContact ? "_onUnLinkAccount" : "_onLinkAccount"].bind(this)}>
+                    <div className="table-cell"><Icon size="2x" name={`${isContact ? "minus" : "plus"}-circle`} /></div>
+                    <div className="table-cell"><Translate content={`account.${isContact ? "unfollow" : "follow"}`} /></div>
+                </li> : null}
+
+                <li className={cnames({active: active.indexOf("/market/") !== -1}, "column-show-small")} onClick={this._onNavigate.bind(this, tradeUrl)}>
+                    <div className="table-cell"><Icon size="2x" name="trade" /></div>
+                    <div className="table-cell"><Translate content="header.exchange" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/explorer") !== -1}, "column-show-small")} onClick={this._onNavigate.bind(this, "/explorer/blocks")}>
+                    <div className="table-cell"><Icon size="2x" name="server" /></div>
+                    <div className="table-cell"><Translate content="header.explorer" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/transfer") !== -1}, {disabled: !isMyAccount})} onClick={!isMyAccount ? () => {} : this._onNavigate.bind(this, "/transfer")}>
+                    <div className="table-cell"><Icon size="2x" name="transfer" /></div>
+                    <div className="table-cell"><Translate content="header.payments_legacy" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/deposit-withdraw") !== -1}, {disabled: !enableDepositWithdraw})} onClick={!enableDepositWithdraw ? () => {} : this._onNavigate.bind(this, "/deposit-withdraw")}>
+                    <div className="table-cell"><Icon size="2x" name="deposit" /></div>
+                    <div className="table-cell"><Translate content="gateway.deposit" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/deposit-withdraw") !== -1}, {disabled: !enableDepositWithdraw})} onClick={!enableDepositWithdraw ? () => {} : this._showDeposit.bind(this)}>
+                    <div className="table-cell"><Icon size="2x" name="deposit" /></div>
+                    <div className="table-cell"><Translate content="modal.deposit.submit_beta" /></div>
+                </li>
+
+                <li className={cnames("divider", {active: active.indexOf("/deposit-withdraw") !== -1}, {disabled: !enableDepositWithdraw})} onClick={!enableDepositWithdraw ? () => {} : this._onNavigate.bind(this, "/deposit-withdraw")}>
+                    <div className="table-cell"><Icon size="2x" name="withdraw" /></div>
+                    <div className="table-cell"><Translate content="modal.withdraw.submit" /></div>
+                </li>
+
+
+                <li className={cnames({active: active.indexOf("/settings") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/settings")}>
+                    <div className="table-cell"><Icon size="2x" name="cogs" /></div>
+                    <div className="table-cell"><Translate content="header.settings" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/news") !== -1})} onClick={this._onNavigate.bind(this, "/news")}>
+                    <div className="table-cell"><Icon size="2x" name="news" /></div>
+                    <div className="table-cell"><Translate content="news.news" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/help/introduction/bitshares") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/help/introduction/bitshares")}>
+                    <div className="table-cell"><Icon size="2x" name="question-circle" /></div>
+                    <div className="table-cell"><Translate content="header.help" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/voting") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/voting`)}>
+                    <div className="table-cell"><Icon size="2x" name="thumbs-up" /></div>
+                    <div className="table-cell"><Translate content="account.voting" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/assets") !== -1 && active.indexOf("/account/") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/assets`)}>
+                    <div className="table-cell"><Icon size="2x" name="assets" /></div>
+                    <div className="table-cell"><Translate content="explorer.assets.title" /></div>
+                </li>
+                <li className={cnames({active: active.indexOf("/signedmessages") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/signedmessages`)}>
+                    <div className="table-cell"><Icon size="2x" name="text" /></div>
+                    <div className="table-cell"><Translate content="account.signedmessages.menuitem" /></div>
+                </li>
+
+                <li className={cnames({active: active.indexOf("/member-stats") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/member-stats`)}>
+                    <div className="table-cell"><Icon size="2x" name="text" /></div>
+                    <div className="table-cell"><Translate content="account.member.stats" /></div>
+                </li>
+
+                {isMyAccount ? <li className={cnames({active: active.indexOf("/vesting") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/vesting`)}>
+                    <div className="table-cell"><Icon size="2x" name="hourglass" /></div>
+                    <div className="table-cell"><Translate content="account.vesting.title" /></div>
+                </li> : null}
+
+                <li className={cnames({active: active.indexOf("/whitelist") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/whitelist`)}>
+                    <div className="table-cell"><Icon size="2x" name="list" /></div>
+                    <div className="table-cell"><Translate content="account.whitelist.title" /></div>
+                </li>
+
+                <li className={cnames("divider", {active: active.indexOf("/permissions") !== -1})} onClick={this._onNavigate.bind(this, `/account/${currentAccount}/permissions`)}>
+                    <div className="table-cell"><Icon size="2x" name="warning" /></div>
+                    <div className="table-cell"><Translate content="account.permissions" /></div>
+                </li>
+
+                { !hasLocalWallet && (
+                    <li className={cnames({active: active.indexOf("/accounts") !== -1}, "divider")} onClick={this._onNavigate.bind(this, "/accounts")}>
+                        <div className="table-cell"><Icon size="2x" name="folder" /></div>
+                        <div className="table-cell"><Translate content="explorer.accounts.title" /></div>
+                    </li>
+                )}
+            </ul>
+        </div>
+    </div>
+</div>
+
 
         );
 

--- a/app/components/Wallet/WalletManager.jsx
+++ b/app/components/Wallet/WalletManager.jsx
@@ -63,7 +63,7 @@ class WalletManager extends Component {
         return (
             <div className="grid-block vertical">
                 <div className="grid-container" style={{maxWidth: "40rem"}}>
-                    <div className="content-block center-content">
+                    <div className="content-block">
                         <div className="page-header">
                             <Translate component="h3" content={this.getTitle()} />
                         </div>


### PR DESCRIPTION
Related to #1082:

- Implemented updated UI styles
- Removed redundant 'create account'
- Burger menu displays all the time now
- Removed settings from the header bar because it is in the burger menu
- 'Create account' link shown in burger menu if the user is logged out
- 'Dashboard' link shown in burger menu if the user is logged in
- Removed the big lock/unlock icon
- Added a small lock/unlock icon next to username to tell if logged in or not
- Updated hamburger icon to bitshares blue
- Have added functionality to truncate the username when it's too long for the resolution
- Fixed #1090
- Aligned page title on 'restore backup' view to left
- Tested both login/password and local wallet accounts
