### PR TITLE
#1265 Fix accounts list toggle

### DIFF
--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -1040,11 +1040,15 @@ class Header extends React.Component {
                 </div>
 
                 <div
-                    onClick={this._toggleAccountDropdownMenu}
                     className="truncated active-account"
                     style={{cursor: "pointer"}}
                 >
-                    <div className="text account-name">{currentAccount}</div>
+                    <div
+                        className="text account-name"
+                        onClick={this._toggleAccountDropdownMenu}
+                    >
+                        {currentAccount}
+                    </div>
                     {walletBalance}
 
                     {hasLocalWallet && (


### PR DESCRIPTION
Issue was that 'toggle' handler was on parent element except be on account name. That fired dropdown open when it closes  