### PR TITLE
Fix withdraw (beta) issues

### DIFF
--- a/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
+++ b/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
@@ -18,7 +18,6 @@ class DepositWithdrawAssetSelector extends React.Component {
         const {props} = this;
         const {include} = props;
         let idMap = {};
-        console.log('props are', props);
 
         let getCoinOption = item => {
             /* Gateway Specific Settings */

--- a/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
+++ b/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
@@ -7,6 +7,7 @@ import GatewayStore from "stores/GatewayStore";
 import GatewayActions from "actions/GatewayActions";
 import TypeAhead from "../Utility/TypeAhead";
 import counterpart from "counterpart";
+import {ChainStore} from "bitsharesjs/es";
 
 class DepositWithdrawAssetSelector extends React.Component {
     constructor(props) {
@@ -17,6 +18,7 @@ class DepositWithdrawAssetSelector extends React.Component {
         const {props} = this;
         const {include} = props;
         let idMap = {};
+        console.log('props are', props);
 
         let getCoinOption = item => {
             /* Gateway Specific Settings */
@@ -45,13 +47,17 @@ class DepositWithdrawAssetSelector extends React.Component {
             // Return null if backedCoin is already stored
             if (!idMap[backedCoin]) {
                 idMap[backedCoin] = true;
+                let account = null;
+                if(!item.issuerId){ 
+                  account = ChainStore.getAccount(item.intermediateAccount);
+                }
 
                 return {
                     id: backedCoin,
                     label: backedCoin,
                     gateway: gateway,
                     gateFee: item.gateFee,
-                    issuer: item.issuerId || "1.2.96397" //Fall back to open ledger
+                    issuer: item.issuerId || (account ? account.get("id") : "1.2.96397") //Fall back to openledger-wallet
                 };
             } else {
                 return null;

--- a/app/components/Modal/WithdrawModalNew.jsx
+++ b/app/components/Modal/WithdrawModalNew.jsx
@@ -678,7 +678,12 @@ class WithdrawModalNew extends React.Component {
             quantity,
             selectedAsset,
             address,
-            isBTS
+            isBTS,
+            gateFee,
+            memo,
+            btsAccount,
+            issuer,
+            feeAmount
         } = this.state;
         let assetName = selectedAsset.toLowerCase();
 
@@ -717,7 +722,7 @@ class WithdrawModalNew extends React.Component {
         const gateFeeAmount = new Asset({
             asset_id: withdrawalCurrencyId,
             precision: withdrawalCurrencyPrecision,
-            real: state.gateFee
+            real: gateFee
         });
 
         sendAmount.plus(gateFeeAmount);
@@ -731,17 +736,17 @@ class WithdrawModalNew extends React.Component {
         let to = "";
 
         if (isBTS) {
-            descriptor = state.memo ? new Buffer(state.memo, "utf-8") : "";
-            to = state.btsAccount.get("id");
+            descriptor = memo ? new Buffer(memo, "utf-8") : "";
+            to = btsAccount.get("id");
         } else {
             descriptor =
                 assetName +
                 ":" +
                 address +
-                (this.state.memo
-                    ? ":" + new Buffer(this.state.memo, "utf-8")
+                (memo
+                    ? ":" + new Buffer(memo, "utf-8")
                     : "");
-            to = state.issuer;
+            to = issuer;
         }
 
         let args = [
@@ -751,7 +756,7 @@ class WithdrawModalNew extends React.Component {
             withdrawalCurrencyId,
             descriptor,
             null,
-            state.feeAmount ? state.feeAmount.asset_id : "1.3.0"
+            feeAmount ? feeAmount.asset_id : "1.3.0"
         ];
 
         AccountActions.transfer(...args).then(() => {

--- a/app/components/Modal/WithdrawModalNew.jsx
+++ b/app/components/Modal/WithdrawModalNew.jsx
@@ -548,18 +548,40 @@ class WithdrawModalNew extends React.Component {
         );
     }
 
+    getIssuerFromAssetAndGateway(assetSymbol, gateway){
+        let backedCoins = this.props.backedCoins.get(gateway);
+        let issuer = null;
+        backedCoins.forEach((item)=>{
+          if(item.symbol == assetSymbol || item.backingCoin == assetSymbol || item.name == assetSymbol || item.backingCoinType == assetSymbol){
+            try {
+              if(item.issuerId){
+                issuer = item.issuerId;
+              } else if(item.issuer){
+                issuer = ChainStore.getAccount(item.issuer).get("id");
+              } else if(item.intermediateAccount) {
+                issuer = ChainStore.getAccount(item.intermediateAccount).get("id");
+              }
+            }catch(e){}
+          }
+        })
+
+        return issuer;
+    }
+
     onAssetSelected(value, asset) {
         let {selectedAsset, selectedGateway} = _onAssetSelected.call(
             this,
             value,
             gatewayBoolCheck
         );
+
         let address = WithdrawAddresses.getLast(value.toLowerCase());
+        let issuer = this.getIssuerFromAssetAndGateway.call(this, selectedAsset, selectedGateway);
         this.setState({
             selectedAsset,
             selectedGateway,
             gateFee: asset.gateFee,
-            issuer: asset.issuer,
+            issuer,
             address,
             isBTS: false
         });
@@ -593,7 +615,8 @@ class WithdrawModalNew extends React.Component {
 
     onGatewayChanged(e) {
         let selectedGateway = e.target.value;
-        this.setState({selectedGateway});
+        let issuer = this.getIssuerFromAssetAndGateway.call(this, this.state.selectedAsset, selectedGateway);
+        this.setState({selectedGateway, issuer});
         this._updateFee();
     }
 


### PR DESCRIPTION
Not sure how this slipped through the cracks (perhaps a merge issue?), but there was an undefined variable in the submit method. Also, asset deposit withdraw typeahead was passing openledger-wallet issuer id back to deposit / withdraw modals instead of appropriate issuer id.

Fixed. Please merge and release new build @svk31 

Resolves issue #1269 and issue #1268