### PR TITLE
#1446: Showing "Switch Node" popup only on node description hover, but not the Help button.

### DIFF
--- a/app/components/Layout/Footer.jsx
+++ b/app/components/Layout/Footer.jsx
@@ -46,7 +46,8 @@ class Footer extends React.Component {
         return (
             nextProps.dynGlobalObject !== this.props.dynGlobalObject ||
             nextProps.backup_recommended !== this.props.backup_recommended ||
-            nextProps.rpc_connection_status !== this.props.rpc_connection_status ||
+            nextProps.rpc_connection_status !==
+                this.props.rpc_connection_status ||
             nextProps.synced !== this.props.synced ||
             nextState.showNodesPopup !== this.state.showNodesPopup
         );
@@ -152,9 +153,7 @@ class Footer extends React.Component {
         let getNode = this.getNode.bind(this);
         let currentNodeIndex = this.getCurrentNodeIndex.call(this);
 
-        let activeNode = getNode(
-            nodes[currentNodeIndex] || nodes[0]
-        );
+        let activeNode = getNode(nodes[currentNodeIndex] || nodes[0]);
 
         if (activeNode.url == autoSelectAPI) {
             let nodeUrl = props.activeNode;
@@ -268,16 +267,16 @@ class Footer extends React.Component {
                             </span>
                         ) : null}
                         {block_height ? (
-                            <div 
-                                onMouseEnter={() => {
-                                    this.setState({showNodesPopup: true});
-                                }}
-                                onMouseLeave={() => {
-                                    this.setState({showNodesPopup: false});
-                                }}
-                                className="grid-block shrink"
-                            >
-                                <div style={{position: "relative"}}>
+                            <div className="grid-block shrink">
+                                <div
+                                    onMouseEnter={() => {
+                                        this.setState({showNodesPopup: true});
+                                    }}
+                                    onMouseLeave={() => {
+                                        this.setState({showNodesPopup: false});
+                                    }}
+                                    style={{position: "relative"}}
+                                >
                                     <div className="footer-status">
                                         {!connected ? (
                                             <span className="warning">
@@ -325,22 +324,24 @@ class Footer extends React.Component {
                         )}
                     </div>
                 </div>
-                <div 
+                <div
                     onMouseEnter={() => {
                         this.setState({showNodesPopup: true});
                     }}
                     onMouseLeave={() => {
                         this.setState({showNodesPopup: false});
                     }}
-                    className="node-access-popup" 
+                    className="node-access-popup"
                     style={{display: this.state.showNodesPopup ? "" : "none"}}
                 >
                     <AccessSettings
                         nodes={this.props.defaults.apiServer}
                         popup={true}
                     />
-                    <div style={{paddingTop: 15}} >
-                        <a onClick={this.onAccess.bind(this)}><Translate content="footer.advanced_settings" /></a>
+                    <div style={{paddingTop: 15}}>
+                        <a onClick={this.onAccess.bind(this)}>
+                            <Translate content="footer.advanced_settings" />
+                        </a>
                     </div>
                 </div>
                 <div
@@ -381,7 +382,12 @@ class AltFooter extends Component {
         var wallet = WalletDb.getWallet();
         return (
             <AltContainer
-                stores={[CachedPropertyStore, BlockchainStore, WalletDb, SettingsStore]}
+                stores={[
+                    CachedPropertyStore,
+                    BlockchainStore,
+                    WalletDb,
+                    SettingsStore
+                ]}
                 inject={{
                     defaults: () => {
                         return SettingsStore.getState().defaults;
@@ -389,11 +395,15 @@ class AltFooter extends Component {
                     apiLatencies: () => {
                         return SettingsStore.getState().apiLatencies;
                     },
-                    currentNode: () => { 
-                        return SettingsStore.getState().settings.get("apiServer");
+                    currentNode: () => {
+                        return SettingsStore.getState().settings.get(
+                            "apiServer"
+                        );
                     },
                     activeNode: () => {
-                        return SettingsStore.getState().settings.get("activeNode");
+                        return SettingsStore.getState().settings.get(
+                            "activeNode"
+                        );
                     },
                     backup_recommended: () =>
                         wallet &&


### PR DESCRIPTION
Actual change takes only a few lines (271-280), the rest is changed by formatting plugin.