### PR TITLE
Account section improvements #1130

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -163,6 +163,7 @@
     "unignore": "Unhide",
     "show_ignored": "Show hidden accounts",
     "hide_ignored": "Hide hidden accounts",
+    "hidden_accounts_row": "Hidden Accounts",
     "accounts": "Accounts",
     "contacts": "Contacts",
     "estimate_value": "Estimated Account value",

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1663,6 +1663,15 @@ $main-content-margin-block-bg-color
             color: $account-primarytext;
             border-color: $account-border;
         }
+        > tbody > tr.dashboard-table--hiddenAccounts {
+            > td {
+                height: 20px;
+                text-align: left;
+                padding-left: 45px;
+                background-color: $account-header;
+                color: $account-primarytext;
+            }
+        }
         > tbody > tr {
             > td {
                 background-color: $account-cells;

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -137,6 +137,12 @@ class DashboardList extends React.Component {
 		let balanceList = Immutable.List();
 
 		return accounts
+		.filter(account => {
+			let accountName = account.get("name");
+			let isMyAccount = AccountStore.isMyAccount(account) || accountName === passwordAccount;
+
+			return (isMyAccount === this.props.showMyAccounts);
+		})
 		.filter(a => {
 			if (!a) return false;
 			return a.get("name").toLowerCase().indexOf(dashboardFilter) !== -1;
@@ -215,11 +221,6 @@ class DashboardList extends React.Component {
 				let isStarred = starredAccounts.has(accountName);
 				let starClass = isStarred ? "gold-star" : "grey-star";
 
-				let shouldShow = (isMyAccount === this.props.showMyAccounts);
-
-				if(!shouldShow)
-					return (null);
-
 				return (
 					<tr key={accountName}>
 						<td className="clickable" onClick={this._onStar.bind(this, accountName, isStarred)}>
@@ -267,7 +268,7 @@ class DashboardList extends React.Component {
 		filterText += "...";
                 
                 let hasLocalWallet = !!WalletDb.getWallet();
-                
+
 		return (
 			<div style={this.props.style}>
 				{!this.props.compact ? (
@@ -296,7 +297,7 @@ class DashboardList extends React.Component {
 					</thead>) : null}
 					<tbody>
 						{includedAccounts}
-						{showIgnored && showMyAccounts ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
+						{showIgnored && hiddenAccounts.length ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
 						{hiddenAccounts}
 					</tbody>
 				</table>

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -130,7 +130,12 @@ class DashboardList extends React.Component {
 		AccountActions.unlinkAccount(account);
 	}
 
-	_renderList(accounts) {
+    _onLinkAccount(account, e) {
+        e.preventDefault();
+        AccountActions.linkAccount(account);
+    }
+
+	_renderList(accounts, isHiddenAccountsList) {
 
 		const {width, starredAccounts, showMyAccounts, passwordAccount} = this.props;
 		const {dashboardFilter, sortBy, inverseSort} = this.state;
@@ -226,10 +231,15 @@ class DashboardList extends React.Component {
 						<td className="clickable" onClick={this._onStar.bind(this, accountName, isStarred)}>
 							<Icon className={starClass} name="fi-star"/>
 						</td>
-						{!showMyAccounts ?
-							<td onClick={this._onUnLinkAccount.bind(this, accountName)}>
-								<Icon name="minus-circle"/>
-							</td>
+						{!showMyAccounts ? (isHiddenAccountsList && (
+                                <td onClick={this._onLinkAccount.bind(this, accountName)}>
+                                    <Icon name="plus-circle"/>
+                                </td>
+                            ) || (
+                                <td onClick={this._onUnLinkAccount.bind(this, accountName)}>
+                                    <Icon name="minus-circle"/>
+                                </td>
+                            ))
 						: null}
 						<td style={{textAlign: "left"}}>
 							{ account.get("id") }
@@ -262,7 +272,7 @@ class DashboardList extends React.Component {
 
 		let includedAccounts = this._renderList(this.props.accounts);
 
-		let hiddenAccounts = showIgnored ? this._renderList(this.props.ignoredAccounts) : null;
+		let hiddenAccounts = this._renderList(this.props.ignoredAccounts, true);
 
 		let filterText = (showMyAccounts) ? counterpart.translate("explorer.accounts.filter") : counterpart.translate("explorer.accounts.filter_contacts");
 		filterText += "...";
@@ -277,7 +287,7 @@ class DashboardList extends React.Component {
                                                 {hasLocalWallet ? (<div onClick={this._createAccount.bind(this)} style={{display: "inline-block", float:"right",marginRight:0}} className="button small">
 							<Translate content="header.create_account" />
 						</div>):null}
-                                                {this.props.ignoredAccounts.length ?<div onClick={this.props.onToggleIgnored} style={{display: "inline-block",float:"right",marginRight:"20px"}} className="button small">
+                                                {hiddenAccounts && hiddenAccounts.length ?<div onClick={this.props.onToggleIgnored} style={{display: "inline-block",float:"right",marginRight:"20px"}} className="button small">
 							<Translate content={`account.${ this.props.showIgnored ? "hide_ignored" : "show_ignored" }`} />
 						</div>:null}
 					</section>) : null}
@@ -298,7 +308,7 @@ class DashboardList extends React.Component {
 					<tbody>
 						{includedAccounts}
 						{showIgnored && hiddenAccounts.length ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
-						{hiddenAccounts}
+						{showIgnored && hiddenAccounts}
 					</tbody>
 				</table>
 			</div>

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -296,7 +296,7 @@ class DashboardList extends React.Component {
 					</thead>) : null}
 					<tbody>
 						{includedAccounts}
-						{showIgnored ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
+						{showIgnored && showMyAccounts ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
 						{hiddenAccounts}
 					</tbody>
 				</table>

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -296,7 +296,7 @@ class DashboardList extends React.Component {
 					</thead>) : null}
 					<tbody>
 						{includedAccounts}
-						{showIgnored ? <tr style={{backgroundColor: "transparent"}} key="hidden"><td style={{height: 20}} colSpan="4"></td></tr> : null}
+						{showIgnored ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
 						{hiddenAccounts}
 					</tbody>
 				</table>


### PR DESCRIPTION
**Tested on MacOS:**

- [x] Chrome
- [x] Opera
- [x] Firefox

Changes I made:
1) Fix divider between Hidden/Shown accounts
2) Do not display divider if hidden accounts doesn't exist
3) Do not display Show/Hide button if hidden accounts doesn't exist
4) Add an ability to add contact back and fix icon
![gif-contacts-fixed](https://user-images.githubusercontent.com/35899973/36237248-fcc28240-11fa-11e8-9b83-d6df2a1a3ee9.gif)