### PR TITLE
Issue 1396 - Full Date in Account Transaction

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -8,6 +8,7 @@
         "formats": {
             "date": {
                 "short_custom": "%e %b '%y",
+                "full": "%F %T %Z",
                 "market_history": "%e/%m %H:%M:%S",
                 "market_history_us": "%m/%e %H:%M:%S"
             }

--- a/app/components/Account/RecentTransactions.jsx
+++ b/app/components/Account/RecentTransactions.jsx
@@ -287,6 +287,7 @@ class RecentTransactions extends React.Component {
                           hideFee
                           inverted={false}
                           hideOpLabel={compactView}
+                          fullDate={true}
                       />
                   );
               })

--- a/app/components/Blockchain/BlockTime.jsx
+++ b/app/components/Blockchain/BlockTime.jsx
@@ -64,12 +64,7 @@ class BlockTime extends React.Component {
                     this.props.fullDate ? 
                         counterpart.localize(new Date(this.state.time), {
                             type: "date",
-                            format:
-                                getLocale()
-                                    .toLowerCase()
-                                    .indexOf("en-us") !== -1
-                                    ? "market_history_us"
-                                    : "market_history"
+                            format: "full"
                         }) : 
                         <TimeAgo time={this.state.time} /> 
                     : null

--- a/app/components/Blockchain/BlockTime.jsx
+++ b/app/components/Blockchain/BlockTime.jsx
@@ -3,6 +3,8 @@ import BindToChainState from "../Utility/BindToChainState";
 import ChainTypes from "../Utility/ChainTypes";
 import TimeAgo from "../Utility/TimeAgo";
 import utils from "common/utils";
+import counterpart from "counterpart";
+import getLocale from "browser-locale";
 
 /**
  * @brief displays block's date and time based on block number
@@ -58,7 +60,20 @@ class BlockTime extends React.Component {
     render() {
         return (
             <span className="time" key={this.props.block_number}>
-                {this.state.time ? <TimeAgo time={this.state.time} /> : null}
+                {this.state.time ? 
+                    this.props.fullDate ? 
+                        counterpart.localize(new Date(this.state.time), {
+                            type: "date",
+                            format:
+                                getLocale()
+                                    .toLowerCase()
+                                    .indexOf("en-us") !== -1
+                                    ? "market_history_us"
+                                    : "market_history"
+                        }) : 
+                        <TimeAgo time={this.state.time} /> 
+                    : null
+                }
             </span>
         );
     }

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -147,7 +147,10 @@ class Row extends React.Component {
                 </td>
                 <td>
                     {!this.props.hideDate ? (
-                        <BlockTime block_number={block} />
+                        <BlockTime 
+                            block_number={block} 
+                            fullDate={this.props.fullDate} 
+                        />
                     ) : null}
                 </td>
             </tr>
@@ -1318,6 +1321,7 @@ class Operation extends React.Component {
                 info={column}
                 hideFee={this.props.hideFee}
                 hidePending={this.props.hidePending}
+                fullDate={this.props.fullDate}
             />
         ) : null;
 


### PR DESCRIPTION
# Fixes Issue #1396 

View full date in account transaction
- Changes to BlockTime and Operation
  - Adding 'fullDate' prop to BlockTime + Operation
  - View fullDate based on fullDate true/false

- Additions to Counterpart.Localize
  - Adding `format: "full"` to view full date incl. timezone


