### PR TITLE
Hotfix - Remove invalid negative margin on table

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -772,7 +772,7 @@ class Asset extends React.Component {
                     <div className="">
                         <Tabs defaultActiveTab={0} segmented={false} setting="bitassetDataTabs">
                             <Tab title="explorer.asset.price_feed_data.title">
-                                <div className="responsive-table" style={{marginTop:"-10px"}}>
+                                <div className="responsive-table">
                                     <table className=" table order-table table-hover" style={{ padding:"1.2rem"}}>
                                         {header}
                                         <tbody>


### PR DESCRIPTION
# Hotfix
Remove invalid negative margin on Asset `Price Feed Data` Tab

## Before
![image](https://user-images.githubusercontent.com/12114550/36813636-80a6f62e-1cd5-11e8-9739-dabb73747290.png)

## After
![image](https://user-images.githubusercontent.com/12114550/36813675-9c72f86c-1cd5-11e8-9171-381a104e4b71.png)
