### PR TITLE
Iss 1289 - Deposit Modal - Autoselect Gateway when available is 1

### DIFF
--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -96,12 +96,7 @@ class DepositModalContent extends DecimalChecker {
             this,
             asset
         );
-        console.log(
-            "selectedAsset",
-            selectedAsset,
-            "selectedGateway",
-            selectedGateway
-        );
+
         if (selectedGateway) {
             this._getDepositAddress(selectedAsset, selectedGateway);
         }

--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -15,7 +15,8 @@ import {
     _getAvailableGateways,
     gatewaySelector,
     _getNumberAvailableGateways,
-    _onAssetSelected
+    _onAssetSelected,
+    _getCoinToGatewayMapping
 } from "lib/common/assetGatewayMixin";
 
 class DepositModalContent extends DecimalChecker {
@@ -59,6 +60,9 @@ class DepositModalContent extends DecimalChecker {
     componentWillMount() {
         let {asset} = this.props;
 
+        let coinToGatewayMapping = _getCoinToGatewayMapping.call(this);
+        this.setState({coinToGatewayMapping});
+
         if (!asset) return;
 
         let backedAsset = asset.split(".");
@@ -91,6 +95,12 @@ class DepositModalContent extends DecimalChecker {
         let {selectedAsset, selectedGateway} = _onAssetSelected.call(
             this,
             asset
+        );
+        console.log(
+            "selectedAsset",
+            selectedAsset,
+            "selectedGateway",
+            selectedGateway
         );
         if (selectedGateway) {
             this._getDepositAddress(selectedAsset, selectedGateway);

--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -94,7 +94,13 @@ class DepositModalContent extends DecimalChecker {
 
         let {selectedAsset, selectedGateway} = _onAssetSelected.call(
             this,
-            asset
+            asset,
+            "depositAllowed",
+            (availableGateways, balancesByGateway) => {
+                if (availableGateways && availableGateways.length == 1)
+                    return availableGateways[0]; //autoselect gateway if exactly 1 item
+                return null;
+            }
         );
 
         if (selectedGateway) {

--- a/app/lib/common/assetGatewayMixin.js
+++ b/app/lib/common/assetGatewayMixin.js
@@ -87,7 +87,11 @@ function _getNumberAvailableGateways() {
     return nAvailableGateways;
 }
 
-function _onAssetSelected(selectedAsset, boolCheck = "depositAllowed") {
+function _onAssetSelected(
+    selectedAsset,
+    boolCheck = "depositAllowed",
+    selectGatewayFn = null
+) {
     const {balances, assets} = this.props || {}; //Function must be bound on calling component and these props must be passed to calling component
     let gatewayStatus = _getAvailableGateways.call(
         this,
@@ -127,7 +131,8 @@ function _onAssetSelected(selectedAsset, boolCheck = "depositAllowed") {
         coinToGatewayMapping[selectedAsset]
     ) {
         let gateways = coinToGatewayMapping[selectedAsset];
-        if (gateways.length) {
+        if (gateways.length && !selectGatewayFn) {
+            //Default gateway selection logic is to pick the gateway with the highest balance, or default to the first available
             if (balancesByAssetAndGateway[selectedAsset]) {
                 let greatestBalance = null;
                 let greatestBalanceGateway = null;
@@ -146,6 +151,11 @@ function _onAssetSelected(selectedAsset, boolCheck = "depositAllowed") {
             } else {
                 selectedGateway = gateways[0];
             }
+        } else if (gateways.length && selectGatewayFn) {
+            selectedGateway = selectGatewayFn(
+                coinToGatewayMapping[selectedAsset],
+                balancesByAssetAndGateway[selectedAsset]
+            );
         }
     }
 


### PR DESCRIPTION
Closes #1289 

This uses gateway auto select logic shared by the withdrawal modal. This will auto select whatever gateway has the greatest balance for the selected asset, or default to the first one.

![update](https://user-images.githubusercontent.com/632938/37875905-f2c28ae6-300a-11e8-88fd-ea7ec577b2c1.gif)

This logic can be modified via an override fn, but I think defaulting to most used and falling back to the first one makes sense.