### PR TITLE
#1320 - Fix data availability issue in market discovery

### DIFF
--- a/app/components/Utility/AssetSelector.jsx
+++ b/app/components/Utility/AssetSelector.jsx
@@ -18,7 +18,7 @@ class AssetDropdown extends React.Component {
 
     render() {
         if (this.props.assets.length === 0 || !this.props.value) return null;
-        console.log("assets:", this.props.assets);
+
         return (
             <FloatingDropdown
                 entries={this.props.assets


### PR DESCRIPTION
Resolves #1320 

This issue was primarily occurring because a search filter of OPEN. was being applied by default, and because only assets / market data for OPEN assets were being loaded. I added a wildcard match and added loading for RUDEX assets as well. Now UIAs as well as RUDEX and OPEN assets will appear in find markets.

Unfortunately this created a performance issue as many new renders were being triggered by changes in market data...hundreds of them. I added timeouts to ignore some of these changes during transition to find market tab or when changing base assets. This results in volumes not appearing for a brief time (500-1500ms). However, it does solve the performance issue and all data loads as expected.

![update](https://user-images.githubusercontent.com/632938/38040686-a9139a76-3275-11e8-9d00-6c6c3ae85725.gif)
