### PR TITLE
Fix Issue #1070 - Loading Status on Assets/User Search

### DIFF
--- a/app/components/Explorer/Accounts.jsx
+++ b/app/components/Explorer/Accounts.jsx
@@ -11,6 +11,7 @@ import BindToChainState from "../Utility/BindToChainState";
 import BalanceComponent from "../Utility/BalanceComponent";
 import AccountStore from "stores/AccountStore";
 import { connect } from "alt-react";
+import LoadingIndicator from "../LoadingIndicator";
 
 class AccountRow extends React.Component {
     static propTypes = {
@@ -79,7 +80,8 @@ class Accounts extends React.Component {
     constructor(props) {
         super();
         this.state = {
-            searchTerm: props.searchTerm
+            searchTerm: props.searchTerm,
+            isLoading: false
         };
 
         this._searchAccounts = debounce(this._searchAccounts, 200);
@@ -88,17 +90,19 @@ class Accounts extends React.Component {
     shouldComponentUpdate(nextProps, nextState) {
         return (
                 !Immutable.is(nextProps.searchAccounts, this.props.searchAccounts) ||
-                nextState.searchTerm !== this.state.searchTerm
+                nextState.searchTerm !== this.state.searchTerm ||
+                nextState.isLoading !== this.state.isLoading
             );
     }
 
     _onSearchChange(e) {
-        this.setState({searchTerm: e.target.value.toLowerCase()});
+        this.setState({searchTerm: e.target.value.toLowerCase(), isLoading: true});
         this._searchAccounts(e.target.value);
     }
 
     _searchAccounts(searchTerm) {
         AccountActions.accountSearch(searchTerm);
+        this.setState({isLoading: false});
     }
 
     render() {
@@ -146,9 +150,14 @@ class Accounts extends React.Component {
                             </thead>
 
                             <tbody>
-                                {accountRows}
+                                {this.state.isLoading ? 
+                                    <tr colSpan="5"></tr>
+                                    :
+                                    accountRows
+                                }
                             </tbody>
                         </table>
+                        {this.state.isLoading ? <div style={{textAlign: "center", padding: 10}}><LoadingIndicator type="three-bounce" /></div> : null}
                     </div>
                 </div>
             </div>

--- a/app/components/Explorer/Assets.jsx
+++ b/app/components/Explorer/Assets.jsx
@@ -38,10 +38,6 @@ class Assets extends React.Component {
     shouldComponentUpdate(nextProps, nextState) {
         return (
             !Immutable.is(nextProps.assets, this.props.assets) ||
-            nextState.filterMPA !== this.state.filterMPA ||
-            nextState.filterUIA !== this.state.filterUIA ||
-            nextState.filterPM !== this.state.filterPM ||
-            nextProps.isLoading !== this.state.isLoading ||
             !utils.are_equal_shallow(nextState, this.state)
         );
     }

--- a/app/components/Explorer/Assets.jsx
+++ b/app/components/Explorer/Assets.jsx
@@ -13,7 +13,10 @@ import AssetName from "../Utility/AssetName";
 import {ChainStore} from "bitsharesjs/es";
 import cnames from "classnames";
 import utils from "common/utils";
+import LoadingIndicator from "../LoadingIndicator";
+import ls from "common/localStorage";
 
+let accountStorage = new ls("__graphene__");
 
 class Assets extends React.Component {
 
@@ -22,6 +25,8 @@ class Assets extends React.Component {
         this.state = {
             foundLast: false,
             lastAsset: "",
+            isLoading: false,
+            totalAssets: typeof accountStorage.get("totalAssets") != "object" ? accountStorage.get("totalAssets") : 3000,
             assetsFetched: 0,
             activeFilter: "market",
             filterUIA: props.filterUIA || "",
@@ -36,6 +41,7 @@ class Assets extends React.Component {
             nextState.filterMPA !== this.state.filterMPA ||
             nextState.filterUIA !== this.state.filterUIA ||
             nextState.filterPM !== this.state.filterPM ||
+            nextProps.isLoading !== this.state.isLoading ||
             !utils.are_equal_shallow(nextState, this.state)
         );
     }
@@ -45,6 +51,7 @@ class Assets extends React.Component {
     }
 
     _checkAssets(assets, force) {
+        this.setState({isLoading: true});
         let lastAsset = assets.sort((a, b) => {
             if (a.symbol > b.symbol) {
                 return 1;
@@ -54,13 +61,21 @@ class Assets extends React.Component {
                 return 0;
             }
         }).last();
-
+        
         if (assets.size === 0 || force) {
             AssetActions.getAssetList.defer("A", 100);
             this.setState({assetsFetched: 100});
         } else if (assets.size >= this.state.assetsFetched) {
             AssetActions.getAssetList.defer(lastAsset.symbol, 100);
             this.setState({assetsFetched: this.state.assetsFetched + 99});
+        }
+        
+        if(assets.size > this.state.totalAssets) { 
+            accountStorage.set("totalAssets", assets.size); 
+        }
+
+        if(this.state.assetsFetched >= this.state.totalAssets - 100) {
+            this.setState({isLoading: false});
         }
     }
 
@@ -202,7 +217,7 @@ class Assets extends React.Component {
                 }
             }).toArray();
         }
-
+        
         return (
             <div className="grid-block vertical">
                 <div className="grid-block vertical">
@@ -221,7 +236,7 @@ class Assets extends React.Component {
                                     </div>
                                 </div>
                             </div>
-                            
+                            {this.state.isLoading ? <LoadingIndicator /> : null}
                             {activeFilter == "market" ? 
                                 <div className="grid-block shrink">
                                     <div className="grid-content">


### PR DESCRIPTION
Fixes Issue #1070 
- Loading Indicator when fetching Accounts search term
- Loading Indicator when fetching Assets cache list

### Regarding Assets
Assets are cached on navigation to the page and loaded by batches of 100 trough the API call of `list_assets`, but we can never know how many there are until we've done this at least once.

A cached value of total assets is stored during the load, and updated if this increases. While the value of the stored number is less than the loaded, a loading indicator will be visible. During the first load a default number of 3000 assets will be set. I'm subtracting 100 from the previous cached total, as I'm unsure if this value would ever decrease? An issue for this has been created on core level here https://github.com/bitshares/bitshares-core/issues/688


