### PR TITLE
fix wallet unlock behavior #1283

### DIFF
--- a/app/actions/WalletActions.js
+++ b/app/actions/WalletActions.js
@@ -304,74 +304,80 @@ class WalletActions {
                 );
                 let unlock = WalletUnlockActions.unlock();
 
-                let p = Promise.all([unlock, account_lookup]).then(results => {
-                    let account = results[1];
-                    //DEBUG console.log('... account',account)
-                    if (account == void 0)
-                        return Promise.reject(
-                            "Unknown account " + account_name_or_id
-                        );
-
-                    let balance_claims = [];
-                    let signer_pubkeys = {};
-                    for (let balance of balances) {
-                        let {vested_balance, public_key_string} = balance;
-
-                        //DEBUG console.log('... balance',b)
-                        let total_claimed;
-                        if (vested_balance) {
-                            if (vested_balance.amount == 0)
-                                // recently claimed
-                                continue;
-
-                            total_claimed = vested_balance.amount;
-                        } else total_claimed = balance.balance.amount;
-
-                        //assert
-                        if (
-                            vested_balance &&
-                            vested_balance.asset_id != balance.balance.asset_id
-                        )
-                            throw new Error(
-                                "Vested balance record and balance record asset_id missmatch",
-                                vested_balance.asset_id,
-                                balance.balance.asset_id
+                let p = Promise.all([unlock, account_lookup])
+                    .then(results => {
+                        let account = results[1];
+                        //DEBUG console.log('... account',account)
+                        if (account == void 0)
+                            return Promise.reject(
+                                "Unknown account " + account_name_or_id
                             );
 
-                        signer_pubkeys[public_key_string] = true;
-                        balance_claims.push({
-                            fee: {amount: "0", asset_id: "1.3.0"},
-                            deposit_to_account: account.get("id"),
-                            balance_to_claim: balance.id,
-                            balance_owner_key: public_key_string,
-                            total_claimed: {
-                                amount: total_claimed,
-                                asset_id: balance.balance.asset_id
-                            }
+                        let balance_claims = [];
+                        let signer_pubkeys = {};
+                        for (let balance of balances) {
+                            let {vested_balance, public_key_string} = balance;
+
+                            //DEBUG console.log('... balance',b)
+                            let total_claimed;
+                            if (vested_balance) {
+                                if (vested_balance.amount == 0)
+                                    // recently claimed
+                                    continue;
+
+                                total_claimed = vested_balance.amount;
+                            } else total_claimed = balance.balance.amount;
+
+                            //assert
+                            if (
+                                vested_balance &&
+                                vested_balance.asset_id !=
+                                    balance.balance.asset_id
+                            )
+                                throw new Error(
+                                    "Vested balance record and balance record asset_id missmatch",
+                                    vested_balance.asset_id,
+                                    balance.balance.asset_id
+                                );
+
+                            signer_pubkeys[public_key_string] = true;
+                            balance_claims.push({
+                                fee: {amount: "0", asset_id: "1.3.0"},
+                                deposit_to_account: account.get("id"),
+                                balance_to_claim: balance.id,
+                                balance_owner_key: public_key_string,
+                                total_claimed: {
+                                    amount: total_claimed,
+                                    asset_id: balance.balance.asset_id
+                                }
+                            });
+                        }
+                        //  if( ! balance_claims.length) {
+                        //      throw new Error("No balances to claim");
+                        //  }
+
+                        //DEBUG console.log('... balance_claims',balance_claims)
+                        let tr = new TransactionBuilder();
+
+                        for (let balance_claim of balance_claims) {
+                            tr.add_type_operation(
+                                "balance_claim",
+                                balance_claim
+                            );
+                        }
+                        // With a lot of balance claims the signing can take so Long
+                        // the transaction will expire.  This will increase the timeout...
+                        tr.set_expire_seconds(15 * 60 + balance_claims.length);
+                        return WalletDb.process_transaction(
+                            tr,
+                            Object.keys(signer_pubkeys),
+                            broadcast
+                        ).then(result => {
+                            dispatch(true);
+                            return result;
                         });
-                    }
-                    //  if( ! balance_claims.length) {
-                    //      throw new Error("No balances to claim");
-                    //  }
-
-                    //DEBUG console.log('... balance_claims',balance_claims)
-                    let tr = new TransactionBuilder();
-
-                    for (let balance_claim of balance_claims) {
-                        tr.add_type_operation("balance_claim", balance_claim);
-                    }
-                    // With a lot of balance claims the signing can take so Long
-                    // the transaction will expire.  This will increase the timeout...
-                    tr.set_expire_seconds(15 * 60 + balance_claims.length);
-                    return WalletDb.process_transaction(
-                        tr,
-                        Object.keys(signer_pubkeys),
-                        broadcast
-                    ).then(result => {
-                        dispatch(true);
-                        return result;
-                    });
-                });
+                    })
+                    .catch(() => {});
                 resolve(p);
             });
         };

--- a/app/actions/WalletUnlockActions.js
+++ b/app/actions/WalletUnlockActions.js
@@ -10,10 +10,14 @@ class WalletUnlockActions {
         return dispatch => {
             return new Promise((resolve, reject) => {
                 dispatch({resolve, reject});
-            }).then(was_unlocked => {
-                //DEBUG  console.log('... WalletUnlockStore\tmodal unlock')
-                if (was_unlocked) WrappedWalletUnlockActions.change();
-            });
+            })
+                .then(was_unlocked => {
+                    //DEBUG  console.log('... WalletUnlockStore\tmodal unlock')
+                    if (was_unlocked) WrappedWalletUnlockActions.change();
+                })
+                .catch(params => {
+                    throw params;
+                });
         };
     }
 

--- a/app/api/ApplicationApi.js
+++ b/app/api/ApplicationApi.js
@@ -106,118 +106,126 @@ const ApplicationApi = {
             FetchChain("getAsset", asset),
             FetchChain("getAsset", fee_asset_id),
             unlock_promise
-        ]).then(res => {
-            let [
-                chain_from,
-                chain_to,
-                chain_memo_sender,
-                chain_propose_account,
-                chain_asset,
-                chain_fee_asset
-            ] = res;
+        ])
+            .then(res => {
+                let [
+                    chain_from,
+                    chain_to,
+                    chain_memo_sender,
+                    chain_propose_account,
+                    chain_asset,
+                    chain_fee_asset
+                ] = res;
 
-            let memo_from_public, memo_to_public;
-            if (memo && encrypt_memo) {
-                memo_from_public = chain_memo_sender.getIn([
-                    "options",
-                    "memo_key"
-                ]);
+                let memo_from_public, memo_to_public;
+                if (memo && encrypt_memo) {
+                    memo_from_public = chain_memo_sender.getIn([
+                        "options",
+                        "memo_key"
+                    ]);
 
-                // The 1s are base58 for all zeros (null)
-                if (/111111111111111111111/.test(memo_from_public)) {
-                    memo_from_public = null;
+                    // The 1s are base58 for all zeros (null)
+                    if (/111111111111111111111/.test(memo_from_public)) {
+                        memo_from_public = null;
+                    }
+
+                    memo_to_public = chain_to.getIn(["options", "memo_key"]);
+                    if (/111111111111111111111/.test(memo_to_public)) {
+                        memo_to_public = null;
+                    }
                 }
 
-                memo_to_public = chain_to.getIn(["options", "memo_key"]);
-                if (/111111111111111111111/.test(memo_to_public)) {
-                    memo_to_public = null;
-                }
-            }
+                let propose_acount_id = propose_account
+                    ? chain_propose_account.get("id")
+                    : null;
 
-            let propose_acount_id = propose_account
-                ? chain_propose_account.get("id")
-                : null;
-
-            let memo_from_privkey;
-            if (encrypt_memo && memo) {
-                memo_from_privkey = WalletDb.getPrivateKey(memo_from_public);
-
-                if (!memo_from_privkey) {
-                    notify.addNotification({
-                        message: counterpart.translate(
-                            "account.errors.memo_missing"
-                        ),
-                        level: "error",
-                        autoDismiss: 10
-                    });
-                    throw new Error(
-                        "Missing private memo key for sender: " + memo_sender
+                let memo_from_privkey;
+                if (encrypt_memo && memo) {
+                    memo_from_privkey = WalletDb.getPrivateKey(
+                        memo_from_public
                     );
-                }
-            }
 
-            let memo_object;
-            if (memo && memo_to_public && memo_from_public) {
-                let nonce =
-                    optional_nonce == null
-                        ? TransactionHelper.unique_nonce_uint64()
-                        : optional_nonce;
-
-                memo_object = {
-                    from: memo_from_public,
-                    to: memo_to_public,
-                    nonce,
-                    message: encrypt_memo
-                        ? Aes.encrypt_with_checksum(
-                              memo_from_privkey,
-                              memo_to_public,
-                              nonce,
-                              memo
-                          )
-                        : Buffer.isBuffer(memo) ? memo.toString("utf-8") : memo
-                };
-            }
-            // Allow user to choose asset with which to pay fees #356
-            let fee_asset = chain_fee_asset.toJS();
-
-            // Default to CORE in case of faulty core_exchange_rate
-            if (
-                fee_asset.options.core_exchange_rate.base.asset_id ===
-                    "1.3.0" &&
-                fee_asset.options.core_exchange_rate.quote.asset_id === "1.3.0"
-            ) {
-                fee_asset_id = "1.3.0";
-            }
-
-            let tr = new TransactionBuilder();
-            let transfer_op = tr.get_type_operation("transfer", {
-                fee: {
-                    amount: 0,
-                    asset_id: fee_asset_id
-                },
-                from: chain_from.get("id"),
-                to: chain_to.get("id"),
-                amount: {amount, asset_id: chain_asset.get("id")},
-                memo: memo_object
-            });
-
-            return tr.update_head_block().then(() => {
-                if (propose_account) {
-                    tr.add_type_operation("proposal_create", {
-                        proposed_ops: [{op: transfer_op}],
-                        fee_paying_account: propose_acount_id
-                    });
-                } else {
-                    tr.add_operation(transfer_op);
+                    if (!memo_from_privkey) {
+                        notify.addNotification({
+                            message: counterpart.translate(
+                                "account.errors.memo_missing"
+                            ),
+                            level: "error",
+                            autoDismiss: 10
+                        });
+                        throw new Error(
+                            "Missing private memo key for sender: " +
+                                memo_sender
+                        );
+                    }
                 }
 
-                return WalletDb.process_transaction(
-                    tr,
-                    null, //signer_private_keys,
-                    broadcast
-                );
-            });
-        });
+                let memo_object;
+                if (memo && memo_to_public && memo_from_public) {
+                    let nonce =
+                        optional_nonce == null
+                            ? TransactionHelper.unique_nonce_uint64()
+                            : optional_nonce;
+
+                    memo_object = {
+                        from: memo_from_public,
+                        to: memo_to_public,
+                        nonce,
+                        message: encrypt_memo
+                            ? Aes.encrypt_with_checksum(
+                                  memo_from_privkey,
+                                  memo_to_public,
+                                  nonce,
+                                  memo
+                              )
+                            : Buffer.isBuffer(memo)
+                                ? memo.toString("utf-8")
+                                : memo
+                    };
+                }
+                // Allow user to choose asset with which to pay fees #356
+                let fee_asset = chain_fee_asset.toJS();
+
+                // Default to CORE in case of faulty core_exchange_rate
+                if (
+                    fee_asset.options.core_exchange_rate.base.asset_id ===
+                        "1.3.0" &&
+                    fee_asset.options.core_exchange_rate.quote.asset_id ===
+                        "1.3.0"
+                ) {
+                    fee_asset_id = "1.3.0";
+                }
+
+                let tr = new TransactionBuilder();
+                let transfer_op = tr.get_type_operation("transfer", {
+                    fee: {
+                        amount: 0,
+                        asset_id: fee_asset_id
+                    },
+                    from: chain_from.get("id"),
+                    to: chain_to.get("id"),
+                    amount: {amount, asset_id: chain_asset.get("id")},
+                    memo: memo_object
+                });
+
+                return tr.update_head_block().then(() => {
+                    if (propose_account) {
+                        tr.add_type_operation("proposal_create", {
+                            proposed_ops: [{op: transfer_op}],
+                            fee_paying_account: propose_acount_id
+                        });
+                    } else {
+                        tr.add_operation(transfer_op);
+                    }
+
+                    return WalletDb.process_transaction(
+                        tr,
+                        null, //signer_private_keys,
+                        broadcast
+                    );
+                });
+            })
+            .catch(() => {});
     },
 
     issue_asset(
@@ -235,77 +243,84 @@ const ApplicationApi = {
             FetchChain("getAccount", from_account),
             FetchChain("getAccount", to_account),
             unlock_promise
-        ]).then(res => {
-            let [chain_memo_sender, chain_to] = res;
+        ])
+            .then(res => {
+                let [chain_memo_sender, chain_to] = res;
 
-            let memo_from_public, memo_to_public;
-            if (memo && encrypt_memo) {
-                memo_from_public = chain_memo_sender.getIn([
-                    "options",
-                    "memo_key"
-                ]);
+                let memo_from_public, memo_to_public;
+                if (memo && encrypt_memo) {
+                    memo_from_public = chain_memo_sender.getIn([
+                        "options",
+                        "memo_key"
+                    ]);
 
-                // The 1s are base58 for all zeros (null)
-                if (/111111111111111111111/.test(memo_from_public)) {
-                    memo_from_public = null;
+                    // The 1s are base58 for all zeros (null)
+                    if (/111111111111111111111/.test(memo_from_public)) {
+                        memo_from_public = null;
+                    }
+
+                    memo_to_public = chain_to.getIn(["options", "memo_key"]);
+                    if (/111111111111111111111/.test(memo_to_public)) {
+                        memo_to_public = null;
+                    }
                 }
 
-                memo_to_public = chain_to.getIn(["options", "memo_key"]);
-                if (/111111111111111111111/.test(memo_to_public)) {
-                    memo_to_public = null;
-                }
-            }
-
-            let memo_from_privkey;
-            if (encrypt_memo && memo) {
-                memo_from_privkey = WalletDb.getPrivateKey(memo_from_public);
-
-                if (!memo_from_privkey) {
-                    throw new Error(
-                        "Missing private memo key for sender: " + from_account
+                let memo_from_privkey;
+                if (encrypt_memo && memo) {
+                    memo_from_privkey = WalletDb.getPrivateKey(
+                        memo_from_public
                     );
+
+                    if (!memo_from_privkey) {
+                        throw new Error(
+                            "Missing private memo key for sender: " +
+                                from_account
+                        );
+                    }
                 }
-            }
 
-            let memo_object;
-            if (memo && memo_to_public && memo_from_public) {
-                let nonce =
-                    optional_nonce == null
-                        ? TransactionHelper.unique_nonce_uint64()
-                        : optional_nonce;
+                let memo_object;
+                if (memo && memo_to_public && memo_from_public) {
+                    let nonce =
+                        optional_nonce == null
+                            ? TransactionHelper.unique_nonce_uint64()
+                            : optional_nonce;
 
-                memo_object = {
-                    from: memo_from_public,
-                    to: memo_to_public,
-                    nonce,
-                    message: encrypt_memo
-                        ? Aes.encrypt_with_checksum(
-                              memo_from_privkey,
-                              memo_to_public,
-                              nonce,
-                              memo
-                          )
-                        : Buffer.isBuffer(memo) ? memo.toString("utf-8") : memo
-                };
-            }
+                    memo_object = {
+                        from: memo_from_public,
+                        to: memo_to_public,
+                        nonce,
+                        message: encrypt_memo
+                            ? Aes.encrypt_with_checksum(
+                                  memo_from_privkey,
+                                  memo_to_public,
+                                  nonce,
+                                  memo
+                              )
+                            : Buffer.isBuffer(memo)
+                                ? memo.toString("utf-8")
+                                : memo
+                    };
+                }
 
-            let tr = new TransactionBuilder();
-            tr.add_type_operation("asset_issue", {
-                fee: {
-                    amount: 0,
-                    asset_id: 0
-                },
-                issuer: from_account,
-                asset_to_issue: {
-                    amount: amount,
-                    asset_id: asset_id
-                },
-                issue_to_account: to_account,
-                memo: memo_object
-            });
+                let tr = new TransactionBuilder();
+                tr.add_type_operation("asset_issue", {
+                    fee: {
+                        amount: 0,
+                        asset_id: 0
+                    },
+                    issuer: from_account,
+                    asset_to_issue: {
+                        amount: amount,
+                        asset_id: asset_id
+                    },
+                    issue_to_account: to_account,
+                    memo: memo_object
+                });
 
-            return WalletDb.process_transaction(tr, null, true);
-        });
+                return WalletDb.process_transaction(tr, null, true);
+            })
+            .catch(() => {});
     },
 
     createWorker(options, account) {

--- a/app/components/Blockchain/MemoText.jsx
+++ b/app/components/Blockchain/MemoText.jsx
@@ -22,10 +22,12 @@ class MemoText extends React.Component {
 
     _toggleLock(e) {
         e.preventDefault();
-        WalletUnlockActions.unlock().then(() => {
-            console.log("unlocked");
-            ReactTooltip.rebuild();
-        });
+        WalletUnlockActions.unlock()
+            .then(() => {
+                console.log("unlocked");
+                ReactTooltip.rebuild();
+            })
+            .catch(() => {});
     }
 
     render() {

--- a/app/components/Blockchain/Transaction.jsx
+++ b/app/components/Blockchain/Transaction.jsx
@@ -118,9 +118,11 @@ class Transaction extends React.Component {
 
     _toggleLock(e) {
         e.preventDefault();
-        WalletUnlockActions.unlock().then(() => {
-            this.forceUpdate();
-        });
+        WalletUnlockActions.unlock()
+            .then(() => {
+                this.forceUpdate();
+            })
+            .catch(() => {});
     }
 
     render() {

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -145,9 +145,11 @@ class Header extends React.Component {
     _toggleLock(e) {
         e.preventDefault();
         if (WalletDb.isLocked()) {
-            WalletUnlockActions.unlock().then(() => {
-                AccountActions.tryToSetCurrentAccount();
-            });
+            WalletUnlockActions.unlock()
+                .then(() => {
+                    AccountActions.tryToSetCurrentAccount();
+                })
+                .catch(() => {});
         } else {
             WalletUnlockActions.lock();
         }

--- a/app/components/PrivateKeyView.jsx
+++ b/app/components/PrivateKeyView.jsx
@@ -8,10 +8,9 @@ import PrivateKeyStore from "stores/PrivateKeyStore";
 import QrcodeModal from "./Modal/QrcodeModal";
 
 export default class PrivateKeyView extends Component {
-
     static propTypes = {
         pubkey: React.PropTypes.string.isRequired
-    }
+    };
 
     constructor() {
         super();
@@ -19,7 +18,7 @@ export default class PrivateKeyView extends Component {
     }
 
     _getInitialState() {
-        return { wif: null };
+        return {wif: null};
     }
 
     reset() {
@@ -29,8 +28,8 @@ export default class PrivateKeyView extends Component {
     componentDidMount() {
         var modalId = "key_view_modal" + this.props.pubkey;
         ZfApi.subscribe(modalId, (name, msg) => {
-            if(name !== modalId) return;
-            if(msg === "close") this.reset();
+            if (name !== modalId) return;
+            if (msg === "close") this.reset();
         });
     }
 
@@ -39,87 +38,137 @@ export default class PrivateKeyView extends Component {
         var keys = PrivateKeyStore.getState().keys;
 
         var has_private = keys.has(this.props.pubkey);
-        if( ! has_private) return <span>{this.props.children}</span>;
+        if (!has_private) return <span>{this.props.children}</span>;
         var key = keys.get(this.props.pubkey);
-        return <span>
-            <a onClick={this.onOpen.bind(this)}>{this.props.children}</a>
-            <BaseModal ref={modalId} id={modalId} overlay={true} overlayClose={false}>
-                <h3><Translate content="account.perm.key_viewer" /></h3>
-                <div className="grid-block vertical">
-                    <div className="content-block">
-
-                        <div className="grid-content">
-                            <label><Translate content="account.perm.public" /></label>
-                            {this.props.pubkey}
-                        </div>
-                        <br/>
-
-                        <div className="grid-block grid-content">
-                            <label><Translate content="account.perm.private" /></label>
-                            <div>
-                                {this.state.wif ? <span>
-                                    <p style={{fontWeight: 600}}>{this.state.wif}</p>
-                                    <div className="button-group">
-                                        <div className="button" onClick={this.onHide.bind(this)}>hide</div>
-                                        <div className="clickable" onClick={this.showQrCode.bind(this)}>
-                                            <img style={{height: 50}} src={require("assets/qr.png")} />
-                                        </div>
-                                    </div>
-                                </span>:<span>
-                                    <div className="button" onClick={this.onShow.bind(this)}><Translate content="account.perm.show" /></div>
-                                </span>}
+        return (
+            <span>
+                <a onClick={this.onOpen.bind(this)}>{this.props.children}</a>
+                <BaseModal
+                    ref={modalId}
+                    id={modalId}
+                    overlay={true}
+                    overlayClose={false}
+                >
+                    <h3>
+                        <Translate content="account.perm.key_viewer" />
+                    </h3>
+                    <div className="grid-block vertical">
+                        <div className="content-block">
+                            <div className="grid-content">
+                                <label>
+                                    <Translate content="account.perm.public" />
+                                </label>
+                                {this.props.pubkey}
                             </div>
-                        </div>
-                        <br/>
+                            <br />
 
-                        <div className="grid-block grid-content">
-                            <label><Translate content="account.perm.brain" /></label>
-                            {key.brainkey_sequence == null ? "Non-deterministic" : key.brainkey_sequence}
-                        </div>
-                        <br/>
+                            <div className="grid-block grid-content">
+                                <label>
+                                    <Translate content="account.perm.private" />
+                                </label>
+                                <div>
+                                    {this.state.wif ? (
+                                        <span>
+                                            <p style={{fontWeight: 600}}>
+                                                {this.state.wif}
+                                            </p>
+                                            <div className="button-group">
+                                                <div
+                                                    className="button"
+                                                    onClick={this.onHide.bind(
+                                                        this
+                                                    )}
+                                                >
+                                                    hide
+                                                </div>
+                                                <div
+                                                    className="clickable"
+                                                    onClick={this.showQrCode.bind(
+                                                        this
+                                                    )}
+                                                >
+                                                    <img
+                                                        style={{height: 50}}
+                                                        src={require("assets/qr.png")}
+                                                    />
+                                                </div>
+                                            </div>
+                                        </span>
+                                    ) : (
+                                        <span>
+                                            <div
+                                                className="button"
+                                                onClick={this.onShow.bind(this)}
+                                            >
+                                                <Translate content="account.perm.show" />
+                                            </div>
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                            <br />
 
-                        {key.import_account_names && key.import_account_names.length ?
-                        <div className="grid-block grid-content">
-                            <label><Translate content="account.perm.from" /></label>
-                            {key.import_account_names.join(", ")}
-                            <br/>
-                        </div>
-                        :null}
+                            <div className="grid-block grid-content">
+                                <label>
+                                    <Translate content="account.perm.brain" />
+                                </label>
+                                {key.brainkey_sequence == null
+                                    ? "Non-deterministic"
+                                    : key.brainkey_sequence}
+                            </div>
+                            <br />
 
+                            {key.import_account_names &&
+                            key.import_account_names.length ? (
+                                <div className="grid-block grid-content">
+                                    <label>
+                                        <Translate content="account.perm.from" />
+                                    </label>
+                                    {key.import_account_names.join(", ")}
+                                    <br />
+                                </div>
+                            ) : null}
+                        </div>
                     </div>
-                </div>
-                <div className="button-group">
-                    <div onClick={this.onClose.bind(this)} className=" button"><Translate content="transfer.close" /></div>
-                </div>
-            </BaseModal>
-            <QrcodeModal ref="qrmodal" keyValue={this.state.wif} />
-        </span>
+                    <div className="button-group">
+                        <div
+                            onClick={this.onClose.bind(this)}
+                            className=" button"
+                        >
+                            <Translate content="transfer.close" />
+                        </div>
+                    </div>
+                </BaseModal>
+                <QrcodeModal ref="qrmodal" keyValue={this.state.wif} />
+            </span>
+        );
     }
 
     onOpen() {
-        var modalId = "key_view_modal" + this.props.pubkey
-        ZfApi.publish(modalId, "open")
+        var modalId = "key_view_modal" + this.props.pubkey;
+        ZfApi.publish(modalId, "open");
     }
 
     onClose() {
-        this.reset()
-        var modalId = "key_view_modal" + this.props.pubkey
-        ZfApi.publish(modalId, "close")
+        this.reset();
+        var modalId = "key_view_modal" + this.props.pubkey;
+        ZfApi.publish(modalId, "close");
     }
 
     onShow() {
-        WalletUnlockActions.unlock().then( () => {
-            var private_key = WalletDb.getPrivateKey(this.props.pubkey)
-            this.setState({ wif: private_key.toWif() })
-        })
+        WalletUnlockActions.unlock()
+            .then(() => {
+                var private_key = WalletDb.getPrivateKey(this.props.pubkey);
+                this.setState({wif: private_key.toWif()});
+            })
+            .catch(() => {});
     }
 
     onHide() {
-        this.setState({ wif: null })
+        this.setState({wif: null});
     }
 
-    showQrCode(){
+    showQrCode() {
         this.refs.qrmodal.show();
     }
-
 }

--- a/app/components/Wallet/ImportKeys.jsx
+++ b/app/components/Wallet/ImportKeys.jsx
@@ -530,11 +530,13 @@ class ImportKeys extends Component {
             if (dups[public_key_string])
                 delete keys_to_account[private_plainhex];
         }
-        WalletUnlockActions.unlock().then(() => {
-            ImportKeysStore.importing(true);
-            // show the loading indicator
-            setTimeout(() => this.saveImport(), 200);
-        });
+        WalletUnlockActions.unlock()
+            .then(() => {
+                ImportKeysStore.importing(true);
+                // show the loading indicator
+                setTimeout(() => this.saveImport(), 200);
+            })
+            .catch(() => {});
     }
 
     saveImport() {

--- a/app/stores/WalletUnlockStore.js
+++ b/app/stores/WalletUnlockStore.js
@@ -63,7 +63,7 @@ class WalletUnlockStore {
     }
 
     onCancel() {
-        //this.state.reject();
+        this.state.reject({isCanceled: true});
         this.setState({resolve: null, reject: null});
     }
 


### PR DESCRIPTION
WalletUnlockActions.unlock() was adjusted and now does
 - requires a catch (for user cancellation)
 - finally handler works as intended

Here is the console output of the example mentioned in the issue:

unlock cancelled:
![image](https://user-images.githubusercontent.com/33128181/37643578-45002be4-2c21-11e8-9e0a-e245a2b7dc1c.png)

unlock successfull:
![image](https://user-images.githubusercontent.com/33128181/37643613-65bc69a6-2c21-11e8-9ea8-d76dd5141484.png)

The actual changes contain the edits from @gibbsfromncis and additionally .catch(() => {}); everywhere where unlock() was used. The rest is reformatting from the commit hook I think.

Signed-off-by: Stefan Schiessl <stefan.schiessl@blockchainprojectsbv.com>