### PR TITLE
Contacts Improvements #1173

### DIFF
--- a/app/actions/AccountActions.js
+++ b/app/actions/AccountActions.js
@@ -179,6 +179,14 @@ class AccountActions {
         return name;
     }
 
+    addAccountContact(name) {
+        return name;
+    }
+
+    removeAccountContact(name) {
+        return name;
+    }
+
     setPasswordAccount(account) {
         return account;
     }

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -24,7 +24,6 @@ import cnames from "classnames";
  */
 
 class AccountSelector extends React.Component {
-
     static propTypes = {
         label: React.PropTypes.string, // a translation key for the label
         error: React.PropTypes.element, // the error message override
@@ -50,26 +49,30 @@ class AccountSelector extends React.Component {
     }
 
     getError() {
-
         let scamMessage = accountUtils.isKnownScammer(this.props.accountName);
 
         let error = this.props.error;
-        if (!error && this.props.accountName && !this.getNameType(this.props.accountName))
+        if (
+            !error &&
+            this.props.accountName &&
+            !this.getNameType(this.props.accountName)
+        )
             error = counterpart.translate("account.errors.invalid");
 
         return scamMessage || error;
     }
 
     getNameType(value) {
-        if(!value) return null;
-        if(value[0] === "#" && utils.is_object_id("1.2." + value.substring(1))) return "id";
-        if(ChainValidation.is_account_name(value, true)) return "name";
-        if(this.props.allowPubKey && PublicKey.fromPublicKeyString(value)) return "pubkey";
+        if (!value) return null;
+        if (value[0] === "#" && utils.is_object_id("1.2." + value.substring(1)))
+            return "id";
+        if (ChainValidation.is_account_name(value, true)) return "name";
+        if (this.props.allowPubKey && PublicKey.fromPublicKeyString(value))
+            return "pubkey";
         return null;
     }
 
     onInputChanged(event) {
-
         let value = null;
         if (typeof event === "string") {
             value = event;
@@ -81,10 +84,13 @@ class AccountSelector extends React.Component {
             value = value.toLowerCase();
         }
         // If regex matches ^.*#/account/account-name/.*$, parse out account-name
-        let newValue = value.replace("#", "").match(/(?:\/account\/)(.*)(?:\/overview)/);
+        let newValue = value
+            .replace("#", "")
+            .match(/(?:\/account\/)(.*)(?:\/overview)/);
         if (newValue) value = newValue[1];
 
-        if (this.props.onChange && value !== this.props.accountName) this.props.onChange(value);
+        if (this.props.onChange && value !== this.props.accountName)
+            this.props.onChange(value);
     }
 
     onKeyDown(event) {
@@ -92,12 +98,16 @@ class AccountSelector extends React.Component {
     }
 
     componentDidMount() {
-        if(this.props.onAccountChanged && this.props.account)
+        if (this.props.onAccountChanged && this.props.account)
             this.props.onAccountChanged(this.props.account);
     }
 
     componentWillReceiveProps(newProps) {
-        if((this.props.onAccountChanged && newProps.account) && newProps.account !== this.props.account)
+        if (
+            this.props.onAccountChanged &&
+            newProps.account &&
+            newProps.account !== this.props.account
+        )
             this.props.onAccountChanged(newProps.account);
     }
 
@@ -113,9 +123,12 @@ class AccountSelector extends React.Component {
 
     onAction(e) {
         e.preventDefault();
-        if(this.props.onAction && !this.getError() && !this.props.disableActionButton) {
-            if (this.props.account)
-                this.props.onAction(this.props.account);
+        if (
+            this.props.onAction &&
+            !this.getError() &&
+            !this.props.disableActionButton
+        ) {
+            if (this.props.account) this.props.onAction(this.props.account);
             else if (this.getNameType(this.props.accountName) === "pubkey")
                 this.props.onAction(this.props.accountName);
         }
@@ -129,114 +142,247 @@ class AccountSelector extends React.Component {
         if (this.props.allowPubKey) {
             if (type === "pubkey") lookup_display = "Public Key";
         } else if (this.props.account) {
-            if(type === "name") lookup_display = "#" + this.props.account.get("id").substring(4);
-            else if (type === "id") lookup_display = this.props.account.get("name");
-        } else if (!error && this.props.accountName) error = counterpart.translate("account.errors.unknown");
+            if (type === "name")
+                lookup_display =
+                    "#" + this.props.account.get("id").substring(4);
+            else if (type === "id")
+                lookup_display = this.props.account.get("name");
+        } else if (!error && this.props.accountName)
+            error = counterpart.translate("account.errors.unknown");
 
         let member_status = null;
-        let isKnownScammer = accountUtils.isKnownScammer(this.props.accountName);
+        let isKnownScammer = accountUtils.isKnownScammer(
+            this.props.accountName
+        );
         if (this.props.account && !isKnownScammer)
-            member_status = counterpart.translate("account.member." + ChainStore.getAccountMemberStatus(this.props.account));
-        else if(this.props.account && isKnownScammer) {
-            member_status = counterpart.translate("account.member.suspected_scammer");
+            member_status = counterpart.translate(
+                "account.member." +
+                    ChainStore.getAccountMemberStatus(this.props.account)
+            );
+        else if (this.props.account && isKnownScammer) {
+            member_status = counterpart.translate(
+                "account.member.suspected_scammer"
+            );
         }
 
-        let action_class = classnames("button", {"disabled" : !(this.props.account || type === "pubkey") || error || this.props.disableActionButton});
+        let action_class = classnames("button", {
+            disabled:
+                !(this.props.account || type === "pubkey") ||
+                error ||
+                this.props.disableActionButton
+        });
 
         let typeAheadAccounts = [];
 
         let isGreenAccount = false;
-        let lookup_name = this.props.account ? this.props.account.get("name"):"";
+        let lookup_name = this.props.account
+            ? this.props.account.get("name")
+            : "";
 
         if (this.props.typeahead) {
-            this.props.typeahead.map(function(account){
-                typeAheadAccounts.push({id:account,label:account});
+            this.props.typeahead.map(function(account) {
+                typeAheadAccounts.push({id: account, label: account});
             });
 
             isGreenAccount = this.props.typeahead.indexOf(lookup_name) !== -1;
         }
 
-        let typeaheadHasAccount = !!this.props.account ? typeAheadAccounts.reduce((boolean, a) => {
-            return boolean || a.label === this.props.account.get("name");
-        }, false) : false;
+        let typeaheadHasAccount = !!this.props.account
+            ? typeAheadAccounts.reduce((boolean, a) => {
+                  return boolean || a.label === this.props.account.get("name");
+              }, false)
+            : false;
         if (!!this.props.account && !typeaheadHasAccount) {
-            typeAheadAccounts.push({id: this.props.account.get("name"), label: this.props.account.get("name")});
+            typeAheadAccounts.push({
+                id: this.props.account.get("name"),
+                label: this.props.account.get("name")
+            });
         }
 
-        let linked_status = !this.props.accountName ? null : (linkedAccounts.has(this.props.accountName)) ?
-            <span className="tooltip" data-place="top" data-tip={counterpart.translate("tooltip.follow_user")} onClick={this.onUnLinkAccount.bind(this)}><Icon className={""+(isGreenAccount? " green":"")} style={{position:"absolute",top:"-0.15em",right:".2em"}} name="user" /></span>
-            : <span className="tooltip" data-place="top" data-tip={counterpart.translate("tooltip.follow_user_add")} onClick={this.onLinkAccount.bind(this)}><Icon style={{position:"absolute",top:"-0.05em",right:".2em"}} name="plus-circle" /></span>;
+        let linked_status = !this.props.accountName ? null : linkedAccounts.has(
+            this.props.accountName
+        ) ? (
+            <span
+                className="tooltip"
+                data-place="top"
+                data-tip={counterpart.translate("tooltip.follow_user")}
+                onClick={this.onUnLinkAccount.bind(this)}
+            >
+                <Icon
+                    className={"" + (isGreenAccount ? " green" : "")}
+                    style={{
+                        position: "absolute",
+                        top: "-0.15em",
+                        right: ".2em"
+                    }}
+                    name="user"
+                />
+            </span>
+        ) : (
+            <span
+                className="tooltip"
+                data-place="top"
+                data-tip={counterpart.translate("tooltip.follow_user_add")}
+                onClick={this.onLinkAccount.bind(this)}
+            >
+                <Icon
+                    style={{
+                        position: "absolute",
+                        top: "-0.05em",
+                        right: ".2em"
+                    }}
+                    name="plus-circle"
+                />
+            </span>
+        );
 
         return (
             <div className="account-selector" style={this.props.style}>
                 <div className="content-area">
                     {this.props.label ? (
-                    <div className={"header-area" + (this.props.hideImage ? " no-margin" : "")}>
-                        {error && !lookup_display ?
-                            <label className="right-label negative"><span>Unknown Account</span></label> :
-                            <label className={cnames("right-label", isGreenAccount ? "positive" : null, isKnownScammer ? "negative" : null)}>
-                                <span className="tooltip" data-place="top" data-tip={isKnownScammer}>{member_status}</span>&nbsp;
-                                <span style={{marginRight:"1.5em"}}>{lookup_display}</span>
-                                &nbsp;{linked_status}
-                            </label>
-                        }
-                        <Translate className="left-label" component="label" content={this.props.label}/>
-                    </div>) : null}
+                        <div
+                            className={
+                                "header-area" +
+                                (this.props.hideImage ? " no-margin" : "")
+                            }
+                        >
+                            {error && !lookup_display ? (
+                                <label className="right-label negative">
+                                    <span>Unknown Account</span>
+                                </label>
+                            ) : (
+                                <label
+                                    className={cnames(
+                                        "right-label",
+                                        isGreenAccount ? "positive" : null,
+                                        isKnownScammer ? "negative" : null
+                                    )}
+                                >
+                                    <span
+                                        className="tooltip"
+                                        data-place="top"
+                                        data-tip={isKnownScammer}
+                                    >
+                                        {member_status}
+                                    </span>&nbsp;
+                                    <span style={{marginRight: "1.5em"}}>
+                                        {lookup_display}
+                                    </span>
+                                    &nbsp;{linked_status}
+                                </label>
+                            )}
+                            <Translate
+                                className="left-label"
+                                component="label"
+                                content={this.props.label}
+                            />
+                        </div>
+                    ) : null}
                     <div className="input-area">
                         <div className="inline-label input-wrapper">
-                            {type === "pubkey" ? <div className="account-image"><Icon name="key" size="4x"/></div> :
-                            this.props.hideImage ? null : <AccountImage size={{height: this.props.size || 80, width: this.props.size || 80}}
-                                account={this.props.account ? this.props.account.get("name") : null} custom_image={null}/>}
-                                {(typeof this.props.typeahead !== "undefined")?
-                                 <TypeAhead items={typeAheadAccounts}
-                                    style={{textTransform: "lowercase", fontVariant: "initial"}}
+                            {type === "pubkey" ? (
+                                <div className="account-image">
+                                    <Icon name="key" size="4x" />
+                                </div>
+                            ) : this.props.hideImage ? null : (
+                                <AccountImage
+                                    size={{
+                                        height: this.props.size || 80,
+                                        width: this.props.size || 80
+                                    }}
+                                    account={
+                                        this.props.account
+                                            ? this.props.account.get("name")
+                                            : null
+                                    }
+                                    custom_image={null}
+                                />
+                            )}
+                            {typeof this.props.typeahead !== "undefined" ? (
+                                <TypeAhead
+                                    items={typeAheadAccounts}
+                                    style={{
+                                        textTransform: "lowercase",
+                                        fontVariant: "initial"
+                                    }}
                                     name="username"
                                     id="username"
                                     defaultValue={this.props.accountName || ""}
-                                    placeholder={this.props.placeholder || counterpart.translate("account.name")}
+                                    placeholder={
+                                        this.props.placeholder ||
+                                        counterpart.translate("account.name")
+                                    }
                                     ref="user_input"
                                     onSelect={this.onInputChanged.bind(this)}
                                     onChange={this.onInputChanged.bind(this)}
                                     onKeyDown={this.onKeyDown.bind(this)}
                                     tabIndex={this.props.tabIndex}
-                                    inputProps={{placeholder: "Search for an account"}}
+                                    inputProps={{
+                                        placeholder: "Search for an account"
+                                    }}
+                                    {...this.props.typeaheadOptions || {}}
                                 />
-                            :<input style={{textTransform: "lowercase", fontVariant: "initial"}}
+                            ) : (
+                                <input
+                                    style={{
+                                        textTransform: "lowercase",
+                                        fontVariant: "initial"
+                                    }}
                                     name="username"
                                     id="username"
                                     type="text"
                                     value={this.props.accountName || ""}
-                                    placeholder={this.props.placeholder || counterpart.translate("account.name")}
+                                    placeholder={
+                                        this.props.placeholder ||
+                                        counterpart.translate("account.name")
+                                    }
                                     ref="user_input"
                                     onChange={this.onInputChanged.bind(this)}
                                     onKeyDown={this.onKeyDown.bind(this)}
                                     tabIndex={this.props.tabIndex}
-                                />}
-                                {this.props.dropDownContent ? <div className="form-label select floating-dropdown">
+                                />
+                            )}
+                            {this.props.dropDownContent ? (
+                                <div className="form-label select floating-dropdown">
                                     <FloatingDropdown
                                         entries={this.props.dropDownContent}
-                                        values={this.props.dropDownContent.reduce((map, a) => {if (a) map[a] = a; return map;}, {})}
-                                        singleEntry={this.props.dropDownContent[0]}
+                                        values={this.props.dropDownContent.reduce(
+                                            (map, a) => {
+                                                if (a) map[a] = a;
+                                                return map;
+                                            },
+                                            {}
+                                        )}
+                                        singleEntry={
+                                            this.props.dropDownContent[0]
+                                        }
                                         value={this.props.dropDownValue || ""}
                                         onChange={this.props.onDropdownSelect}
                                     />
-                                </div> : null}
-                                { this.props.children }
-                                { this.props.onAction ? (
-                                    <button className={action_class}
-                                        onClick={this.onAction.bind(this)}>
-                                        <Translate content={this.props.action_label}/></button>
-                                    ) : null }
                                 </div>
-                            </div>
-
-                            {error ? <div className="error-area">
-                                <span>{error}</span>
-                            </div> : null}
+                            ) : null}
+                            {this.props.children}
+                            {this.props.onAction ? (
+                                <button
+                                    className={action_class}
+                                    onClick={this.onAction.bind(this)}
+                                >
+                                    <Translate
+                                        content={this.props.action_label}
+                                    />
+                                </button>
+                            ) : null}
                         </div>
+                    </div>
+
+                    {error ? (
+                        <div className="error-area">
+                            <span>{error}</span>
+                        </div>
+                    ) : null}
+                </div>
             </div>
         );
-
     }
 }
 

--- a/app/components/Dashboard/DashboardAccountsOnly.jsx
+++ b/app/components/Dashboard/DashboardAccountsOnly.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Immutable from "immutable";
 import DashboardList from "./DashboardList";
-import { RecentTransactions } from "../Account/RecentTransactions";
+import {RecentTransactions} from "../Account/RecentTransactions";
 import LoadingIndicator from "../LoadingIndicator";
 import LoginSelector from "../LoginSelector";
 import SettingsActions from "actions/SettingsActions";
@@ -17,6 +17,9 @@ class AccountsContainer extends React.Component {
             <AltContainer
                 stores={[AccountStore, SettingsStore, MarketsStore]}
                 inject={{
+                    contacts: () => {
+                        return AccountStore.getState().accountContacts;
+                    },
                     linkedAccounts: () => {
                         return AccountStore.getState().linkedAccounts;
                     },
@@ -24,7 +27,10 @@ class AccountsContainer extends React.Component {
                         return AccountStore.getState().myIgnoredAccounts;
                     },
                     accountsReady: () => {
-                        return AccountStore.getState().accountsLoaded && AccountStore.getState().refsLoaded;
+                        return (
+                            AccountStore.getState().accountsLoaded &&
+                            AccountStore.getState().refsLoaded
+                        );
                     },
                     passwordAccount: () => {
                         return AccountStore.getState().passwordAccount;
@@ -32,8 +38,12 @@ class AccountsContainer extends React.Component {
                     lowVolumeMarkets: () => {
                         return MarketsStore.getState().lowVolumeMarkets;
                     },
-                    currentEntry: SettingsStore.getState().viewSettings.get("dashboardEntry", "accounts")
-                }}>
+                    currentEntry: SettingsStore.getState().viewSettings.get(
+                        "dashboardEntry",
+                        "accounts"
+                    )
+                }}
+            >
                 <Accounts {...this.props} />
             </AltContainer>
         );
@@ -41,7 +51,6 @@ class AccountsContainer extends React.Component {
 }
 
 class Accounts extends React.Component {
-
     constructor(props) {
         super();
 
@@ -57,12 +66,16 @@ class Accounts extends React.Component {
     componentDidMount() {
         this._setDimensions();
 
-        window.addEventListener("resize", this._setDimensions, {capture: false, passive: true});
+        window.addEventListener("resize", this._setDimensions, {
+            capture: false,
+            passive: true
+        });
     }
 
     shouldComponentUpdate(nextProps, nextState) {
         return (
             nextProps.linkedAccounts !== this.props.linkedAccounts ||
+            nextProps.contacts !== this.props.contacts ||
             nextProps.ignoredAccounts !== this.props.ignoredAccounts ||
             nextProps.passwordAccount !== this.props.passwordAccount ||
             nextState.width !== this.state.width ||
@@ -100,17 +113,32 @@ class Accounts extends React.Component {
     }
 
     render() {
-        let { linkedAccounts, myIgnoredAccounts, accountsReady, passwordAccount } = this.props;
-        let {width, showIgnored, featuredMarkets, newAssets, currentEntry} = this.state;
+        let {
+            linkedAccounts,
+            myIgnoredAccounts,
+            accountsReady,
+            passwordAccount
+        } = this.props;
+        let {
+            width,
+            showIgnored,
+            featuredMarkets,
+            newAssets,
+            currentEntry
+        } = this.state;
 
         if (passwordAccount && !linkedAccounts.has(passwordAccount)) {
             linkedAccounts = linkedAccounts.add(passwordAccount);
         }
         let names = linkedAccounts.toArray().sort();
-        if (passwordAccount && names.indexOf(passwordAccount) === -1) names.push(passwordAccount);
+        if (passwordAccount && names.indexOf(passwordAccount) === -1)
+            names.push(passwordAccount);
         let ignored = myIgnoredAccounts.toArray().sort();
 
-        let accountCount = linkedAccounts.size + myIgnoredAccounts.size + (passwordAccount ? 1 : 0);
+        let accountCount =
+            linkedAccounts.size +
+            myIgnoredAccounts.size +
+            (passwordAccount ? 1 : 0);
 
         if (!accountsReady) {
             return <LoadingIndicator />;
@@ -120,9 +148,13 @@ class Accounts extends React.Component {
             return <LoginSelector />;
         }
 
+        const contacts = this.props.contacts.toArray();
         return (
             <div ref="wrapper" className="grid-block page-layout vertical">
-                <div ref="container" className="tabs-container generic-bordered-box">
+                <div
+                    ref="container"
+                    className="tabs-container generic-bordered-box"
+                >
                     <Tabs
                         setting="accountTab"
                         className="account-tabs"
@@ -135,9 +167,13 @@ class Accounts extends React.Component {
                                 <div className="box-content">
                                     <DashboardList
                                         accounts={Immutable.List(names)}
-                                        ignoredAccounts={Immutable.List(ignored)}
+                                        ignoredAccounts={Immutable.List(
+                                            ignored
+                                        )}
                                         width={width}
-                                        onToggleIgnored={this._onToggleIgnored.bind(this)}
+                                        onToggleIgnored={this._onToggleIgnored.bind(
+                                            this
+                                        )}
                                         showIgnored={showIgnored}
                                         showMyAccounts={true}
                                     />
@@ -148,11 +184,15 @@ class Accounts extends React.Component {
                             <div className="generic-bordered-box">
                                 <div className="box-content">
                                     <DashboardList
-                                        accounts={Immutable.List(names)}
+                                        accounts={contacts}
                                         passwordAccount={passwordAccount}
-                                        ignoredAccounts={Immutable.List(ignored)}
+                                        ignoredAccounts={Immutable.List(
+                                            ignored
+                                        )}
                                         width={width}
-                                        onToggleIgnored={this._onToggleIgnored.bind(this)}
+                                        onToggleIgnored={this._onToggleIgnored.bind(
+                                            this
+                                        )}
                                         showIgnored={showIgnored}
                                         showMyAccounts={false}
                                     />
@@ -176,7 +216,7 @@ class Accounts extends React.Component {
     }
 }
 
-const DashboardAccountsOnly = (props) => {
+const DashboardAccountsOnly = props => {
     return <AccountsContainer {...props} onlyAccounts />;
 };
 

--- a/app/components/Dashboard/DashboardAccountsOnly.jsx
+++ b/app/components/Dashboard/DashboardAccountsOnly.jsx
@@ -194,7 +194,7 @@ class Accounts extends React.Component {
                                             this
                                         )}
                                         showIgnored={showIgnored}
-                                        showMyAccounts={false}
+                                        isContactsList={true}
                                     />
                                 </div>
                             </div>

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -69,6 +69,7 @@ class DashboardList extends React.Component {
     shouldComponentUpdate(nextProps, nextState) {
         return (
             !utils.are_equal_shallow(nextProps.accounts, this.props.accounts) ||
+            nextProps.isContactsList !== this.props.isContactsList ||
             nextProps.showMyAccounts !== this.props.showMyAccounts ||
             nextProps.width !== this.props.width ||
             nextProps.showIgnored !== this.props.showIgnored ||
@@ -138,7 +139,7 @@ class DashboardList extends React.Component {
         const {
             width,
             starredAccounts,
-            showMyAccounts,
+            isContactsList,
             passwordAccount
         } = this.props;
         const {dashboardFilter, sortBy, inverseSort} = this.state;
@@ -151,8 +152,13 @@ class DashboardList extends React.Component {
                 let isMyAccount =
                     AccountStore.isMyAccount(account) ||
                     accountName === passwordAccount;
-
-                return isMyAccount === this.props.showMyAccounts;
+                /*
+                Display all accounts from contacts list
+                Display only my Accounts for Accounts page
+                */
+                return isContactsList
+                    ? true
+                    : isMyAccount === this.props.showMyAccounts;
             })
             .filter(a => {
                 if (!a) return false;
@@ -291,7 +297,7 @@ class DashboardList extends React.Component {
                             >
                                 <Icon className={starClass} name="fi-star" />
                             </td>
-                            {!showMyAccounts
+                            {isContactsList
                                 ? (isHiddenAccountsList && (
                                       <td
                                           onClick={this._onAddContact.bind(
@@ -404,14 +410,14 @@ class DashboardList extends React.Component {
     }
 
     render() {
-        let {width, showIgnored, showMyAccounts} = this.props;
+        let {width, showIgnored, isContactsList} = this.props;
         const {dashboardFilter} = this.state;
 
         let includedAccounts = this._renderList(this.props.accounts);
 
         let hiddenAccounts = this._renderList(this.props.ignoredAccounts, true);
 
-        let filterText = showMyAccounts
+        let filterText = !isContactsList
             ? counterpart.translate("explorer.accounts.filter")
             : counterpart.translate("explorer.accounts.filter_contacts");
         filterText += "...";
@@ -479,7 +485,7 @@ class DashboardList extends React.Component {
                                         name="fi-star"
                                     />
                                 </th>
-                                {!showMyAccounts ? (
+                                {isContactsList ? (
                                     <th>
                                         <Icon name="user" />
                                     </th>

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -73,7 +73,6 @@ class DashboardList extends React.Component {
             nextProps.width !== this.props.width ||
             nextProps.showIgnored !== this.props.showIgnored ||
             nextProps.locked !== this.props.locked ||
-            nextProps.linkedAccounts !== this.props.linkedAccounts ||
             nextProps.passwordAccount !== this.props.passwordAccount ||
             !utils.are_equal_shallow(
                 nextProps.starredAccounts,
@@ -125,16 +124,6 @@ class DashboardList extends React.Component {
             dashboardSort: field,
             dashboardSortInverse: inverse
         });
-    }
-
-    _onUnLinkAccount(account, e) {
-        e.preventDefault();
-        AccountActions.unlinkAccount(account);
-    }
-
-    _onLinkAccount(account, e) {
-        e.preventDefault();
-        AccountActions.linkAccount(account);
     }
 
     _onAddContact(account) {
@@ -565,7 +554,6 @@ export default connect(AccountsListWrapper, {
         return {
             locked: WalletUnlockStore.getState().locked,
             starredAccounts: AccountStore.getState().starredAccounts,
-            linkedAccounts: AccountStore.getState().linkedAccounts,
             viewSettings: SettingsStore.getState().viewSettings
         };
     }

--- a/app/components/Dashboard/DashboardList.jsx
+++ b/app/components/Dashboard/DashboardList.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Immutable from "immutable";
 import utils from "common/utils";
 import Translate from "react-translate-component";
-import { connect } from "alt-react";
+import {connect} from "alt-react";
 import SettingsStore from "stores/SettingsStore";
 import WalletUnlockStore from "stores/WalletUnlockStore";
 import ChainTypes from "../Utility/ChainTypes";
@@ -17,327 +17,556 @@ import counterpart from "counterpart";
 import WalletDb from "stores/WalletDb";
 
 const starSort = function(a, b, inverse, starredAccounts) {
-	let aName = a.get("name");
-	let bName = b.get("name");
-	let aStarred = starredAccounts.has(aName);
-	let bStarred = starredAccounts.has(bName);
+    let aName = a.get("name");
+    let bName = b.get("name");
+    let aStarred = starredAccounts.has(aName);
+    let bStarred = starredAccounts.has(bName);
 
-	if (aStarred && !bStarred) {
-		return inverse ? -1 : 1;
-	} else if (bStarred && !aStarred) {
-		return inverse ? 1 : -1;
-	} else {
-		if (aName > bName) {
-			return inverse ? 1 : -1;
-		} else if (aName < bName) {
-			return inverse ? -1 : 1;
-		} else {
-			return utils.sortText(aName, bName, !inverse);
-		}
-	}
+    if (aStarred && !bStarred) {
+        return inverse ? -1 : 1;
+    } else if (bStarred && !aStarred) {
+        return inverse ? 1 : -1;
+    } else {
+        if (aName > bName) {
+            return inverse ? 1 : -1;
+        } else if (aName < bName) {
+            return inverse ? -1 : 1;
+        } else {
+            return utils.sortText(aName, bName, !inverse);
+        }
+    }
 };
 
-
 class DashboardList extends React.Component {
-	static contextTypes = {
-		router: React.PropTypes.object.isRequired
-	}
+    static contextTypes = {
+        router: React.PropTypes.object.isRequired
+    };
 
-	static propTypes = {
-		accounts: ChainTypes.ChainAccountsList.isRequired,
-		ignoredAccounts: ChainTypes.ChainAccountsList
-	};
+    static propTypes = {
+        accounts: ChainTypes.ChainAccountsList.isRequired,
+        ignoredAccounts: ChainTypes.ChainAccountsList
+    };
 
-	static defaultProps = {
-		width: 2000,
-		compact: false
-	};
+    static defaultProps = {
+        width: 2000,
+        compact: false
+    };
 
-	constructor(props) {
-		super();
-		let inputValue = props.viewSettings.get("marketLookupInput");
-		let symbols = inputValue ? inputValue.split(":") : [null];
-		let quote = symbols[0];
-		let base = symbols.length === 2 ? symbols[1] : null;
+    constructor(props) {
+        super();
+        let inputValue = props.viewSettings.get("marketLookupInput");
+        let symbols = inputValue ? inputValue.split(":") : [null];
+        let quote = symbols[0];
+        let base = symbols.length === 2 ? symbols[1] : null;
 
-		this.state = {
-			inverseSort: props.viewSettings.get("dashboardSortInverse", true),
-			sortBy: props.viewSettings.get("dashboardSort", "star"),
-			dashboardFilter: props.viewSettings.get("dashboardFilter", "")
-		};
+        this.state = {
+            inverseSort: props.viewSettings.get("dashboardSortInverse", true),
+            sortBy: props.viewSettings.get("dashboardSort", "star"),
+            dashboardFilter: props.viewSettings.get("dashboardFilter", "")
+        };
+    }
 
-	}
+    shouldComponentUpdate(nextProps, nextState) {
+        return (
+            !utils.are_equal_shallow(nextProps.accounts, this.props.accounts) ||
+            nextProps.showMyAccounts !== this.props.showMyAccounts ||
+            nextProps.width !== this.props.width ||
+            nextProps.showIgnored !== this.props.showIgnored ||
+            nextProps.locked !== this.props.locked ||
+            nextProps.linkedAccounts !== this.props.linkedAccounts ||
+            nextProps.passwordAccount !== this.props.passwordAccount ||
+            !utils.are_equal_shallow(
+                nextProps.starredAccounts,
+                this.props.starredAccounts
+            ) ||
+            !utils.are_equal_shallow(nextState, this.state)
+        );
+    }
 
-	shouldComponentUpdate(nextProps, nextState) {
-
-		return (
-			!utils.are_equal_shallow(nextProps.accounts, this.props.accounts) ||
-			nextProps.showMyAccounts !== this.props.showMyAccounts ||
-			nextProps.width !== this.props.width ||
-			nextProps.showIgnored !== this.props.showIgnored ||
-			nextProps.locked !== this.props.locked ||
-			nextProps.linkedAccounts !== this.props.linkedAccounts ||
-			nextProps.passwordAccount !== this.props.passwordAccount ||
-			!utils.are_equal_shallow(nextProps.starredAccounts, this.props.starredAccounts) ||
-			!utils.are_equal_shallow(nextState, this.state )
-		);
-
-	}
-
-	_onStar(account, isStarred, e) {
-		e.preventDefault();
-		if (!isStarred) {
-			AccountActions.addStarAccount(account);
-		} else {
-			AccountActions.removeStarAccount(account);
-		}
-	}
-
-	_goAccount(name, tab) {
-		this.context.router.push(`/account/${name}`);
-		SettingsActions.changeViewSetting({
-			overviewTab: tab
-		});
-	}
-
-        _createAccount() {
-            this.context.router.push("/create-account/wallet");
+    _onStar(account, isStarred, e) {
+        e.preventDefault();
+        if (!isStarred) {
+            AccountActions.addStarAccount(account);
+        } else {
+            AccountActions.removeStarAccount(account);
         }
+    }
 
-	_onFilter(e) {
-		this.setState({dashboardFilter: e.target.value.toLowerCase()});
+    _goAccount(name, tab) {
+        this.context.router.push(`/account/${name}`);
+        SettingsActions.changeViewSetting({
+            overviewTab: tab
+        });
+    }
 
-		SettingsActions.changeViewSetting({
-			dashboardFilter: e.target.value.toLowerCase()
-		});
-	}
+    _createAccount() {
+        this.context.router.push("/create-account/wallet");
+    }
 
-	_setSort(field) {
-		let inverse = field === this.state.sortBy ? !this.state.inverseSort : this.state.inverseSort;
-		this.setState({
-			sortBy: field,
-			inverseSort: inverse
-		});
+    _onFilter(e) {
+        this.setState({dashboardFilter: e.target.value.toLowerCase()});
 
-		SettingsActions.changeViewSetting({
-			dashboardSort: field,
-			dashboardSortInverse: inverse
-		});
-	}
+        SettingsActions.changeViewSetting({
+            dashboardFilter: e.target.value.toLowerCase()
+        });
+    }
 
-	_onUnLinkAccount(account, e) {
-		e.preventDefault();
-		AccountActions.unlinkAccount(account);
-	}
+    _setSort(field) {
+        let inverse =
+            field === this.state.sortBy
+                ? !this.state.inverseSort
+                : this.state.inverseSort;
+        this.setState({
+            sortBy: field,
+            inverseSort: inverse
+        });
+
+        SettingsActions.changeViewSetting({
+            dashboardSort: field,
+            dashboardSortInverse: inverse
+        });
+    }
+
+    _onUnLinkAccount(account, e) {
+        e.preventDefault();
+        AccountActions.unlinkAccount(account);
+    }
 
     _onLinkAccount(account, e) {
         e.preventDefault();
         AccountActions.linkAccount(account);
     }
 
-	_renderList(accounts, isHiddenAccountsList) {
+    _onAddContact(account) {
+        AccountActions.addAccountContact(account);
+    }
 
-		const {width, starredAccounts, showMyAccounts, passwordAccount} = this.props;
-		const {dashboardFilter, sortBy, inverseSort} = this.state;
-		let balanceList = Immutable.List();
+    _onRemoveContact(account) {
+        AccountActions.removeAccountContact(account);
+    }
 
-		return accounts
-		.filter(account => {
-			let accountName = account.get("name");
-			let isMyAccount = AccountStore.isMyAccount(account) || accountName === passwordAccount;
+    _renderList(accounts, isHiddenAccountsList) {
+        const {
+            width,
+            starredAccounts,
+            showMyAccounts,
+            passwordAccount
+        } = this.props;
+        const {dashboardFilter, sortBy, inverseSort} = this.state;
+        let balanceList = Immutable.List();
 
-			return (isMyAccount === this.props.showMyAccounts);
-		})
-		.filter(a => {
-			if (!a) return false;
-			return a.get("name").toLowerCase().indexOf(dashboardFilter) !== -1;
-		})
-		.sort((a, b) => {
-			switch (sortBy) {
-				case "star":
-					return starSort(a, b, inverseSort, starredAccounts);
-					break;
+        return accounts
+            .filter(account => {
+                if (!account) return false;
+                let accountName = account.get("name");
+                let isMyAccount =
+                    AccountStore.isMyAccount(account) ||
+                    accountName === passwordAccount;
 
-				case "name":
-					return utils.sortText(a.get("name"), b.get("name"), inverseSort);
-					break;
+                return isMyAccount === this.props.showMyAccounts;
+            })
+            .filter(a => {
+                if (!a) return false;
+                return (
+                    a
+                        .get("name")
+                        .toLowerCase()
+                        .indexOf(dashboardFilter) !== -1
+                );
+            })
+            .sort((a, b) => {
+                switch (sortBy) {
+                    case "star":
+                        return starSort(a, b, inverseSort, starredAccounts);
+                        break;
 
-				default:
-					break;
-			}
-		}).map(account => {
+                    case "name":
+                        return utils.sortText(
+                            a.get("name"),
+                            b.get("name"),
+                            inverseSort
+                        );
+                        break;
 
-			if (account) {
-				let collateral = {}, debt = {}, openOrders = {};
-				balanceList = balanceList.clear();
+                    default:
+                        break;
+                }
+            })
+            .map(account => {
+                if (account) {
+                    let collateral = {},
+                        debt = {},
+                        openOrders = {};
+                    balanceList = balanceList.clear();
 
-				let accountName = account.get("name");
-				let isLTM = account.get("lifetime_referrer_name") === accountName;
+                    let accountName = account.get("name");
+                    let isLTM =
+                        account.get("lifetime_referrer_name") === accountName;
 
-				if (account.get("orders")) {
-					account.get("orders").forEach( (orderID, key) => {
-						let order = ChainStore.getObject(orderID);
-						if (order) {
-							let orderAsset = order.getIn(["sell_price", "base", "asset_id"]);
-							if (!openOrders[orderAsset]) {
-								openOrders[orderAsset] = parseInt(order.get("for_sale"), 10);
-							} else {
-								openOrders[orderAsset] += parseInt(order.get("for_sale"), 10);
-							}
-						}
-					});
-				}
+                    if (account.get("orders")) {
+                        account.get("orders").forEach((orderID, key) => {
+                            let order = ChainStore.getObject(orderID);
+                            if (order) {
+                                let orderAsset = order.getIn([
+                                    "sell_price",
+                                    "base",
+                                    "asset_id"
+                                ]);
+                                if (!openOrders[orderAsset]) {
+                                    openOrders[orderAsset] = parseInt(
+                                        order.get("for_sale"),
+                                        10
+                                    );
+                                } else {
+                                    openOrders[orderAsset] += parseInt(
+                                        order.get("for_sale"),
+                                        10
+                                    );
+                                }
+                            }
+                        });
+                    }
 
-				// console.log("openOrders:", openOrders);
+                    // console.log("openOrders:", openOrders);
 
-				if (account.get("call_orders")) {
-					account.get("call_orders").forEach( (callID, key) => {
-						let position = ChainStore.getObject(callID);
-						if (position) {
-							let collateralAsset = position.getIn(["call_price", "base", "asset_id"]);
-			                if (!collateral[collateralAsset]) {
-			                    collateral[collateralAsset] = parseInt(position.get("collateral"), 10);
-			                } else {
-			                    collateral[collateralAsset] += parseInt(position.get("collateral"), 10);
-			                }
-							let debtAsset = position.getIn(["call_price", "quote", "asset_id"]);
-							if (!debt[debtAsset]) {
-								debt[debtAsset] = parseInt(position.get("debt"), 10);
-							} else {
-								debt[debtAsset] += parseInt(position.get("debt"), 10);
-							}
-						}
-					});
-				}
+                    if (account.get("call_orders")) {
+                        account.get("call_orders").forEach((callID, key) => {
+                            let position = ChainStore.getObject(callID);
+                            if (position) {
+                                let collateralAsset = position.getIn([
+                                    "call_price",
+                                    "base",
+                                    "asset_id"
+                                ]);
+                                if (!collateral[collateralAsset]) {
+                                    collateral[collateralAsset] = parseInt(
+                                        position.get("collateral"),
+                                        10
+                                    );
+                                } else {
+                                    collateral[collateralAsset] += parseInt(
+                                        position.get("collateral"),
+                                        10
+                                    );
+                                }
+                                let debtAsset = position.getIn([
+                                    "call_price",
+                                    "quote",
+                                    "asset_id"
+                                ]);
+                                if (!debt[debtAsset]) {
+                                    debt[debtAsset] = parseInt(
+                                        position.get("debt"),
+                                        10
+                                    );
+                                } else {
+                                    debt[debtAsset] += parseInt(
+                                        position.get("debt"),
+                                        10
+                                    );
+                                }
+                            }
+                        });
+                    }
 
-				let account_balances = account.get("balances");
-				if (account.get("balances")) {
-					account_balances.forEach( balance => {
-						let balanceAmount = ChainStore.getObject(balance);
-						if (!balanceAmount || !balanceAmount.get("balance")) {
-							return null;
-						}
-						balanceList = balanceList.push(balance);
-					});
-				}
+                    let account_balances = account.get("balances");
+                    if (account.get("balances")) {
+                        account_balances.forEach(balance => {
+                            let balanceAmount = ChainStore.getObject(balance);
+                            if (
+                                !balanceAmount ||
+                                !balanceAmount.get("balance")
+                            ) {
+                                return null;
+                            }
+                            balanceList = balanceList.push(balance);
+                        });
+                    }
 
-				let isMyAccount = AccountStore.isMyAccount(account) || accountName === passwordAccount;
+                    let isMyAccount =
+                        AccountStore.isMyAccount(account) ||
+                        accountName === passwordAccount;
 
-				let isStarred = starredAccounts.has(accountName);
-				let starClass = isStarred ? "gold-star" : "grey-star";
+                    let isStarred = starredAccounts.has(accountName);
+                    let starClass = isStarred ? "gold-star" : "grey-star";
 
-				return (
-					<tr key={accountName}>
-						<td className="clickable" onClick={this._onStar.bind(this, accountName, isStarred)}>
-							<Icon className={starClass} name="fi-star"/>
-						</td>
-						{!showMyAccounts ? (isHiddenAccountsList && (
-                                <td onClick={this._onLinkAccount.bind(this, accountName)}>
-                                    <Icon name="plus-circle"/>
+                    return (
+                        <tr key={accountName}>
+                            <td
+                                className="clickable"
+                                onClick={this._onStar.bind(
+                                    this,
+                                    accountName,
+                                    isStarred
+                                )}
+                            >
+                                <Icon className={starClass} name="fi-star" />
+                            </td>
+                            {!showMyAccounts
+                                ? (isHiddenAccountsList && (
+                                      <td
+                                          onClick={this._onAddContact.bind(
+                                              this,
+                                              accountName
+                                          )}
+                                      >
+                                          <Icon name="plus-circle" />
+                                      </td>
+                                  )) || (
+                                      <td
+                                          onClick={this._onRemoveContact.bind(
+                                              this,
+                                              accountName
+                                          )}
+                                      >
+                                          <Icon name="minus-circle" />
+                                      </td>
+                                  )
+                                : null}
+                            <td style={{textAlign: "left"}}>
+                                {account.get("id")}
+                            </td>
+                            <td
+                                style={{textAlign: "left", paddingLeft: 10}}
+                                onClick={this._goAccount.bind(
+                                    this,
+                                    accountName,
+                                    0
+                                )}
+                                className={
+                                    "clickable" +
+                                    (isMyAccount ? " my-account" : "")
+                                }
+                            >
+                                <span className={isLTM ? "lifetime" : ""}>
+                                    {accountName}
+                                </span>
+                            </td>
+                            <td
+                                className="clickable"
+                                onClick={this._goAccount.bind(
+                                    this,
+                                    accountName,
+                                    1
+                                )}
+                                style={{textAlign: "right"}}
+                            >
+                                <TotalBalanceValue
+                                    noTip
+                                    balances={[]}
+                                    openOrders={openOrders}
+                                />
+                            </td>
+                            {width >= 750 ? (
+                                <td
+                                    className="clickable"
+                                    onClick={this._goAccount.bind(
+                                        this,
+                                        accountName,
+                                        2
+                                    )}
+                                    style={{textAlign: "right"}}
+                                >
+                                    <TotalBalanceValue
+                                        noTip
+                                        balances={[]}
+                                        collateral={collateral}
+                                    />
                                 </td>
-                            ) || (
-                                <td onClick={this._onUnLinkAccount.bind(this, accountName)}>
-                                    <Icon name="minus-circle"/>
+                            ) : null}
+                            {width >= 1200 ? (
+                                <td
+                                    className="clickable"
+                                    onClick={this._goAccount.bind(
+                                        this,
+                                        accountName,
+                                        2
+                                    )}
+                                    style={{textAlign: "right"}}
+                                >
+                                    <TotalBalanceValue
+                                        noTip
+                                        balances={[]}
+                                        debt={debt}
+                                    />
                                 </td>
-                            ))
-						: null}
-						<td style={{textAlign: "left"}}>
-							{ account.get("id") }
-						</td>
-						<td style={{textAlign: "left", paddingLeft: 10}} onClick={this._goAccount.bind(this, accountName, 0)} className={"clickable" + (isMyAccount ? " my-account" : "")}>
-							<span className={isLTM ? "lifetime" : ""}>{accountName}</span>
-						</td>
-						<td className="clickable" onClick={this._goAccount.bind(this, accountName, 1)} style={{textAlign: "right"}}>
-							<TotalBalanceValue noTip balances={[]} openOrders={openOrders}/>
-						</td>
-						{width >= 750 ? <td className="clickable" onClick={this._goAccount.bind(this, accountName, 2)} style={{textAlign: "right"}}>
-							<TotalBalanceValue noTip balances={[]} collateral={collateral}/>
-						</td> : null}
-						{width >= 1200 ? <td className="clickable" onClick={this._goAccount.bind(this, accountName, 2)} style={{textAlign: "right"}}>
-							<TotalBalanceValue noTip balances={[]} debt={debt}/>
-						</td> : null}
-						<td className="clickable" onClick={this._goAccount.bind(this, accountName, 0)} style={{textAlign: "right"}}>
-							<TotalBalanceValue noTip balances={balanceList} collateral={collateral} debt={debt} openOrders={openOrders}/>
-						</td>
-					</tr>
-				);
-			}
-		});
-	}
+                            ) : null}
+                            <td
+                                className="clickable"
+                                onClick={this._goAccount.bind(
+                                    this,
+                                    accountName,
+                                    0
+                                )}
+                                style={{textAlign: "right"}}
+                            >
+                                <TotalBalanceValue
+                                    noTip
+                                    balances={balanceList}
+                                    collateral={collateral}
+                                    debt={debt}
+                                    openOrders={openOrders}
+                                />
+                            </td>
+                        </tr>
+                    );
+                }
+            });
+    }
 
-	render() {
+    render() {
+        let {width, showIgnored, showMyAccounts} = this.props;
+        const {dashboardFilter} = this.state;
 
-		let { width, showIgnored, showMyAccounts } = this.props;
-		const { dashboardFilter } = this.state;
+        let includedAccounts = this._renderList(this.props.accounts);
 
-		let includedAccounts = this._renderList(this.props.accounts);
+        let hiddenAccounts = this._renderList(this.props.ignoredAccounts, true);
 
-		let hiddenAccounts = this._renderList(this.props.ignoredAccounts, true);
+        let filterText = showMyAccounts
+            ? counterpart.translate("explorer.accounts.filter")
+            : counterpart.translate("explorer.accounts.filter_contacts");
+        filterText += "...";
 
-		let filterText = (showMyAccounts) ? counterpart.translate("explorer.accounts.filter") : counterpart.translate("explorer.accounts.filter_contacts");
-		filterText += "...";
+        let hasLocalWallet = !!WalletDb.getWallet();
 
-		let hasLocalWallet = !!WalletDb.getWallet();
-
-		return (
-			<div style={this.props.style}>
-				{!this.props.compact ? (
-					<section style={{paddingTop: "1rem", paddingLeft: "2rem"}}>
-						<input placeholder={filterText} style={{maxWidth: "20rem", display:"inline-block"}} type="text" value={dashboardFilter} onChange={this._onFilter.bind(this)} />
-							{hasLocalWallet ? (<div onClick={this._createAccount.bind(this)} style={{display: "inline-block", marginLeft: 5, marginBottom: "1rem"}} className="button small">
-							<Translate content="header.create_account" />
-						</div>):null}
-                        {hiddenAccounts && hiddenAccounts.length ? <div onClick={this.props.onToggleIgnored} style={{display: "inline-block",float:"right",marginRight:"20px"}} className="button small">
-							<Translate content={`account.${ this.props.showIgnored ? "hide_ignored" : "show_ignored" }`} />
-						</div>:null}
-					</section>) : null}
-				<table className="table table-hover dashboard-table" style={{fontSize: "0.85rem"}}>
-					{!this.props.compact ? (
-					<thead>
-						<tr>
-							<th onClick={this._setSort.bind(this, "star")} className="clickable"><Icon className="grey-star" name="fi-star"/></th>
-							{!showMyAccounts ? <th><Icon name="user"/></th> : null}
-							<th style={{textAlign: "left"}}>ID</th>
-							<th style={{textAlign: "left", paddingLeft: 10}} onClick={this._setSort.bind(this, "name")} className="clickable"><Translate content="header.account" /></th>
-							<th style={{textAlign: "right"}}><Translate content="account.open_orders" /></th>
-							{width >= 750 ? <th style={{textAlign: "right"}}><Translate content="account.as_collateral" /></th> : null}
-							{width >= 1200 ? <th style={{textAlign: "right"}}><Translate content="transaction.borrow_amount" /></th> : null}
-							<th style={{textAlign: "right", marginRight: 20}}><Translate content="account.total_value" /></th>
-						</tr>
-					</thead>) : null}
-					<tbody>
-						{includedAccounts}
-						{showIgnored && hiddenAccounts.length ? <tr className="dashboard-table--hiddenAccounts" style={{backgroundColor: "transparent"}} key="hidden"><td colSpan="8">{ counterpart.translate("account.hidden_accounts_row") }:</td></tr> : null}
-						{showIgnored && hiddenAccounts}
-					</tbody>
-				</table>
-			</div>
-		);
-	}
+        return (
+            <div style={this.props.style}>
+                {!this.props.compact ? (
+                    <section style={{paddingTop: "1rem", paddingLeft: "2rem"}}>
+                        <input
+                            placeholder={filterText}
+                            style={{maxWidth: "20rem", display: "inline-block"}}
+                            type="text"
+                            value={dashboardFilter}
+                            onChange={this._onFilter.bind(this)}
+                        />
+                        {hasLocalWallet ? (
+                            <div
+                                onClick={this._createAccount.bind(this)}
+                                style={{
+                                    display: "inline-block",
+                                    marginLeft: 5,
+                                    marginBottom: "1rem"
+                                }}
+                                className="button small"
+                            >
+                                <Translate content="header.create_account" />
+                            </div>
+                        ) : null}
+                        {hiddenAccounts && hiddenAccounts.length ? (
+                            <div
+                                onClick={this.props.onToggleIgnored}
+                                style={{
+                                    display: "inline-block",
+                                    float: "right",
+                                    marginRight: "20px"
+                                }}
+                                className="button small"
+                            >
+                                <Translate
+                                    content={`account.${
+                                        this.props.showIgnored
+                                            ? "hide_ignored"
+                                            : "show_ignored"
+                                    }`}
+                                />
+                            </div>
+                        ) : null}
+                    </section>
+                ) : null}
+                <table
+                    className="table table-hover dashboard-table"
+                    style={{fontSize: "0.85rem"}}
+                >
+                    {!this.props.compact ? (
+                        <thead>
+                            <tr>
+                                <th
+                                    onClick={this._setSort.bind(this, "star")}
+                                    className="clickable"
+                                >
+                                    <Icon
+                                        className="grey-star"
+                                        name="fi-star"
+                                    />
+                                </th>
+                                {!showMyAccounts ? (
+                                    <th>
+                                        <Icon name="user" />
+                                    </th>
+                                ) : null}
+                                <th style={{textAlign: "left"}}>ID</th>
+                                <th
+                                    style={{textAlign: "left", paddingLeft: 10}}
+                                    onClick={this._setSort.bind(this, "name")}
+                                    className="clickable"
+                                >
+                                    <Translate content="header.account" />
+                                </th>
+                                <th style={{textAlign: "right"}}>
+                                    <Translate content="account.open_orders" />
+                                </th>
+                                {width >= 750 ? (
+                                    <th style={{textAlign: "right"}}>
+                                        <Translate content="account.as_collateral" />
+                                    </th>
+                                ) : null}
+                                {width >= 1200 ? (
+                                    <th style={{textAlign: "right"}}>
+                                        <Translate content="transaction.borrow_amount" />
+                                    </th>
+                                ) : null}
+                                <th
+                                    style={{
+                                        textAlign: "right",
+                                        marginRight: 20
+                                    }}
+                                >
+                                    <Translate content="account.total_value" />
+                                </th>
+                            </tr>
+                        </thead>
+                    ) : null}
+                    <tbody>
+                        {includedAccounts}
+                        {showIgnored && hiddenAccounts.length ? (
+                            <tr
+                                className="dashboard-table--hiddenAccounts"
+                                style={{backgroundColor: "transparent"}}
+                                key="hidden"
+                            >
+                                <td colSpan="8">
+                                    {counterpart.translate(
+                                        "account.hidden_accounts_row"
+                                    )}:
+                                </td>
+                            </tr>
+                        ) : null}
+                        {showIgnored && hiddenAccounts}
+                    </tbody>
+                </table>
+            </div>
+        );
+    }
 }
 DashboardList = BindToChainState(DashboardList);
 
 class AccountsListWrapper extends React.Component {
-
-	render () {
-		return (
-			<DashboardList
-				{...this.props}
-			/>
-		);
-	}
+    render() {
+        return <DashboardList {...this.props} />;
+    }
 }
 
 export default connect(AccountsListWrapper, {
-	listenTo() {
-		return [SettingsStore, WalletUnlockStore, AccountStore];
-	},
-	getProps() {
-		return {
-			locked: WalletUnlockStore.getState().locked,
-			starredAccounts: AccountStore.getState().starredAccounts,
-			linkedAccounts: AccountStore.getState().linkedAccounts,
-			viewSettings: SettingsStore.getState().viewSettings
-		};
-	}
+    listenTo() {
+        return [SettingsStore, WalletUnlockStore, AccountStore];
+    },
+    getProps() {
+        return {
+            locked: WalletUnlockStore.getState().locked,
+            starredAccounts: AccountStore.getState().starredAccounts,
+            linkedAccounts: AccountStore.getState().linkedAccounts,
+            viewSettings: SettingsStore.getState().viewSettings
+        };
+    }
 });

--- a/app/components/Explorer/Accounts.jsx
+++ b/app/components/Explorer/Accounts.jsx
@@ -25,9 +25,19 @@ class AccountRow extends React.Component {
 
     shouldComponentUpdate(nextProps) {
         return (
-            nextProps.linkedAccounts !== this.props.linkedAccounts ||
+            nextProps.contacts !== this.props.contacts ||
             nextProps.account !== this.props.account
         );
+    }
+
+    _onAddContact(account, e) {
+        e.preventDefault();
+        AccountActions.addAccountContact(account);
+    }
+
+    _onRemoveContact(account, e) {
+        e.preventDefault();
+        AccountActions.removeAccountContact(account);
     }
 
     _onLinkAccount(account, e) {
@@ -41,7 +51,7 @@ class AccountRow extends React.Component {
     }
 
     render() {
-        let {account, linkedAccounts} = this.props;
+        let {account, contacts} = this.props;
 
         let balance = account.getIn(["balances", "1.3.0"]) || null;
         let accountName = account.get("name");
@@ -49,12 +59,12 @@ class AccountRow extends React.Component {
         return (
             <tr key={account.get("id")}>
                 <td>{account.get("id")}</td>
-                {linkedAccounts.has(accountName) ? (
-                    <td onClick={this._onUnLinkAccount.bind(this, accountName)}>
+                {contacts.has(accountName) ? (
+                    <td onClick={this._onRemoveContact.bind(this, accountName)}>
                         <Icon name="minus-circle" />
                     </td>
                 ) : (
-                    <td onClick={this._onLinkAccount.bind(this, accountName)}>
+                    <td onClick={this._onAddContact.bind(this, accountName)}>
                         <Icon name="plus-circle" />
                     </td>
                 )}
@@ -92,7 +102,7 @@ AccountRowWrapper = connect(AccountRowWrapper, {
     },
     getProps() {
         return {
-            linkedAccounts: AccountStore.getState().linkedAccounts
+            contacts: AccountStore.getState().accountContacts
         };
     }
 });

--- a/app/components/Transfer/Transfer.jsx
+++ b/app/components/Transfer/Transfer.jsx
@@ -502,6 +502,17 @@ class Transfer extends React.Component {
 
         const contactsList = this.props.contactsList.toArray();
 
+        const receiverProps = contactsList.length
+            ? {
+                  typeahead: contactsList,
+                  typeaheadOptions: {
+                      typeaheadVisibleStyle: {
+                          paddingBottom: "1rem"
+                      }
+                  }
+              }
+            : {};
+
         return (
             <div className="grid-block vertical">
                 <div
@@ -540,12 +551,6 @@ class Transfer extends React.Component {
                             <AccountSelector
                                 label="transfer.to"
                                 accountName={to_name}
-                                typeahead={contactsList}
-                                typeaheadOptions={{
-                                    typeaheadVisibleStyle: {
-                                        paddingBottom: "1rem"
-                                    }
-                                }}
                                 onChange={this.toChanged.bind(this)}
                                 onAccountChanged={this.onToAccountChanged.bind(
                                     this
@@ -553,6 +558,7 @@ class Transfer extends React.Component {
                                 account={to_name}
                                 size={60}
                                 tabIndex={tabIndex++}
+                                {...receiverProps}
                             />
                         </div>
                         {/*  A M O U N T   */}

--- a/app/components/Transfer/Transfer.jsx
+++ b/app/components/Transfer/Transfer.jsx
@@ -541,6 +541,11 @@ class Transfer extends React.Component {
                                 label="transfer.to"
                                 accountName={to_name}
                                 typeahead={contactsList}
+                                typeaheadOptions={{
+                                    typeaheadVisibleStyle: {
+                                        paddingBottom: "1rem"
+                                    }
+                                }}
                                 onChange={this.toChanged.bind(this)}
                                 onAccountChanged={this.onToAccountChanged.bind(
                                     this

--- a/app/components/Utility/TypeAhead.js
+++ b/app/components/Utility/TypeAhead.js
@@ -157,10 +157,13 @@ export default class TypeAhead extends React.Component {
 
     render() {
         const {isMenuShowing} = this.state || {};
+
+        const style = isMenuShowing ? this.props.typeaheadVisibleStyle : {};
+
         return (
             <div
                 className="typeahead"
-                style={{paddingBottom: isMenuShowing ? "1rem" : ""}} // Something is making the typeahead take less space when dropdown is open. Add extra padding for now...
+                style={style} // Something is making the typeahead take less space when dropdown is open. Add extra padding for now...
             >
                 {!!this.props.label ? (
                     <label className="left-label">

--- a/app/stores/AccountStore.js
+++ b/app/stores/AccountStore.js
@@ -34,7 +34,9 @@ class AccountStore extends BaseStore {
             onChangeSetting: SettingsActions.changeSetting,
             onSetWallet: WalletActions.setWallet,
             onAddStarAccount: AccountActions.addStarAccount,
-            onRemoveStarAccount: AccountActions.removeStarAccount
+            onRemoveStarAccount: AccountActions.removeStarAccount,
+            onAddAccountContact: AccountActions.addAccountContact,
+            onRemoveAccountContact: AccountActions.removeAccountContact
             // onNewPrivateKeys: [ PrivateKeyActions.loadDbData, PrivateKeyActions.addKey ]
         });
 
@@ -60,6 +62,7 @@ class AccountStore extends BaseStore {
             passwordAccount: null,
             starredAccounts: Immutable.Map(),
             searchAccounts: Immutable.Map(),
+            accountContacts: Immutable.Set(),
             referralAccount
         };
 
@@ -117,6 +120,12 @@ class AccountStore extends BaseStore {
                     )
                 ),
                 linkedAccounts: Immutable.Set(),
+                accountContacts: Immutable.Set(
+                    accountStorage.get(
+                        this._getStorageKey("accountContacts", {wallet_name}),
+                        []
+                    )
+                ),
                 myIgnoredAccounts: Immutable.Set(),
                 unFollowedAccounts: Immutable.Set()
             });
@@ -134,6 +143,14 @@ class AccountStore extends BaseStore {
                 this._getStorageKey("starredAccounts", {wallet_name})
             )
         );
+
+        let accountContacts = Immutable.Set(
+            accountStorage.get(
+                this._getStorageKey("accountContacts", {wallet_name}),
+                []
+            )
+        );
+
         return {
             update: false,
             subbed: false,
@@ -153,7 +170,8 @@ class AccountStore extends BaseStore {
             searchAccounts: Immutable.Map(),
             searchTerm: "",
             wallet_name,
-            starredAccounts
+            starredAccounts,
+            accountContacts
         };
     }
 
@@ -513,6 +531,40 @@ class AccountStore extends BaseStore {
                     this.setCurrentAccount(account.name);
                 }
             });
+    }
+
+    onAddAccountContact(name) {
+        if (!ChainValidation.is_account_name(name, true))
+            throw new Error("Invalid account name: " + name);
+
+        if (!this.state.accountContacts.has(name)) {
+            const accountContacts = this.state.accountContacts.add(name);
+            accountStorage.set(
+                this._getStorageKey("accountContacts"),
+                accountContacts.toArray()
+            );
+            this.setState({
+                accountContacts: accountContacts
+            });
+        }
+    }
+
+    onRemoveAccountContact(name) {
+        if (!ChainValidation.is_account_name(name, true))
+            throw new Error("Invalid account name: " + name);
+
+        if (this.state.accountContacts.has(name)) {
+            const accountContacts = this.state.accountContacts.remove(name);
+
+            accountStorage.set(
+                this._getStorageKey("accountContacts"),
+                accountContacts
+            );
+
+            this.setState({
+                accountContacts: accountContacts
+            });
+        }
     }
 
     onLinkAccount(name) {


### PR DESCRIPTION
Task: #1173

**Tested on MacOS**
- [x] Firefox
- [x] Opera
- [x] Chrome

**Changes**:
- Add Contacts API on AccountStore/AccountActions
- Replace Accounts Linking for Accounts Contacts on Explorer/Accounts
- Replace Accounts Linking for Accounts Contacts on Account / Contacts page
- Use isContactsList as flag for DashboadList instead of showMyAccounts (it's more logical, on previous version we used showMyAccounts to detect "Accounts"/"Contacts" tabs.
- Add typeahead for Send modal (user can see there his contacts. If contacts list empty typeahead is disabled because it looks awful and no sense when no contacts)

![gif-contacts-send](https://user-images.githubusercontent.com/35899973/37445827-5e71ced0-281a-11e8-91be-b80cc6c6bbd6.gif)


