### PR TITLE
Api nodes

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -91,6 +91,7 @@ export const settingsAPIs = {
         {url: "wss://ws.hellobts.com/", location: "Japan"},
         {url: "wss://bitshares.cyberit.io/", location: "Hong Kong"},
         {url: "wss://bts-seoul.clockwork.gr/", location: "Seoul, Korea"},
+        {url: "wss://bts.to0l.cn:4443/ws", location: "China"},
         // Testnet
         {
             url: "wss://node.testnet.bitshares.eu",

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -51,10 +51,12 @@ export const settingsAPIs = {
         {url: "wss://ws.gdex.top", location: "China"},
         {url: "wss://dex.rnglab.org", location: "Netherlands"},
         {url: "wss://dexnode.net/ws", location: "Dallas, USA"},
+        {url: "wss://la.dexnode.net/ws", location: "LA, USA"},
         {url: "wss://kc-us-dex.xeldal.com/ws", location: "Kansas City, USA"},
         {url: "wss://btsza.co.za:8091/ws", location: "Cape Town, South Africa"},
         {url: "wss://api.bts.blckchnd.com", location: "Falkenstein, Germany"},
         {url: "wss://api-ru.bts.blckchnd.com", location: "Moscow, Russia"},
+        {url: "wss://node.market.rudex.org", location: "Germany"},
         {
             url: "wss://eu.nodes.bitshares.ws",
             location: "Central Europe - BitShares Infrastructure Program"
@@ -74,6 +76,21 @@ export const settingsAPIs = {
             location: "Global (Asia Pacific (Singapore) / US East (N. Virginia) / EU (London))"
         },
         {url: "wss://api.bts.network", location: "East Coast, USA"},
+        {url: "wss://btsws.roelandp.nl/ws", location: "Canada"},
+        {url: "wss://api.bitshares.bhuz.info/ws", location: "Europe"},
+        {url: "wss://bts-api.lafona.net/ws", location: "USA"},
+        {url: "wss://kimziv.com/ws", location: "Singapore"},
+        {url: "wss://api.btsgo.net/ws", location: "Singapore"},
+        {url: "wss://bts.proxyhosts.info/wss", location: "Germany"},
+        {url: "wss://bts.open.icowallet.net/ws", location: "Hangzhou, China"},
+        {url: "wss://blockzms.xyz/ws", location: "USA"},
+        {url: "wss://crazybit.online", location: "China"},
+        {url: "wss://freedom.bts123.cc:15138/", location: "China"},
+        {url: "wss://bitshares.bts123.cc:15138/", location: "China"},
+        {url: "wss://api.bts.ai/", location: "Beijing, China"},
+        {url: "wss://ws.hellobts.com/", location: "Japan"},
+        {url: "wss://bitshares.cyberit.io/", location: "Hong Kong"},
+        {url: "wss://bts-seoul.clockwork.gr/", location: "Seoul, Korea"},
         // Testnet
         {
             url: "wss://node.testnet.bitshares.eu",

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -41,7 +41,7 @@ export const settingsAPIs = {
         {url: "wss://eu.openledger.info/ws", location: "Berlin, Germany"},
         {url: "wss://bitshares.nu/ws", location: "Stockholm, Sweden"},
         {url: "wss://bit.btsabc.org/ws", location: "Hong Kong"},
-        {url: "wss://bts.ai.la/ws", location: "Hong Kong"},
+        {url: "wss://node.btscharts.com/ws", location: "Hong Kong"},
         {url: "wss://bitshares.apasia.tech/ws", location: "Bangkok, Thailand"},
         {url: "wss://japan.bitshares.apasia.tech/ws", location: "Tokyo, Japan"},
         {url: "wss://bitshares.dacplay.org/ws", location: "Hangzhou, China"},

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -76,7 +76,7 @@ export const settingsAPIs = {
             location: "Global (Asia Pacific (Singapore) / US East (N. Virginia) / EU (London))"
         },
         {url: "wss://api.bts.network", location: "East Coast, USA"},
-        {url: "wss://btsws.roelandp.nl/ws", location: "Canada"},
+        {url: "wss://btsws.roelandp.nl/ws", location: "Finland"},
         {url: "wss://api.bitshares.bhuz.info/ws", location: "Europe"},
         {url: "wss://bts-api.lafona.net/ws", location: "USA"},
         {url: "wss://kimziv.com/ws", location: "Singapore"},

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -48,6 +48,7 @@ export const settingsAPIs = {
         {url: "wss://bitshares-api.wancloud.io/ws", location: "China"},
         {url: "wss://openledger.hk/ws", location: "Hong Kong"},
         {url: "wss://bitshares.crypto.fans/ws", location: "Munich, Germany"},
+        {url: "wss://ws.gdex.io", location: "Japan"},
         {url: "wss://ws.gdex.top", location: "China"},
         {url: "wss://dex.rnglab.org", location: "Netherlands"},
         {url: "wss://dexnode.net/ws", location: "Dallas, USA"},


### PR DESCRIPTION
Added API nodes provided by witnesses, for issue <del>#1390 and</del> #1391.

As of writing, some nodes are not online (and I've reported to the maintainers), but since they claimed that they'll maintain the nodes, I added them anyway. Since UI will usually detect latency of nodes and use the fastest one, it should not matter if some nodes are offline. In the future if we found some nodes are never online, we can always remove them.

Update: latest news from apasia is that their nodes are being reorganized, so I removed them and force pushed.