### PR TITLE
1437 - Fix calls order fail

### DIFF
--- a/app/components/Wallet/WalletUnlockModal.jsx
+++ b/app/components/Wallet/WalletUnlockModal.jsx
@@ -189,8 +189,8 @@ class WalletUnlockModal extends React.Component {
             WalletUnlockActions.change();
             if (stopAskingForBackup) WalletActions.setBackupDate();
             else if (this.shouldUseBackupLogin()) this.backup();
-            WalletUnlockActions.cancel();
             resolve();
+            WalletUnlockActions.cancel();
         }
     };
 


### PR DESCRIPTION
I failed a call order and the unlock modal doesn't resolve whatever called it.
The symptom is that you have to click again after unlock.