### PR TITLE
Issue #1331 - Order Expiration Updates

### DIFF
--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -64,6 +64,10 @@ class SettingsActions {
     updateLatencies(latencies) {
         return latencies;
     }
+
+    setExchangeLastExpiration(value) {
+        return value;
+    }
 }
 
 export default alt.createActions(SettingsActions);

--- a/app/components/Exchange/BuySell.jsx
+++ b/app/components/Exchange/BuySell.jsx
@@ -427,7 +427,9 @@ class BuySell extends React.Component {
                                         keys={[
                                             {
                                                 type: "asset",
-                                                value: this.props[isBid ? "base" : "quote"].get("symbol"),
+                                                value: this.props[
+                                                    isBid ? "base" : "quote"
+                                                ].get("symbol"),
                                                 arg: "asset"
                                             },
                                             {
@@ -435,7 +437,7 @@ class BuySell extends React.Component {
                                                 value: "exchange.buy",
                                                 arg: "direction"
                                             }
-                                        ]} 
+                                        ]}
                                     />
                                 </a>
                             </div>
@@ -443,13 +445,15 @@ class BuySell extends React.Component {
                         {this.props.backedCoin ? (
                             <div className="float-right buy-sell-deposit">
                                 <a onClick={this._onDeposit.bind(this)}>
-                                <TranslateWithLinks
+                                    <TranslateWithLinks
                                         string="exchange.buysell_formatter"
                                         noLink
                                         keys={[
                                             {
                                                 type: "asset",
-                                                value: this.props[isBid ? "base" : "quote"].get("symbol"),
+                                                value: this.props[
+                                                    isBid ? "base" : "quote"
+                                                ].get("symbol"),
                                                 arg: "asset"
                                             },
                                             {
@@ -457,7 +461,7 @@ class BuySell extends React.Component {
                                                 value: "exchange.deposit",
                                                 arg: "direction"
                                             }
-                                        ]} 
+                                        ]}
                                     />
                                 </a>
                             </div>
@@ -471,7 +475,9 @@ class BuySell extends React.Component {
                                         keys={[
                                             {
                                                 type: "asset",
-                                                value: this.props[isBid ? "base" : "quote"].get("symbol"),
+                                                value: this.props[
+                                                    isBid ? "base" : "quote"
+                                                ].get("symbol"),
                                                 arg: "asset"
                                             },
                                             {
@@ -479,7 +485,7 @@ class BuySell extends React.Component {
                                                 value: "exchange.borrow",
                                                 arg: "direction"
                                             }
-                                        ]} 
+                                        ]}
                                     />
                                 </a>
                             </div>
@@ -723,6 +729,9 @@ class BuySell extends React.Component {
                                                 {this.props.expirationType ===
                                                 "SPECIFIC" ? (
                                                     <DatePicker
+                                                        pickerPosition={
+                                                            "bottom center"
+                                                        }
                                                         wrapperClassName={theme}
                                                         timePicker={true}
                                                         min={minExpirationDate}

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -59,8 +59,8 @@ class Exchange extends React.Component {
         this.state = {
             ...this._initialState(props),
             expirationType: {
-                bid: "MONTH",
-                ask: "MONTH"
+                bid: "YEAR",
+                ask: "YEAR"
             },
             expirationCustomTime: {
                 bid: moment().add(1, "day"),
@@ -135,6 +135,13 @@ class Exchange extends React.Component {
             get: () =>
                 moment()
                     .add(30, "day")
+                    .valueOf()
+        },
+        YEAR: {
+            title: "1 year",
+            get: () =>
+                moment()
+                    .add(1, "year")
                     .valueOf()
         },
         SPECIFIC: {

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -59,8 +59,8 @@ class Exchange extends React.Component {
         this.state = {
             ...this._initialState(props),
             expirationType: {
-                bid: "YEAR",
-                ask: "YEAR"
+                bid: props.exchange.getIn(["lastExpiration", "bid"]) || "YEAR",
+                ask: props.exchange.getIn(["lastExpiration", "ask"]) || "YEAR"
             },
             expirationCustomTime: {
                 bid: moment().add(1, "day"),
@@ -84,6 +84,15 @@ class Exchange extends React.Component {
             ...this.state.expirationType,
             [type]: e.target.value
         };
+
+        if (e.target.value !== "SPECIFIC") {
+            SettingsActions.setExchangeLastExpiration({
+                ...((this.props.exchange.has("lastExpiration") &&
+                    this.props.exchange.get("lastExpiration").toJS()) ||
+                    {}),
+                [type]: e.target.value
+            });
+        }
 
         this.setState({
             expirationType: expirationType

--- a/app/components/Exchange/ExchangeContainer.jsx
+++ b/app/components/Exchange/ExchangeContainer.jsx
@@ -78,6 +78,9 @@ class ExchangeContainer extends React.Component {
                     settings: () => {
                         return SettingsStore.getState().settings;
                     },
+                    exchange: () => {
+                        return SettingsStore.getState().exchange;
+                    },
                     starredMarkets: () => {
                         return SettingsStore.getState().starredMarkets;
                     },

--- a/app/stores/SettingsStore.js
+++ b/app/stores/SettingsStore.js
@@ -1,7 +1,7 @@
 import alt from "alt-instance";
 import SettingsActions from "actions/SettingsActions";
 import IntlActions from "actions/IntlActions";
-import Immutable from "immutable";
+import Immutable, {fromJS} from "immutable";
 import {merge} from "lodash";
 import ls from "common/localStorage";
 import {Apis} from "bitsharesjs-ws";
@@ -22,6 +22,8 @@ class SettingsStore {
         });
 
         this.bindListeners({
+            onSetExchangeLastExpiration:
+                SettingsActions.setExchangeLastExpiration,
             onChangeSetting: SettingsActions.changeSetting,
             onChangeViewSetting: SettingsActions.changeViewSetting,
             onChangeMarketDirection: SettingsActions.changeMarketDirection,
@@ -163,6 +165,8 @@ class SettingsStore {
             "testnet_faucet",
             settingsAPIs.TESTNET_FAUCET
         );
+
+        this.exchange = fromJS(ss.get("exchange", {}));
     }
 
     init() {
@@ -474,6 +478,24 @@ class SettingsStore {
 
     setLastBudgetObject(value) {
         ss.set(this._getChainKey("lastBudgetObject"), value);
+    }
+
+    setExchangeSettings(key, value) {
+        this.exchange = this.exchange.set(key, value);
+
+        ss.set("exchange", this.exchange.toJS());
+    }
+
+    getExchangeSettings(key) {
+        return this.exchange.get(key);
+    }
+
+    onSetExchangeLastExpiration(value) {
+        this.setExchangeSettings("lastExpiration", fromJS(value));
+    }
+
+    getExhchangeLastExpiration() {
+        return this.getExchangeSettings("lastExpiration");
     }
 }
 


### PR DESCRIPTION
Task: #1331

*Tested on Mac OS*:
- [x] Firefox
- [x] Chrome
- [x] Opera

Changes:
- Add option "1 year" to time select list
- Set default expiration "1 year"
- Display Calendar above the field
- Store last selected expiration on localStorage (all except Specific time. There is no reason to store specific time and then make a checks is it past time or future etc.)

@svk31 please accept my PR to Calendar first - https://github.com/bitshares/react-datepicker2/pull/1
I've added an ability to set position of calendar using props.