### PR TITLE
#1319 Missing Asset Description

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -8,7 +8,6 @@ import FormattedPrice from "../Utility/FormattedPrice";
 import AssetName from "../Utility/AssetName";
 import TimeAgo from "../Utility/TimeAgo";
 import HelpContent from "../Utility/HelpContent";
-import Icon from "../Icon/Icon";
 import assetUtils from "common/asset_utils";
 import utils from "common/utils";
 import FormattedTime from "../Utility/FormattedTime";
@@ -234,10 +233,7 @@ class Asset extends React.Component {
         var issuer = ChainStore.getObject(asset.issuer, false, false);
         var issuerName = issuer ? issuer.get("name") : "";
 
-        var icon = <Icon name="asset" className="asset" size="4x" />;
-
         // Add <a to any links included in the description
-
         let description = assetUtils.parseDescription(
             asset.options.description
         );

--- a/app/components/Utility/HelpContent.jsx
+++ b/app/components/Utility/HelpContent.jsx
@@ -90,7 +90,7 @@ class HelpContent extends React.Component {
 
     setVars(str, hideIssuer) {
         if (hideIssuer == "true") {
-            var str = str.replace(/^.*{issuer}.*$/gm, "");
+            str = str.replace(/<p>[^<]*{issuer}[^<]*<\/p>/gm, "");
         }
 
         return str.replace(/(\{.+?\})/gi, (match, text) => {
@@ -105,7 +105,6 @@ class HelpContent extends React.Component {
                 );
             if (value.date) value = utils.format_date(value.date);
             if (value.time) value = utils.format_time(value.time);
-            // console.log("-- var -->", key, value);
             return value;
         });
     }
@@ -160,7 +159,9 @@ class HelpContent extends React.Component {
             return !null;
         }
 
-        if (this.props.section) value = value[this.props.section];
+        if (this.props.section) {
+            value = value[this.props.section];
+        }
 
         if (!value) {
             console.error(


### PR DESCRIPTION
Fix for #1319 

Limited a greedy regex that was wiping out the description on the asset view. I suspect it only occurred on production due to whitespace/multiline minification.