### PR TITLE
Browser notifications #686

### DIFF
--- a/app/App.jsx
+++ b/app/App.jsx
@@ -11,6 +11,7 @@ import { connect, supplyFluxContext } from "alt-react";
 import {IntlProvider} from "react-intl";
 import SyncError from "./components/SyncError";
 import LoadingIndicator from "./components/LoadingIndicator";
+import BrowserNotifications from "./components/BrowserNotifications/BrowserNotificationsContainer";
 import Header from "components/Layout/Header";
 // import MobileMenu from "components/Layout/MobileMenu";
 import ReactTooltip from "react-tooltip";
@@ -215,6 +216,7 @@ class App extends React.Component {
                         }}
                     />
                     <TransactionConfirm/>
+                    <BrowserNotifications/>
                     <WalletUnlockModal/>
                     <BrowserSupportModal ref="browser_modal"/>
                 </div>

--- a/app/assets/locales/locale-de.json
+++ b/app/assets/locales/locale-de.json
@@ -33,6 +33,10 @@
     "account_notify": "The active account is now %(account)s",
     "account_value": "Kontowert"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Übertragen von %(from)s",
+    "money_received_body": "Hat dich geschickt %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "This is the call price of the least collateralized margin position in the market.",
     "margin_price": "This is the maximum price that a margin called position can be made to pay. It also called the Squeeze Price.",

--- a/app/assets/locales/locale-de.json
+++ b/app/assets/locales/locale-de.json
@@ -690,6 +690,7 @@
   "settings": {
     "browser_notifications": "Browserbenachrichtigungen",
     "browser_notifications_allow": "Benachrichtigungen aktivieren",
+    "browser_notifications_additional_transfer_to_me": "Über Überweisungen an mein Konto benachrichtigen",
     "passwordLogin": "Login using the account model",
     "inverseMarket": "Bevorzugte Marktorientierung",
     "unit": "Bevorzugte Rechnungseinheit",

--- a/app/assets/locales/locale-de.json
+++ b/app/assets/locales/locale-de.json
@@ -684,6 +684,8 @@
     }
   },
   "settings": {
+    "browser_notifications": "Browserbenachrichtigungen",
+    "browser_notifications_allow": "Benachrichtigungen aktivieren",
     "passwordLogin": "Login using the account model",
     "inverseMarket": "Bevorzugte Marktorientierung",
     "unit": "Bevorzugte Rechnungseinheit",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -55,6 +55,10 @@
     "account_notify": "The active account is now %(account)s",
     "account_value": "Account value"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Transfer from %(from)s",
+    "money_received_body": "Sent you %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "This is the call price of the least collateralized margin position in the market.",
     "margin_price": "This is the maximum price that a margin called position can be made to pay. It is also called the Squeeze Price.",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -937,6 +937,7 @@
     "browser_notifications": "Browser Notifications",
     "browser_notifications_allow": "Enable notifications",
     "browser_notifications_additional_transfer_to_me": "Notify about transfers to my account",
+    "browser_notifications_disabled_by_browser_notify": "Your browser disabled notifications. Click to learn how enable browser notifications",
     "general": "General",
     "wallet": "Local Wallet",
     "accounts": "Accounts",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -936,6 +936,7 @@
     "reset": "Reset settings",
     "browser_notifications": "Browser Notifications",
     "browser_notifications_allow": "Enable notifications",
+    "browser_notifications_additional_transfer_to_me": "Notify about transfers to my account",
     "general": "General",
     "wallet": "Local Wallet",
     "accounts": "Accounts",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -930,6 +930,8 @@
     "midnightTheme": "Midnight",
     "olDarkTheme": "Openledger dark",
     "reset": "Reset settings",
+    "browser_notifications": "Browser Notifications",
+    "browser_notifications_allow": "Enable notifications",
     "general": "General",
     "wallet": "Local Wallet",
     "accounts": "Accounts",

--- a/app/assets/locales/locale-es.json
+++ b/app/assets/locales/locale-es.json
@@ -53,6 +53,10 @@
     "account_notify": "La cuenta activa es ahora %(account)s",
     "account_value": "Valor de la cuenta"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Transferido de %(from)s",
+    "money_received_body": "Enviado %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "Este es el precio de llamada (call price) de la posición en el mercado colateralizada a margen .",
     "margin_price": "Este es el precio máximo que una posición a margen puede pagar. Es tambien llamado precio Squeeze.",

--- a/app/assets/locales/locale-es.json
+++ b/app/assets/locales/locale-es.json
@@ -885,6 +885,8 @@
     }
   },
   "settings": {
+    "browser_notifications": "Notificaciones del navegador",
+    "browser_notifications_allow": "Permitir notificaciones",
     "passwordLogin": "Modo de acceso",
     "cloud_login": "Inicio de sesión en el Cloud Wallet",
     "local_wallet": "Acceso local a la billetera",

--- a/app/assets/locales/locale-es.json
+++ b/app/assets/locales/locale-es.json
@@ -891,6 +891,7 @@
   "settings": {
     "browser_notifications": "Notificaciones del navegador",
     "browser_notifications_allow": "Permitir notificaciones",
+    "browser_notifications_additional_transfer_to_me": "Notificar sobre transferencias a mi cuenta",
     "passwordLogin": "Modo de acceso",
     "cloud_login": "Inicio de sesión en el Cloud Wallet",
     "local_wallet": "Acceso local a la billetera",

--- a/app/assets/locales/locale-fr.json
+++ b/app/assets/locales/locale-fr.json
@@ -28,6 +28,10 @@
     "account_notify": "The active account is now %(account)s",
     "account_value": "Valeur de compte"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Transfert à partir de %(from)s",
+    "money_received_body": "Vous a envoyé %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "This is the call price of the least collateralized margin position in the market.",
     "margin_price": "This is the maximum price that a margin called position can be made to pay. It also called the Squeeze Price.",

--- a/app/assets/locales/locale-fr.json
+++ b/app/assets/locales/locale-fr.json
@@ -449,6 +449,7 @@
   "settings": {
     "browser_notifications": "Notifications de navigateurs",
     "browser_notifications_allow": "Activer les notifications",
+    "browser_notifications_additional_transfer_to_me": "Notifier les transferts sur mon compte",
     "passwordLogin": "Login using the account model",
     "inverseMarket": "Orientation préféré pour les marchés",
     "unit": "Unité de valeur préféré",

--- a/app/assets/locales/locale-fr.json
+++ b/app/assets/locales/locale-fr.json
@@ -443,6 +443,8 @@
     }
   },
   "settings": {
+    "browser_notifications": "Notifications de navigateurs",
+    "browser_notifications_allow": "Activer les notifications",
     "passwordLogin": "Login using the account model",
     "inverseMarket": "Orientation préféré pour les marchés",
     "unit": "Unité de valeur préféré",

--- a/app/assets/locales/locale-it.json
+++ b/app/assets/locales/locale-it.json
@@ -838,6 +838,8 @@
     }
   },
   "settings": {
+    "browser_notifications": "Notifiche del browser",
+    "browser_notifications_allow": "Attivare le notifiche",
     "passwordLogin": "Fai il login usando il modalità account",
     "cloud_login": "Login Portafoglio Cloud",
     "local_wallet": "Login Portafoglio locale",

--- a/app/assets/locales/locale-it.json
+++ b/app/assets/locales/locale-it.json
@@ -844,6 +844,7 @@
   "settings": {
     "browser_notifications": "Notifiche del browser",
     "browser_notifications_allow": "Attivare le notifiche",
+    "browser_notifications_additional_transfer_to_me": "Notifica sui trasferimenti al mio account",
     "passwordLogin": "Fai il login usando il modalità account",
     "cloud_login": "Login Portafoglio Cloud",
     "local_wallet": "Login Portafoglio locale",

--- a/app/assets/locales/locale-it.json
+++ b/app/assets/locales/locale-it.json
@@ -42,6 +42,10 @@
     "account_notify": "L'account attivo è ora %(account)s",
     "account_value": "Valore dell'Account"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Trasferito da %(from)s",
+    "money_received_body": "Ti ho inviato %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "Questo è il prezzo di chiamata (call price) della posizione con margine nel mercato con la più bassa garanzia.",
     "margin_price": "Questo è il prezzo massimo che una posizione con margine può essere tenuta a pagare in caso di chiamata. È anche detto Squeeze Price.",

--- a/app/assets/locales/locale-ko.json
+++ b/app/assets/locales/locale-ko.json
@@ -572,6 +572,7 @@
   "settings": {
     "browser_notifications": "브라우저 알림",
     "browser_notifications_allow": "알림 사용",
+    "browser_notifications_additional_transfer_to_me": "내 계정으로의 이전 알림",
     "passwordLogin": "Login using the account model",
     "inverseMarket": "선호 거래쌍",
     "unit": "선호 화폐단위",

--- a/app/assets/locales/locale-ko.json
+++ b/app/assets/locales/locale-ko.json
@@ -32,6 +32,10 @@
     "account_notify": "The active account is now %(account)s",
     "account_value": "계정 값"
   },
+  "browser_notification_messages": {
+    "money_received_title": "에서 이전 %(from)s",
+    "money_received_body": "너 한테 보냈어 %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "This is the call price of the least collateralized margin position in the market.",
     "margin_price": "This is the maximum price that a margin called position can be made to pay. It also called the Squeeze Price.",

--- a/app/assets/locales/locale-ko.json
+++ b/app/assets/locales/locale-ko.json
@@ -566,6 +566,8 @@
     }
   },
   "settings": {
+    "browser_notifications": "브라우저 알림",
+    "browser_notifications_allow": "알림 사용",
     "passwordLogin": "Login using the account model",
     "inverseMarket": "선호 거래쌍",
     "unit": "선호 화폐단위",

--- a/app/assets/locales/locale-ru.json
+++ b/app/assets/locales/locale-ru.json
@@ -54,6 +54,10 @@
     "account_notify":"Активный аккаунт в настоящее время %(account)s",
     "account_value":"Оценка"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Перевод от %(from)s",
+    "money_received_body": "Отправлено Вам %(amount)s %(symbol)s"
+  },
   "tooltip":{
     "call_limit":"Это цена досрочного погашения наименее обеспеченной залогом позиции с гарантийным взносом на рынке.",
     "margin_price":"Это максимальная цена, которую может быть вынуждена заплатить позиция с затребованным дополнительным обеспечением. Также она называется Squeeze Price.",

--- a/app/assets/locales/locale-ru.json
+++ b/app/assets/locales/locale-ru.json
@@ -900,6 +900,7 @@
   "settings":{
     "browser_notifications": "Уведомления браузера",
     "browser_notifications_allow": "Включить уведомления",
+    "browser_notifications_additional_transfer_to_me": "Уведомлять о переводах на мой счет",
     "passwordLogin":"Режим входа",
     "cloud_login":"Вход в облачный кошелек (модель \"Аккаунт\")",
     "local_wallet":"Вход в локальный кошелек (модель \"Кошелек\")",

--- a/app/assets/locales/locale-ru.json
+++ b/app/assets/locales/locale-ru.json
@@ -894,6 +894,8 @@
     }
   },
   "settings":{
+    "browser_notifications": "Уведомления браузера",
+    "browser_notifications_allow": "Включить уведомления",
     "passwordLogin":"Режим входа",
     "cloud_login":"Вход в облачный кошелек (модель \"Аккаунт\")",
     "local_wallet":"Вход в локальный кошелек (модель \"Кошелек\")",

--- a/app/assets/locales/locale-tr.json
+++ b/app/assets/locales/locale-tr.json
@@ -783,6 +783,8 @@
     }
   },
   "settings": {
+    "browser_notifications": "Tarayıcı Bildirimleri",
+    "browser_notifications_allow": "Bildirimleri etkinleştir",
     "inverseMarket": "Piyasa eğilim tercihi",
     "unit": "Tercih edilen hesap birimi",
     "confirmMarketOrder": "Piyasa emirleri için teyit iste",

--- a/app/assets/locales/locale-tr.json
+++ b/app/assets/locales/locale-tr.json
@@ -789,6 +789,7 @@
   "settings": {
     "browser_notifications": "Tarayıcı Bildirimleri",
     "browser_notifications_allow": "Bildirimleri etkinleştir",
+    "browser_notifications_additional_transfer_to_me": "Hesabıma yapılan aktarmalar hakkında bilgi ver",
     "inverseMarket": "Piyasa eğilim tercihi",
     "unit": "Tercih edilen hesap birimi",
     "confirmMarketOrder": "Piyasa emirleri için teyit iste",

--- a/app/assets/locales/locale-tr.json
+++ b/app/assets/locales/locale-tr.json
@@ -33,6 +33,10 @@
     "account_notify": "Aktif hesap: %(account)s",
     "account_value": "Hesap değeri"
   },
+  "browser_notification_messages": {
+    "money_received_title": "Şuradan transfer %(from)s",
+    "money_received_body": "Seni gönderdi %(amount)s %(symbol)s"
+  },
   "tooltip": {
     "call_limit": "Piyasadaki en az teminatlı marjin pozisyonunun itfa fiyatı",
     "margin_price": "Teminat tamamlama çağrısı yapılmış pozisyonun ödemesi istenebilecek en yüksek değer",

--- a/app/assets/locales/locale-zh.json
+++ b/app/assets/locales/locale-zh.json
@@ -898,6 +898,7 @@
     "settings": {
         "browser_notifications": "瀏覽器通知",
         "browser_notifications_allow": "啟用通知",
+        "browser_notifications_additional_transfer_to_me": "通知我的帐户转账",
         "passwordLogin": "登录方式",
         "cloud_login": "账号模式",
         "local_wallet": "本地钱包模式",

--- a/app/assets/locales/locale-zh.json
+++ b/app/assets/locales/locale-zh.json
@@ -53,6 +53,10 @@
         "account_notify": "当前活跃账户为 %(account)s",
         "account_value": "账户价值"
     },
+    "browser_notification_messages": {
+        "money_received_title": "从转移 %(from)s",
+        "money_received_body": "发给你了 %(amount)s %(symbol)s"
+    },
     "tooltip": {
         "call_limit": "市场中抵押率最低的债仓的平仓价",
         "margin_price": "这是触发平仓的最大价格。也被称为挤压价格。",

--- a/app/assets/locales/locale-zh.json
+++ b/app/assets/locales/locale-zh.json
@@ -892,6 +892,8 @@
         }
     },
     "settings": {
+        "browser_notifications": "瀏覽器通知",
+        "browser_notifications_allow": "啟用通知",
         "passwordLogin": "登录方式",
         "cloud_login": "账号模式",
         "local_wallet": "本地钱包模式",

--- a/app/assets/stylesheets/components/_settings.scss
+++ b/app/assets/stylesheets/components/_settings.scss
@@ -15,6 +15,12 @@
     }
 }
 
+.settings--notifications {
+    input[type="checkbox"] {
+        cursor: pointer;
+    }
+}
+
 .nodes-header {
     text-transform: uppercase;
     font-size: 1rem;

--- a/app/assets/stylesheets/components/_settings.scss
+++ b/app/assets/stylesheets/components/_settings.scss
@@ -19,6 +19,17 @@
     input[type="checkbox"] {
         cursor: pointer;
     }
+    .settings--notifications--group {
+        margin: 15px 10px;
+        .settings--notifications--item {
+            label {
+                text-transform: none;
+            }
+        }
+    }
+    > .settings--notifications--group {
+        margin-left: 0;
+    }
 }
 
 .nodes-header {

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1455,6 +1455,16 @@ $main-content-margin-block-bg-color
         }
     }
 
+    .settings--notifications {
+        .settings--notifications--group {
+            .settings--notifications--item {
+                label {
+                    color: $settings-select-color;
+                }
+            }
+        }
+    }
+
     @media(max-width: $hamburger-submenu-display-endpoint) {
         .settings-menu {
             display: none;

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1463,6 +1463,10 @@ $main-content-margin-block-bg-color
                 }
             }
         }
+        .settings--notifications--no-browser-support {
+            color: $error-text-color;
+            font-size: 12px;
+        }
     }
 
     @media(max-width: $hamburger-submenu-display-endpoint) {

--- a/app/components/BrowserNotifications/BrowserNotifications.jsx
+++ b/app/components/BrowserNotifications/BrowserNotifications.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ChainTypes from "../Utility/ChainTypes";
 import BindToChainState from "../Utility/BindToChainState";
 import {ChainTypes as GraphChainTypes} from "bitsharesjs/es";
+import Notify from "notifyjs";
 let {operations} = GraphChainTypes;
 
 let OPERATIONS = Object.keys(operations);
@@ -18,16 +19,72 @@ class BrowserNotifications extends React.Component {
         return null;
     }
 
+    _isOperationTransfer(operation) {
+        return this._getOperationName(operation) === "transfer";
+    }
+
+    _isTransferToMyAccount(operation) {
+        if (!this._isOperationTransfer(operation))
+            throw Error("Operation is not transfer");
+
+        return operation.getIn(["op", 1, "to"]) === this.props.account.get("id");
+    }
+
+    _notifyUserAboutTransferToHisAccount(/*operation*/) {
+        this.notifyUsingBrowserNotification({
+            title: "Money received",
+            body: "Somebody sent some coins for you! Nice day!",
+            closeOnClick: true,
+        });
+    }
+
     componentWillReceiveProps(nextProps) {
         if (nextProps.account.size && this.props.account.get("history")) {
 
-            // there should be check for operation type and notification about it
+            let lastOperation = this.props.account.get("history").first();
 
-            // nextProps.account.get("history").forEach((operation) => {
-            //     console.log(this._getOperationName(operation));
-            // });
+            if(this._isOperationTransfer(lastOperation) && this._isTransferToMyAccount(lastOperation)) {
+                this._notifyUserAboutTransferToHisAccount(lastOperation);
+            }
 
         }
+    }
+
+    notifyUsingBrowserNotification(params = {}) {
+
+        /*
+        * params.title (string) - title of notification
+        * params.body (string) - body of notification
+        * params.showTimeout (number) - number of seconds to show the notification
+        * params.closeOnClick (boolean) - close the notification when clicked. Useful in chrome where the notification remains open until the timeout or the x is clicked.
+        * params.onNotifyShow (function) - callback when notification is shown
+        * params.onNotifyClose (function) - callback when notification is closed
+        * params.onNotifyClick (function) - callback when notification is clicked
+        * params.onNotifyError (function) - callback when notification throws an error
+        * */
+
+        if(!params.title && !params.body)
+            return null;
+
+        const notifyParams = {
+            body: params.body
+        };
+
+        if(typeof params.onNotifyShow === "function")
+            notifyParams.notifyShow = params.onNotifyShow;
+
+        if(typeof params.onNotifyClose === "function")
+            notifyParams.notifyClose = params.onNotifyShow;
+
+        if(typeof params.onNotifyClick === "function")
+            notifyParams.notifyClick = params.onNotifyShow;
+
+        if(typeof params.onNotifyError === "function")
+            notifyParams.notifyError = params.onNotifyShow;
+
+        const notify = new Notify(params.title, notifyParams);
+
+        notify.show();
     }
 
     render() {

--- a/app/components/BrowserNotifications/BrowserNotifications.jsx
+++ b/app/components/BrowserNotifications/BrowserNotifications.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import ChainTypes from "../Utility/ChainTypes";
+import BindToChainState from "../Utility/BindToChainState";
+import {ChainTypes as GraphChainTypes} from "bitsharesjs/es";
+let {operations} = GraphChainTypes;
+
+let OPERATIONS = Object.keys(operations);
+
+class BrowserNotifications extends React.Component {
+
+    static propTypes = {
+        account: ChainTypes.ChainAccount.isRequired
+    };
+
+    _getOperationName(operation) {
+        if (operation.getIn(["op", 0]) !== undefined)
+            return OPERATIONS[operation.getIn(["op", 0])];
+        return null;
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.account.size && this.props.account.get("history")) {
+
+            // there should be check for operation type and notification about it
+
+            // nextProps.account.get("history").forEach((operation) => {
+            //     console.log(this._getOperationName(operation));
+            // });
+
+        }
+    }
+
+    render() {
+        return (
+            null
+        );
+    }
+
+}
+
+BrowserNotifications = BindToChainState(BrowserNotifications, {keep_updating: true});
+
+export default BrowserNotifications;

--- a/app/components/BrowserNotifications/BrowserNotifications.jsx
+++ b/app/components/BrowserNotifications/BrowserNotifications.jsx
@@ -16,6 +16,12 @@ class BrowserNotifications extends React.Component {
         settings: React.PropTypes.object,
     };
 
+    componentWillMount() {
+        if(Notify.needsPermission) {
+            Notify.requestPermission();
+        }
+    }
+
     componentWillReceiveProps(nextProps) {
 
         // if browser notifications disabled on settings we can skip all checks

--- a/app/components/BrowserNotifications/BrowserNotifications.jsx
+++ b/app/components/BrowserNotifications/BrowserNotifications.jsx
@@ -40,7 +40,7 @@ class BrowserNotifications extends React.Component {
                 return false;
             }
 
-            if(this._isOperationTransfer(lastOperationNew) && this._isTransferToMyAccount(lastOperationNew)) {
+            if(this._isOperationTransfer(lastOperationNew) && this._isTransferToMyAccount(lastOperationNew) && nextProps.settings.get("browser_notifications").additional.transferToMe) {
                 this._notifyUserAboutTransferToHisAccount(lastOperationNew);
             }
 

--- a/app/components/BrowserNotifications/BrowserNotificationsContainer.jsx
+++ b/app/components/BrowserNotifications/BrowserNotificationsContainer.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import AccountStore from "stores/AccountStore";
+import AltContainer from "alt-container";
+import BrowserNotifications from "./BrowserNotifications";
+
+class BrowserNotificationsContainer extends React.Component {
+
+    render() {
+
+        return (
+            <AltContainer
+                stores={[AccountStore]}
+                inject={{
+                    account: () => {
+                        return AccountStore.getState().currentAccount;
+                    }
+                }}
+            >
+                <BrowserNotifications/>
+            </AltContainer>
+        );
+    }
+}
+
+export default BrowserNotificationsContainer;

--- a/app/components/BrowserNotifications/BrowserNotificationsContainer.jsx
+++ b/app/components/BrowserNotifications/BrowserNotificationsContainer.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import AccountStore from "stores/AccountStore";
+import SettingsStore from "stores/SettingsStore";
 import AltContainer from "alt-container";
 import BrowserNotifications from "./BrowserNotifications";
 
@@ -13,7 +14,10 @@ class BrowserNotificationsContainer extends React.Component {
                 inject={{
                     account: () => {
                         return AccountStore.getState().currentAccount;
-                    }
+                    },
+                    settings: () => {
+                        return SettingsStore.getState().settings;
+                    },
                 }}
             >
                 <BrowserNotifications/>

--- a/app/components/Settings/Settings.jsx
+++ b/app/components/Settings/Settings.jsx
@@ -12,6 +12,7 @@ import RestoreSettings from "./RestoreSettings";
 import ResetSettings from "./ResetSettings";
 import BackupSettings from "./BackupSettings";
 import AccessSettings from "./AccessSettings";
+import _ from "lodash";
 
 class Settings extends React.Component {
 
@@ -35,11 +36,13 @@ class Settings extends React.Component {
             activeSetting,
             menuEntries,
             settingEntries: {
-                general: ["locale", "unit", "showSettles", "walletLockTimeout", "themes",
+                general: ["locale", "unit", "browser_notifications", "showSettles", "walletLockTimeout", "themes",
                 "showAssetPercent", "passwordLogin", "reset"],
                 access: ["apiServer", "faucet_address"]
             }
         };
+
+        this._handleNotificationChange = this._handleNotificationChange.bind(this);
     }
 
     componentDidUpdate(prevProps) {
@@ -99,6 +102,18 @@ class Settings extends React.Component {
 
     triggerModal(e, ...args) {
         this.refs.ws_modal.show(e, ...args);
+    }
+
+    _handleNotificationChange(path, value) {
+        // use different change handler because checkbox doesn't work
+        // normal with e.preventDefault()
+
+        let updatedValue = _.set(this.props.settings.get("browser_notifications"), path, value);
+
+        SettingsActions.changeSetting({
+            setting: "browser_notifications",
+            value: updatedValue
+        });
     }
 
     _onChangeSetting(setting, e) {
@@ -244,6 +259,7 @@ class Settings extends React.Component {
                         settings={settings}
                         defaults={defaults[setting]}
                         onChange={this._onChangeSetting.bind(this)}
+                        onNotificationChange={this._handleNotificationChange}
                         locales={this.props.localesObject}
                         {...this.state}
                     />);

--- a/app/components/Settings/SettingsEntry.jsx
+++ b/app/components/Settings/SettingsEntry.jsx
@@ -11,6 +11,8 @@ export default class SettingsEntry extends React.Component {
         this.state = {
             message: null
         };
+
+        this.handleNotificationChange = this.handleNotificationChange.bind(this);
     }
 
     _setMessage(key) {
@@ -27,10 +29,17 @@ export default class SettingsEntry extends React.Component {
         clearTimeout(this.timer);
     }
 
+    handleNotificationChange(path) {
+        return (evt) => {
+            this.props.onNotificationChange(path, !!evt.target.checked);
+        };
+    }
+
     render() {
         let {defaults, setting, settings} = this.props;
         let options, optional, confirmButton, value, input, selected = settings.get(setting);
         let noHeader = false;
+        let component = null;
 
         switch (setting) {
             case "locale":
@@ -52,6 +61,23 @@ export default class SettingsEntry extends React.Component {
 
                     return <option key={entry} value={entry}>{value}</option>;
                 });
+
+                break;
+
+            case "browser_notifications":
+
+                value = selected;
+
+                component = (
+                    <div className="settings--notifications">
+                        <div className="settings--notifications--group">
+                            <div className="settings--notifications--item">
+                                <input type="checkbox" id="browser_notifications.allow" checked={!!value.allow} onChange={this.handleNotificationChange("allow")}/>
+                                <label htmlFor="browser_notifications.allow">{ counterpart.translate("settings.browser_notifications_allow") }</label>
+                            </div>
+                        </div>
+                    </div>
+                );
 
                 break;
 
@@ -115,6 +141,8 @@ export default class SettingsEntry extends React.Component {
                     </li>
                 </ul> : null}
                 {input ? <ul><li>{input}</li></ul> : null}
+
+                {component ? component : null}
 
                 <div className="facolor-success">{this.state.message}</div>
             </section>

--- a/app/components/Settings/SettingsEntry.jsx
+++ b/app/components/Settings/SettingsEntry.jsx
@@ -3,6 +3,7 @@ import counterpart from "counterpart";
 import Translate from "react-translate-component";
 import SettingsActions from "actions/SettingsActions";
 import AssetName from "../Utility/AssetName";
+import Notify from "notifyjs";
 export default class SettingsEntry extends React.Component {
 
     constructor() {
@@ -85,6 +86,11 @@ export default class SettingsEntry extends React.Component {
                                 </div>
                             </div>
                         </div>
+                        { !!value.allow && Notify.needsPermission && (
+                            <a href="https://goo.gl/zZ7NHY" target="_blank">
+                                <Translate component="div" className="settings--notifications--no-browser-support" content="settings.browser_notifications_disabled_by_browser_notify"/>
+                            </a>
+                        )}
                     </div>
                 );
 

--- a/app/components/Settings/SettingsEntry.jsx
+++ b/app/components/Settings/SettingsEntry.jsx
@@ -75,6 +75,15 @@ export default class SettingsEntry extends React.Component {
                                 <input type="checkbox" id="browser_notifications.allow" checked={!!value.allow} onChange={this.handleNotificationChange("allow")}/>
                                 <label htmlFor="browser_notifications.allow">{ counterpart.translate("settings.browser_notifications_allow") }</label>
                             </div>
+                            <div className="settings--notifications--group">
+                                <div className="settings--notifications--item">
+                                    <input type="checkbox" id="browser_notifications.additional.transferToMe"
+                                           disabled={!value.allow}
+                                           checked={!!value.additional.transferToMe}
+                                           onChange={this.handleNotificationChange("additional.transferToMe")}/>
+                                    <label htmlFor="browser_notifications.allow">{ counterpart.translate("settings.browser_notifications_additional_transfer_to_me") }</label>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 );

--- a/app/stores/SettingsStore.js
+++ b/app/stores/SettingsStore.js
@@ -49,7 +49,10 @@ class SettingsStore {
             showAssetPercent: false,
             walletLockTimeout: 60 * 10,
             themes: "darkTheme",
-            passwordLogin: true
+            passwordLogin: true,
+            browser_notifications: {
+                allow: true
+            }
         });
 
         // If you want a default value to be translated, add the translation to settings in locale-xx.js

--- a/app/stores/SettingsStore.js
+++ b/app/stores/SettingsStore.js
@@ -51,7 +51,10 @@ class SettingsStore {
             themes: "darkTheme",
             passwordLogin: true,
             browser_notifications: {
-                allow: true
+                allow: true,
+                additional: {
+                    transferToMe: true
+                }
             }
         });
 

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "lzma": "2.1.6",
     "node-fetch": "^1.3.1",
     "node-rsa": "^0.4.2",
+    "notifyjs": "^3.0.0",
     "numeral": "2.0.4",
     "object-assign": "^4.0.1",
     "perfect-scrollbar": "git+https://github.com/bitshares/perfect-scrollbar.git",


### PR DESCRIPTION
*Tested on MacOS*

- [x] Chrome
- [x] Firefox
- [x] Opera

1) Now when user opens app for the first time browser will ask him to allow notifications
2) For now supported only "transfer to me" notifications but it's scaleable and easy to track more events and fire notifications for them.
3) If user disabled permissions for Notifications on Browser Settings (or just click Deny when browser ask for permission to send notifications) and user has "Allow browser notifications" on settings I display the following message: 

<img width="1440" alt="screenshot 2018-02-15 01 05 21" src="https://user-images.githubusercontent.com/35899973/36234956-33ff3b66-11ee-11e8-8ac6-c215bbd3c184.png">
(Link opens google - turn on browser notifications, on new tab)

If Notifications disabled there is no any message:
<img width="373" alt="screenshot 2018-02-15 01 21 08" src="https://user-images.githubusercontent.com/35899973/36235019-88cdad12-11ee-11e8-9141-6bee8ec696ca.png">

4) User is able to disable specific event (for now we have only one event) 

<img width="366" alt="screenshot 2018-02-15 01 17 02" src="https://user-images.githubusercontent.com/35899973/36235068-c219a8aa-11ee-11e8-8d4f-eb54b90b02f2.png">
<img width="385" alt="screenshot 2018-02-15 01 13 28" src="https://user-images.githubusercontent.com/35899973/36235069-c239007e-11ee-11e8-890b-37eb58361d0a.png">
<img width="374" alt="screenshot 2018-02-15 01 11 03" src="https://user-images.githubusercontent.com/35899973/36235070-c25461fc-11ee-11e8-8af6-2dab6e7f80db.png">
