### PR TITLE
#1271 Add an ability to filter portfolio by asset name

### DIFF
--- a/app/components/Account/AccountOverview.jsx
+++ b/app/components/Account/AccountOverview.jsx
@@ -70,6 +70,15 @@ class AccountOverview extends React.Component {
         for (let key in this.sortFunctions) {
             this.sortFunctions[key] = this.sortFunctions[key].bind(this);
         }
+
+        this._handleFilterInput = this._handleFilterInput.bind(this);
+    }
+
+    _handleFilterInput(e) {
+        e.preventDefault();
+        this.setState({
+            filterValue: e.target.value
+        });
     }
 
     sortFunctions = {
@@ -170,7 +179,8 @@ class AccountOverview extends React.Component {
             nextProps.account !== this.props.account ||
             nextProps.settings !== this.props.settings ||
             nextProps.hiddenAssets !== this.props.hiddenAssets ||
-            !utils.are_equal_shallow(nextState, this.state)
+            !utils.are_equal_shallow(nextState, this.state) ||
+            this.state.filterValue !== nextState.filterValue
         );
     }
 
@@ -866,9 +876,31 @@ class AccountOverview extends React.Component {
 
             // Separate balances into hidden and included
             account_balances.forEach((a, asset_type) => {
-                if (hiddenAssets.includes(asset_type)) {
+                const asset = ChainStore.getAsset(asset_type);
+
+                let assetName = "";
+                let filter = "";
+
+                if (this.state.filterValue) {
+                    filter = this.state.filterValue
+                        ? String(this.state.filterValue).toLowerCase()
+                        : "";
+                    assetName = asset.get("symbol").toLowerCase();
+
+                    if (asset.has("bitasset_data_id")) {
+                        assetName = "bit" + assetName;
+                    }
+                }
+
+                if (
+                    hiddenAssets.includes(asset_type) &&
+                    assetName.includes(filter)
+                ) {
                     hiddenBalancesList = hiddenBalancesList.push(a);
-                } else {
+                } else if (
+                    assetName.includes(filter) &&
+                    assetName.includes(filter)
+                ) {
                     includedBalancesList = includedBalancesList.push(a);
                 }
             });
@@ -1007,7 +1039,14 @@ class AccountOverview extends React.Component {
                                 subText={portfolioActiveAssetsBalance}
                             >
                                 <div className="header-selector">
-                                    <div className="selector">
+                                    <div className="filter inline-block">
+                                        <input
+                                            type="text"
+                                            placeholder="Filter"
+                                            onChange={this._handleFilterInput}
+                                        />
+                                    </div>
+                                    <div className="selector inline-block">
                                         <div
                                             className={cnames("inline-block", {
                                                 inactive:


### PR DESCRIPTION
- [x] Ability to filter Active/Inactive/Visual by asset name
- [x] Handle `bit*` assets

<img width="740" alt="screenshot 2018-03-13 07 11 43" src="https://user-images.githubusercontent.com/35899973/37325348-d9eba6e6-268d-11e8-92ab-a23806a4b706.png">
