### PR TITLE
Issue 1275 - Gateway Update to support Winex

### DIFF
--- a/app/App.jsx
+++ b/app/App.jsx
@@ -24,6 +24,7 @@ import Deprecate from "./Deprecate";
 import WalletManagerStore from "stores/WalletManagerStore";
 import Incognito from "./components/Layout/Incognito";
 import {isIncognito} from "feature_detect";
+import {updateGatewayBackers} from "common/gatewayUtils";
 
 class App extends React.Component {
     constructor(props) {
@@ -121,12 +122,13 @@ class App extends React.Component {
         this.props.router.listen(this._rebuildTooltips);
 
         this._rebuildTooltips();
-
+        
         isIncognito(
             function(incognito) {
                 this.setState({incognito});
             }.bind(this)
         );
+        updateGatewayBackers();
     }
 
     _onIgnoreIncognitoWarning() {

--- a/app/actions/GatewayActions.js
+++ b/app/actions/GatewayActions.js
@@ -17,7 +17,7 @@ const onGatewayTimeout = (dispatch, gateway) => {
 };
 
 class GatewayActions {
-    fetchCoins({backer = "OPEN", url = undefined} = {}) {
+    fetchCoins({backer = "OPEN", url = undefined, urlBridge = blockTradesAPIs.BASE_OL, urlWallets = undefined} = {}) {
         if (!inProgress["fetchCoins_" + backer]) {
             inProgress["fetchCoins_" + backer] = true;
             return dispatch => {
@@ -28,8 +28,8 @@ class GatewayActions {
 
                 Promise.all([
                     fetchCoins(url),
-                    fetchBridgeCoins(blockTradesAPIs.BASE_OL),
-                    getActiveWallets(url)
+                    fetchBridgeCoins(urlBridge),
+                    getActiveWallets(urlWallets)
                 ]).then(result => {
                     clearTimeout(fetchCoinsTimeout);
                     delete inProgress["fetchCoins_" + backer];

--- a/app/actions/GatewayActions.js
+++ b/app/actions/GatewayActions.js
@@ -6,7 +6,7 @@ import {
     getBackedCoins,
     getActiveWallets
 } from "common/blockTradesMethods";
-import {blockTradesAPIs} from "api/apiConfig";
+import {blockTradesAPIs, openledgerAPIs} from "api/apiConfig";
 
 let inProgress = {};
 
@@ -17,7 +17,7 @@ const onGatewayTimeout = (dispatch, gateway) => {
 };
 
 class GatewayActions {
-    fetchCoins({backer = "OPEN", url = undefined, urlBridge = blockTradesAPIs.BASE_OL, urlWallets = undefined} = {}) {
+    fetchCoins({backer = "OPEN", url = undefined, urlBridge = openledgerAPIs.BASE, urlWallets = undefined} = {}) {
         if (!inProgress["fetchCoins_" + backer]) {
             inProgress["fetchCoins_" + backer] = true;
             return dispatch => {

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -1,6 +1,5 @@
 export const blockTradesAPIs = {
     BASE: "https://api.blocktrades.us/v2",
-    // BASE_OL: "https://api.blocktrades.us/ol/v2",
     BASE_OL: "https://ol-api1.openledger.info/api/v0/ol/support",
     COINS_LIST: "/coins",
     ACTIVE_WALLETS: "/active-wallets",
@@ -12,12 +11,14 @@ export const blockTradesAPIs = {
 
 export const rudexAPIs = {
     BASE: "https://gateway.rudex.org/api/v0_1",
+    BASE_OL: "https://gateway.rudex.org/api/v0_1",
     COINS_LIST: "/coins",
     NEW_DEPOSIT_ADDRESS: "/new-deposit-address"
 };
 
 export const widechainAPIs = {
     BASE: "https://gateway.winex.pro/api/v0/ol/support",
+    BASE_OL: "https://gateway.winex.pro/api/v0/ol/support",
     COINS_LIST: "/coins",
     ACTIVE_WALLETS: "/active-wallets",
     NEW_DEPOSIT_ADDRESS: "/new-deposit-address",

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -1,6 +1,15 @@
 export const blockTradesAPIs = {
     BASE: "https://api.blocktrades.us/v2",
-    BASE_OL: "https://ol-api1.openledger.info/api/v0/ol/support",
+    COINS_LIST: "/coins",
+    ACTIVE_WALLETS: "/active-wallets",
+    TRADING_PAIRS: "/trading-pairs",
+    DEPOSIT_LIMIT: "/deposit-limits",
+    ESTIMATE_OUTPUT: "/estimate-output-amount",
+    ESTIMATE_INPUT: "/estimate-input-amount"
+};
+
+export const openledgerAPIs = {
+    BASE: "https://ol-api1.openledger.info/api/v0/ol/support",
     COINS_LIST: "/coins",
     ACTIVE_WALLETS: "/active-wallets",
     TRADING_PAIRS: "/trading-pairs",
@@ -11,14 +20,12 @@ export const blockTradesAPIs = {
 
 export const rudexAPIs = {
     BASE: "https://gateway.rudex.org/api/v0_1",
-    BASE_OL: "https://gateway.rudex.org/api/v0_1",
     COINS_LIST: "/coins",
     NEW_DEPOSIT_ADDRESS: "/new-deposit-address"
 };
 
 export const widechainAPIs = {
     BASE: "https://gateway.winex.pro/api/v0/ol/support",
-    BASE_OL: "https://gateway.winex.pro/api/v0/ol/support",
     COINS_LIST: "/coins",
     ACTIVE_WALLETS: "/active-wallets",
     NEW_DEPOSIT_ADDRESS: "/new-deposit-address",

--- a/app/components/Account/AccountDepositWithdraw.jsx
+++ b/app/components/Account/AccountDepositWithdraw.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {connect} from "alt-react";
 import accountUtils from "common/account_utils";
+import {updateGatewayBackers} from "common/gatewayUtils";
 import utils from "common/utils";
 import Translate from "react-translate-component";
 import ChainTypes from "../Utility/ChainTypes";
@@ -13,12 +14,10 @@ import HelpContent from "../Utility/HelpContent";
 import AccountStore from "stores/AccountStore";
 import SettingsStore from "stores/SettingsStore";
 import SettingsActions from "actions/SettingsActions";
-import {Apis} from "bitsharesjs-ws";
-import {settingsAPIs, rudexAPIs} from "api/apiConfig";
+import {settingsAPIs} from "api/apiConfig";
 import BitKapital from "../DepositWithdraw/BitKapital";
 import RuDexGateway from "../DepositWithdraw/rudex/RuDexGateway";
 import GatewayStore from "stores/GatewayStore";
-import GatewayActions from "actions/GatewayActions";
 import AccountImage from "../Account/AccountImage";
 import GdexGateway from "../DepositWithdraw/gdex/GdexGateway";
 import WinexGateway from "../DepositWithdraw/winex/WinexGateway";
@@ -481,15 +480,7 @@ AccountDepositWithdraw = BindToChainState(AccountDepositWithdraw);
 
 class DepositStoreWrapper extends React.Component {
     componentWillMount() {
-        if (Apis.instance().chain_id.substr(0, 8) === "4018d784") {
-            // Only fetch this when on BTS main net
-            GatewayActions.fetchCoins.defer(); // Openledger
-            GatewayActions.fetchCoinsSimple.defer({
-                backer: "RUDEX",
-                url: rudexAPIs.BASE + rudexAPIs.COINS_LIST
-            }); // RuDEX
-            GatewayActions.fetchCoins.defer({backer: "TRADE"}); // Blocktrades
-        }
+        updateGatewayBackers();
     }
 
     render() {
@@ -515,6 +506,10 @@ export default connect(DepositStoreWrapper, {
             ),
             blockTradesBackedCoins: GatewayStore.getState().backedCoins.get(
                 "TRADE",
+                []
+            ),
+            winexBackedCoins: GatewayStore.getState().backedCoins.get(
+                "WIN",
                 []
             ),
             servicesDown: GatewayStore.getState().down || {}

--- a/app/components/Account/BalanceWrapper.jsx
+++ b/app/components/Account/BalanceWrapper.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import BindToChainState from "../Utility/BindToChainState";
 import ChainTypes from "../Utility/ChainTypes";
 import Immutable from "immutable";
-import {Apis} from "bitsharesjs-ws";
-import GatewayActions from "actions/GatewayActions";
 
 class BalanceWrapper extends React.Component {
     static propTypes = {
@@ -17,14 +15,6 @@ class BalanceWrapper extends React.Component {
     };
 
     componentWillMount() {
-        if (
-            Apis.instance().chain_id.substr(0, 8) === "4018d784" &&
-            !this.props.skipCoinFetch
-        ) {
-            // Only fetch this when on BTS main net
-            GatewayActions.fetchCoins();
-            GatewayActions.fetchBridgeCoins();
-        }
     }
 
     render() {

--- a/app/components/Dashboard/SimpleDepositWithdraw.jsx
+++ b/app/components/Dashboard/SimpleDepositWithdraw.jsx
@@ -23,7 +23,7 @@ import AssetName from "../Utility/AssetName";
 import {ChainStore} from "bitsharesjs/es";
 import {debounce} from "lodash";
 import {DecimalChecker} from "../Exchange/ExchangeInput";
-import {blockTradesAPIs} from "api/apiConfig";
+import {openledgerAPIs} from "api/apiConfig";
 
 // import DepositFiatOpenLedger from "components/DepositWithdraw/openledger/DepositFiatOpenLedger";
 // import WithdrawFiatOpenLedger from "components/DepositWithdraw/openledger/WithdrawFiatOpenLedger";
@@ -376,7 +376,7 @@ class DepositWithdrawContent extends DecimalChecker {
 
     _validateAddress(address, props = this.props) {
         validateAddress({
-            url: blockTradesAPIs.BASE_OL,
+            url: openledgerAPIs.BASE,
             walletType: props.walletType,
             newAddress: address
         })

--- a/app/components/DepositWithdraw/blocktrades/BlockTradesGatewayDepositRequest.jsx
+++ b/app/components/DepositWithdraw/blocktrades/BlockTradesGatewayDepositRequest.jsx
@@ -11,7 +11,7 @@ import BlockTradesDepositAddressCache from "common/BlockTradesDepositAddressCach
 import AssetName from "components/Utility/AssetName";
 import LinkToAccountById from "components/Utility/LinkToAccountById";
 import { requestDepositAddress, getDepositAddress } from "common/blockTradesMethods";
-import { blockTradesAPIs } from "api/apiConfig";
+import { blockTradesAPIs, openledgerAPIs } from "api/apiConfig";
 import LoadingIndicator from "components/LoadingIndicator";
 import counterpart from "counterpart";
 
@@ -43,7 +43,7 @@ class BlockTradesGatewayDepositRequest extends React.Component {
 
         let urls = {
             blocktrades: blockTradesAPIs.BASE,
-            openledger: blockTradesAPIs.BASE_OL
+            openledger: openledgerAPIs.BASE
         };
 
         this.state = {

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -25,7 +25,6 @@ import Highcharts from "highcharts/highstock";
 import ExchangeHeader from "./ExchangeHeader";
 import Translate from "react-translate-component";
 import {Apis} from "bitsharesjs-ws";
-import GatewayActions from "actions/GatewayActions";
 import {checkFeeStatusAsync} from "common/trxHelper";
 import LoadingIndicator from "../LoadingIndicator";
 import moment from "moment";
@@ -251,11 +250,6 @@ class Exchange extends React.Component {
     }
 
     componentWillMount() {
-        if (Apis.instance().chain_id.substr(0, 8) === "4018d784") {
-            GatewayActions.fetchCoins.defer();
-            GatewayActions.fetchBridgeCoins.defer();
-        }
-
         this._checkFeeStatus();
     }
 

--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -151,7 +151,7 @@ class DepositModalContent extends DecimalChecker {
 
         if (selectedGateway == "OPEN" || selectedGateway == "WIN") {
             if (!depositAddress) {
-                requestDepositAddress(this._getDepositObject(selectedAsset, selectedGateway, this.state.gatewayStatus[selectedGateway].baseAPI.BASE_OL));
+                requestDepositAddress(this._getDepositObject(selectedAsset, selectedGateway, this.state.gatewayStatus[selectedGateway].baseAPI.BASE));
             } else {
                 this.setState({
                     depositAddress,

--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -12,12 +12,16 @@ import {DecimalChecker} from "../Exchange/ExchangeInput";
 import QRCode from "qrcode.react";
 import DepositWithdrawAssetSelector from "../DepositWithdraw/DepositWithdrawAssetSelector.js";
 import {
-    _getAvailableGateways,
     gatewaySelector,
     _getNumberAvailableGateways,
     _onAssetSelected,
     _getCoinToGatewayMapping
 } from "lib/common/assetGatewayMixin";
+import {getAvailableGateways} from "common/gateways";
+import {
+    updateGatewayBackers,
+    getGatewayStatusByAsset
+} from "common/gatewayUtils";
 
 class DepositModalContent extends DecimalChecker {
     constructor() {
@@ -29,26 +33,10 @@ class DepositModalContent extends DecimalChecker {
             selectedGateway: null,
             fetchingAddress: false,
             backingAsset: null,
-            gatewayStatus: {
-                OPEN: {
-                    id: "OPEN",
-                    name: "OPENLEDGER",
-                    enabled: false,
-                    selected: false,
-                    support_url:
-                        "https://wallet.bitshares.org/#/help/gateways/openledger"
-                },
-                RUDEX: {
-                    id: "RUDEX",
-                    name: "RUDEX",
-                    enabled: false,
-                    selected: false,
-                    support_url:
-                        "https://wallet.bitshares.org/#/help/gateways/rudex"
-                }
-            }
+            gatewayStatus: getAvailableGateways.call()
         };
 
+        
         this.deposit_address_cache = new BlockTradesDepositAddressCache();
         this.addDepositAddress = this.addDepositAddress.bind(this);
     }
@@ -108,13 +96,26 @@ class DepositModalContent extends DecimalChecker {
         }
     }
 
+    _getDepositObject(selectedAsset, selectedGateway, url) {
+        let {props} = this;
+        let {account} = props;
+
+        return {
+            inputCoinType: selectedAsset.toLowerCase(),
+            outputCoinType: selectedGateway.toLowerCase() + "." + selectedAsset.toLowerCase(),
+            outputAddress: account,
+            url: url,
+            stateCallback: this.addDepositAddress
+        };
+    }
+
     _getDepositAddress(selectedAsset, selectedGateway) {
         let {account} = this.props;
 
         this.setState({
             fetchingAddress: true,
             depositAddress: null,
-            gatewayStatus: _getAvailableGateways.call(this, selectedAsset)
+            gatewayStatus: getGatewayStatusByAsset.call(this, selectedAsset)
         });
 
         // Get Backing Asset for Gateway
@@ -138,25 +139,19 @@ class DepositModalContent extends DecimalChecker {
             return;
         }
 
-        if (selectedGateway == "OPEN") {
-            this.setState({
-                isOpenledger: true
-            });
-            let depositAddress = this.deposit_address_cache.getCachedInputAddress(
-                selectedGateway.toUpperCase(),
+        let depositAddress;
+        if(selectedGateway && selectedAsset) {
+            depositAddress = this.deposit_address_cache.getCachedInputAddress(
+                selectedGateway.toLowerCase(),
                 account,
                 selectedAsset.toLowerCase(),
-                selectedGateway.toLowerCase() +
-                    "." +
-                    selectedAsset.toLowerCase()
+                selectedGateway.toLowerCase() + "." + selectedAsset.toLowerCase()
             );
+        }
+
+        if (selectedGateway == "OPEN" || selectedGateway == "WIN") {
             if (!depositAddress) {
-                requestDepositAddress({
-                    inputCoinType: selectedAsset.toLowerCase(),
-                    outputCoinType: "open." + selectedAsset.toLowerCase(),
-                    outputAddress: account,
-                    stateCallback: this.addDepositAddress
-                });
+                requestDepositAddress(this._getDepositObject(selectedAsset, selectedGateway, this.state.gatewayStatus[selectedGateway].baseAPI.BASE_OL));
             } else {
                 this.setState({
                     depositAddress,
@@ -170,7 +165,6 @@ class DepositModalContent extends DecimalChecker {
                     memo: "dex:" + account
                 },
                 fetchingAddress: false,
-                isOpenledger: false
             });
         } else {
             console.log(
@@ -193,7 +187,7 @@ class DepositModalContent extends DecimalChecker {
         let {account} = this.props;
 
         this.deposit_address_cache.cacheInputAddress(
-            "OPEN",
+            selectedGateway.toLowerCase(),
             account,
             selectedAsset.toLowerCase(),
             selectedGateway.toLowerCase() + "." + selectedAsset.toLowerCase(),
@@ -225,22 +219,29 @@ class DepositModalContent extends DecimalChecker {
 
         // Count available gateways
         let nAvailableGateways = _getNumberAvailableGateways.call(this);
+        let isAddressValid = depositAddress && depositAddress !== "unknown" && !depositAddress.error;
 
-        const QR =
-            depositAddress &&
-            depositAddress.address &&
-            !depositAddress.error ? (
-                <div className="QR">
-                    <QRCode size={140} value={depositAddress.address} />
-                </div>
-            ) : (
-                <div>
-                    <Icon size="5x" name="minus-circle" />
-                    <p className="error-msg">
-                        <Translate content="modal.deposit.address_generation_error" />
-                    </p>
-                </div>
+        let minDeposit = !backingAsset ? 0 : backingAsset.gateFee ? backingAsset.gateFee * 2 : 
+            utils.format_number(
+                backingAsset.minAmount /
+                utils.get_asset_precision(backingAsset.precision),
+                backingAsset.precision,
+                false
             );
+        //let maxDeposit = backingAsset.maxAmount ? backingAsset.maxAmount : null;
+
+        const QR = isAddressValid ? 
+            <div className="QR">
+                <QRCode size={140} value={depositAddress.address} />
+            </div>
+            :
+            <div>
+                <Icon size="5x" name="minus-circle" />
+                <p className="error-msg">
+                    <Translate content="modal.deposit.address_generation_error" />
+                </p>
+            </div>
+        ;
 
         return (
             <div className="grid-block vertical no-overflow">
@@ -275,14 +276,14 @@ class DepositModalContent extends DecimalChecker {
                         </div>
                     </div>
 
-                    {usingGateway && selectedAsset
-                        ? gatewaySelector.call(this, {
-                              selectedGateway,
-                              gatewayStatus,
-                              nAvailableGateways,
-                              error: depositAddress && depositAddress.error,
-                              onGatewayChanged: this.onGatewayChanged.bind(this)
-                          })
+                    {usingGateway && selectedAsset ? 
+                        gatewaySelector.call(this, {
+                            selectedGateway,
+                            gatewayStatus,
+                            nAvailableGateways,
+                            error: depositAddress && depositAddress.error,
+                            onGatewayChanged: this.onGatewayChanged.bind(this)
+                        })
                         : null}
 
                     {!fetchingAddress ? (
@@ -290,7 +291,7 @@ class DepositModalContent extends DecimalChecker {
                             (usingGateway &&
                                 selectedGateway &&
                                 gatewayStatus[selectedGateway].enabled)) &&
-                        depositAddress &&
+                        isAddressValid &&
                         !depositAddress.memo ? (
                             <div
                                 className="container-row"
@@ -309,34 +310,15 @@ class DepositModalContent extends DecimalChecker {
                     )}
                     {selectedGateway &&
                     gatewayStatus[selectedGateway].enabled &&
-                    depositAddress &&
-                    !depositAddress.error ? (
+                    isAddressValid ?
                         <div className="container-row">
-                            {backingAsset.minAmount ? (
-                                <div className="grid-block container-row maxDeposit">
-                                    <Translate
-                                        content="gateway.rudex.min_amount"
-                                        minAmount={utils.format_number(
-                                            backingAsset.minAmount /
-                                                utils.get_asset_precision(
-                                                    backingAsset.precision
-                                                ),
-                                            backingAsset.precision,
-                                            false
-                                        )}
-                                        symbol={selectedAsset}
-                                    />
-                                </div>
-                            ) : null}
-                            {this.state.isOpenledger && (
-                                <Translate
-                                    className="grid-block container-row maxDeposit"
-                                    style={{fontSize: "1rem"}}
-                                    content="gateway.min_deposit_warning_amount"
-                                    minDeposit={backingAsset.gateFee * 2 || 0}
-                                    coin={selectedAsset}
-                                />
-                            )}
+                            <Translate
+                                className="grid-block container-row maxDeposit"
+                                style={{fontSize: "1rem"}}
+                                content="gateway.min_deposit_warning_amount"
+                                minDeposit={minDeposit || 0}
+                                coin={selectedAsset}
+                            />
 
                             <div className="grid-block container-row">
                                 <div style={{paddingRight: "1rem"}}>
@@ -391,17 +373,15 @@ class DepositModalContent extends DecimalChecker {
                                     </div>
                                 </div>
                             ) : null}
-                            {this.state.isOpenledger && (
-                                <Translate
-                                    component="span"
-                                    style={{fontSize: "0.8rem"}}
-                                    content="gateway.min_deposit_warning_asset"
-                                    minDeposit={backingAsset.gateFee * 2 || 0}
-                                    coin={selectedAsset}
-                                />
-                            )}
+                            <Translate
+                                component="span"
+                                style={{fontSize: "0.8rem"}}
+                                content="gateway.min_deposit_warning_asset"
+                                minDeposit={minDeposit || 0}
+                                coin={selectedAsset}
+                            />
                         </div>
-                    ) : null}
+                        : null}
                     {!usingGateway ? (
                         <div className="container-row deposit-directly">
                             <h2

--- a/app/help/en/gateways/winex.md
+++ b/app/help/en/gateways/winex.md
@@ -1,0 +1,9 @@
+# Winex Gateway Service
+
+Winex is a gateway service built on the Bitshares Exchange. A gateway service is responsible for moving cryptocurrencies to and from the Bitshares Exchange. They support a wide range of popular assets. You can easily identify those supported by Winex because they are prefixed with the word WIN.*. For example WIN.EOS etc.
+
+## Website
+[https://exchange.winex.pro/](https://exchange.winex.pro/)
+
+## Support
+- Ask For Help：support@winex.pro

--- a/app/help/en/toc.md
+++ b/app/help/en/toc.md
@@ -22,3 +22,4 @@
     * [OpenLedger](gateways/openledger.md)
     * [Rudex](gateways/rudex.md)
     * [CryptoBridge](gateways/cryptobridge.md)
+    * [Winex](gateways/winex.md)

--- a/app/lib/common/assetGatewayMixin.js
+++ b/app/lib/common/assetGatewayMixin.js
@@ -1,36 +1,9 @@
 import React from "react";
 import Translate from "react-translate-component";
 import Icon from "../../components/Icon/Icon";
-
-function _getAvailableGateways(selectedAsset, boolCheck = "depositAllowed") {
-    let {gatewayStatus} = this.state;
-
-    for (let g in gatewayStatus) {
-        gatewayStatus[g].enabled = false;
-    }
-
-    for (let g in gatewayStatus) {
-        this.props.backedCoins.get(g.toUpperCase(), []).find(c => {
-            if (
-                g == "OPEN" &&
-                selectedAsset == c.backingCoinType &&
-                c[boolCheck] &&
-                c.isAvailable
-            ) {
-                gatewayStatus.OPEN.enabled = true;
-            }
-            if (
-                g == "RUDEX" &&
-                selectedAsset == c.backingCoin &&
-                c[boolCheck]
-            ) {
-                gatewayStatus.RUDEX.enabled = true;
-            }
-        });
-    }
-
-    return gatewayStatus;
-}
+import {
+    getGatewayStatusByAsset
+} from "common/gatewayUtils";
 
 function _getCoinToGatewayMapping(boolCheck = "depositAllowed") {
     let coinToGatewayMapping = {};
@@ -56,7 +29,7 @@ function _getCoinToGatewayMapping(boolCheck = "depositAllowed") {
 
 function _openGatewaySite() {
     let {selectedGateway, gatewayStatus} = this.state;
-    let win = window.open(gatewayStatus[selectedGateway].support_url, "_blank");
+    let win = window.open("https://wallet.bitshares.org/#/help/gateways/" + gatewayStatus[selectedGateway].name, "_blank");
     win.focus();
 }
 
@@ -93,7 +66,7 @@ function _onAssetSelected(
     selectGatewayFn = null
 ) {
     const {balances, assets} = this.props || {}; //Function must be bound on calling component and these props must be passed to calling component
-    let gatewayStatus = _getAvailableGateways.call(
+    let gatewayStatus = getGatewayStatusByAsset.call(
         this,
         selectedAsset,
         boolCheck
@@ -192,10 +165,12 @@ function gatewaySelector(args) {
                             </span>
                         ) : null}
                         <span className="floatRight error-msg">
-                            {selectedGateway &&
-                            !gatewayStatus[selectedGateway].enabled ? (
+                            {!error && 
+                            selectedGateway &&
+                            gatewayStatus[selectedGateway] && 
+                            !gatewayStatus[selectedGateway].enabled ?
                                 <Translate content="modal.deposit_withdraw.disabled" />
-                            ) : null}
+                                : null}
                             {error ? (
                                 <Translate content="modal.deposit_withdraw.wallet_error" />
                             ) : null}
@@ -231,6 +206,11 @@ function gatewaySelector(args) {
                                     {gatewayStatus.OPEN.name}
                                 </option>
                             ) : null}
+                            {gatewayStatus.WIN.enabled ? (
+                                <option value="WIN">
+                                    {gatewayStatus.WIN.name}
+                                </option>
+                            ) : null}
                         </select>
                         <Icon
                             name="chevron-down"
@@ -248,7 +228,6 @@ function gatewaySelector(args) {
 }
 
 export {
-    _getAvailableGateways,
     gatewaySelector,
     _getNumberAvailableGateways,
     _onAssetSelected,

--- a/app/lib/common/blockTradesMethods.js
+++ b/app/lib/common/blockTradesMethods.js
@@ -1,5 +1,5 @@
 import ls from "./localStorage";
-import {blockTradesAPIs} from "api/apiConfig";
+import {blockTradesAPIs, openledgerAPIs} from "api/apiConfig";
 const blockTradesStorage = new ls("");
 
 let fetchInProgess = {};
@@ -14,7 +14,7 @@ function setCacheClearTimer(key) {
 }
 
 export function fetchCoins(
-    url = blockTradesAPIs.BASE_OL + blockTradesAPIs.COINS_LIST
+    url = openledgerAPIs.BASE + openledgerAPIs.COINS_LIST
 ) {
     const key = "fetchCoins_" + url;
     let currentPromise = fetchInProgess[key];
@@ -46,7 +46,7 @@ export function fetchCoins(
 }
 
 export function fetchCoinsSimple(
-    url = blockTradesAPIs.BASE_OL + blockTradesAPIs.COINS_LIST
+    url = openledgerAPIs.BASE + openledgerAPIs.COINS_LIST
 ) {
     return fetch(url)
         .then(reply =>
@@ -188,7 +188,7 @@ export function estimateInput(
 }
 
 export function getActiveWallets(
-    url = blockTradesAPIs.BASE_OL + blockTradesAPIs.ACTIVE_WALLETS
+    url = openledgerAPIs.BASE + openledgerAPIs.ACTIVE_WALLETS
 ) {
     const key = "getActiveWallets_" + url;
     let currentPromise = fetchInProgess[key];
@@ -229,7 +229,7 @@ export function getDepositAddress({coin, account, stateCallback}) {
 
     let body_string = JSON.stringify(body);
 
-    fetch(blockTradesAPIs.BASE_OL + "/simple-api/get-last-address", {
+    fetch(openledgerAPIs.BASE + "/simple-api/get-last-address", {
         method: "POST",
         headers: new Headers({
             Accept: "application/json",
@@ -272,7 +272,7 @@ export function requestDepositAddress({
     inputCoinType,
     outputCoinType,
     outputAddress,
-    url = blockTradesAPIs.BASE_OL,
+    url = openledgerAPIs.BASE,
     stateCallback
 }) {
     let body = {

--- a/app/lib/common/gatewayUtils.js
+++ b/app/lib/common/gatewayUtils.js
@@ -70,6 +70,9 @@ export function updateGatewayBackers(chain = "4018d784") {
             url: rudexAPIs.BASE + rudexAPIs.COINS_LIST
         }); 
 
+        // BlockTrades
+        GatewayActions.fetchBridgeCoins.defer();
+
         /* // GDex does not comply with current standards
         GatewayActions.fetchCoins.defer({
             backer: "GDEX",

--- a/app/lib/common/gatewayUtils.js
+++ b/app/lib/common/gatewayUtils.js
@@ -1,3 +1,25 @@
+import {Apis} from "bitsharesjs-ws";
+import GatewayActions from "actions/GatewayActions";
+import {rudexAPIs, widechainAPIs, blockTradesAPIs} from "api/apiConfig";
+
+export function getGatewayStatusByAsset(selectedAsset, boolCheck = "depositAllowed") {
+    let {gatewayStatus} = this.state;
+
+    for (let g in gatewayStatus) {
+        
+        gatewayStatus[g].enabled = false;
+        this.props.backedCoins.get(g.toUpperCase(), []).find(c => {
+            if(c[boolCheck] && 
+                (typeof c.isAvailable == "undefined" || (typeof c.isAvailable == "boolean" && c.isAvailable)) && 
+                (selectedAsset == c.backingCoinType || selectedAsset == c.backingCoin)
+            ) {
+                gatewayStatus[g].enabled = true;
+            }
+        });
+    }
+    return gatewayStatus;
+}
+
 export function getIntermediateAccount(symbol, backedCoins) {
     let {selectedGateway} = getAssetAndGateway(symbol);
     let coin = getBackedCoin(symbol, backedCoins);
@@ -26,4 +48,40 @@ export function getAssetAndGateway(symbol) {
         selectedAsset = "PPY";
     }
     return {selectedGateway, selectedAsset};
+}
+
+export function updateGatewayBackers(chain = "4018d784") {
+    // Only fetch this when on BTS main net
+    if (Apis.instance().chain_id.substr(0, 8) === chain) {
+        // OpenLedger
+        GatewayActions.fetchCoins.defer();
+
+        // WinEx
+        GatewayActions.fetchCoins.defer({
+            backer: "WIN", 
+            url: widechainAPIs.BASE + widechainAPIs.COINS_LIST,
+            urlBridge: widechainAPIs.BASE,
+            urlWallets: widechainAPIs.BASE + widechainAPIs.ACTIVE_WALLETS
+        });
+
+        // RuDEX
+        GatewayActions.fetchCoinsSimple.defer({
+            backer: "RUDEX",
+            url: rudexAPIs.BASE + rudexAPIs.COINS_LIST
+        }); 
+
+        /* // GDex does not comply with current standards
+        GatewayActions.fetchCoins.defer({
+            backer: "GDEX",
+            url: 
+        });
+        */
+
+        /*
+        // BlockTrades
+        GatewayActions.fetchCoins.defer({
+            backer: "TRADE"
+        }); 
+        */
+    } 
 }

--- a/app/lib/common/gateways.js
+++ b/app/lib/common/gateways.js
@@ -1,0 +1,36 @@
+/**
+ * Settings storage for all Gateway Services
+ * General API Settings are stored in api/apiConfig and should be imported here
+ */
+
+import {rudexAPIs, widechainAPIs, blockTradesAPIs} from "api/apiConfig";
+
+export function getAvailableGateways() {
+    return {
+        OPEN: {
+            id: "OPEN",
+            name: "OPENLEDGER",
+            enabled: false,
+            selected: false,
+            baseAPI: blockTradesAPIs
+        },
+        RUDEX: {
+            id: "RUDEX",
+            name: "RUDEX",
+            enabled: false,
+            selected: false,
+            baseAPI: rudexAPIs
+        },
+        WIN: {
+            id: "WIN",
+            name: "Winex",
+            enabled: false,
+            selected: false,
+            baseAPI: widechainAPIs
+        }
+
+    };
+}
+
+
+

--- a/app/lib/common/gateways.js
+++ b/app/lib/common/gateways.js
@@ -3,7 +3,7 @@
  * General API Settings are stored in api/apiConfig and should be imported here
  */
 
-import {rudexAPIs, widechainAPIs, blockTradesAPIs} from "api/apiConfig";
+import {rudexAPIs, widechainAPIs, openledgerAPIs} from "api/apiConfig";
 
 export function getAvailableGateways() {
     return {
@@ -12,7 +12,7 @@ export function getAvailableGateways() {
             name: "OPENLEDGER",
             enabled: false,
             selected: false,
-            baseAPI: blockTradesAPIs
+            baseAPI: openledgerAPIs
         },
         RUDEX: {
             id: "RUDEX",

--- a/app/stores/GatewayStore.js
+++ b/app/stores/GatewayStore.js
@@ -25,7 +25,7 @@ class GatewayStore {
     onFetchCoins({backer, coins, backedCoins, down} = {}) {
         if (backer && coins) {
             this.backedCoins = this.backedCoins.set(backer, backedCoins);
-
+            
             ss.set("backedCoins", this.backedCoins.toJS());
 
             this.down = this.down.set(backer, false);


### PR DESCRIPTION
# Fixes Issue #1275 + #1244  

This PR contains many changes and are also part of #1244 (Backend Cleaning). It contains a starting base for unifying adding new gateways in a simpler fashion than having to write a whole new section, using the new Modal Deposit/Withdraw.

A lot of redundant code has been moved or removed.

- Adding Winex
- Fix Deposit Address checker (was always checking against OL)
- Updating Help to contain Winex information
- Moving backingAsset calls to one specific section
- Replacing backingAsset calls with cache
- Only update backingAssets when app starts
- Initial Move of common Gateway Settings
- Many Gateway specific code sections are replaced to support general gateway additions
- Update Deposit/Withdraw Modals
- Always display deposit warning regardless of gateway.
- General code cleaning and optimizing

### Part of a second update these things have been fixed
- Move BlockTrades calls to new updateGatewayBackers function
- Break out OL from BlockTrades API settings
- Rebase all functions with default OL calls