### PR TITLE
Fix ability filter and provide an ability to filter by pair #1255

### DIFF
--- a/app/components/Dashboard/MarketsTable.jsx
+++ b/app/components/Dashboard/MarketsTable.jsx
@@ -324,8 +324,35 @@ class MarketsTable extends React.Component {
             if (row.isHidden !== this.state.showHidden) {
                 visible = false;
             } else if (filter) {
-                visible =
-                    row.quote.includes(filter) || row.base.includes(filter);
+
+                const quoteObject = ChainStore.getAsset(row.quote);
+                const baseObject = ChainStore.getAsset(row.base);
+
+                let quoteSymbol = row.quote;
+                let baseSymbol = row.base;
+
+                if(quoteObject.has('bitasset_data_id')) {
+                    quoteSymbol = 'bit'+quoteSymbol;
+                }
+
+                if(baseObject.has('bitasset_data_id')) {
+                    baseSymbol = 'bit'+baseSymbol;
+                }
+
+                const filterPair = filter.includes(':');
+
+                if (filterPair) {
+
+                    const quoteFilter = filter.split(':')[0].trim();
+                    const baseFilter = filter.split(':')[1].trim();
+
+                    visible =
+                        quoteSymbol.toLowerCase().includes(String(quoteFilter).toLowerCase()) && baseSymbol.toLowerCase().includes(String(baseFilter).toLowerCase());
+                } else {
+                    visible =
+                        quoteSymbol.toLowerCase().includes(String(filter).toLowerCase()) || baseSymbol.toLowerCase().includes(String(filter).toLowerCase());
+                }
+
             }
 
             if (visible) ++visibleRow;


### PR DESCRIPTION
- [x] Fix ability to filter by "bit" prefix. 
- [x] Add ability to filter by pair like: "bit:bts"

@svk31 please make sure on likes `333` and `337` I do correct check for bit* asset. If you can advice the better way just let me know. 

<img width="289" alt="screenshot 2018-03-13 04 27 03" src="https://user-images.githubusercontent.com/35899973/37321016-ce0a7e5e-2676-11e8-9ad4-a1b53e1123a1.png">
<img width="273" alt="screenshot 2018-03-13 04 26 51" src="https://user-images.githubusercontent.com/35899973/37321017-ce2c5092-2676-11e8-817e-199c4e0b363f.png">
<img width="267" alt="screenshot 2018-03-13 04 26 43" src="https://user-images.githubusercontent.com/35899973/37321018-ce60acd4-2676-11e8-8141-2100c6c363f1.png">
