### PR TITLE
Issue 1516 - Exchange Header Tooltip Issue

### DIFF
--- a/app/components/Exchange/ExchangeHeader.jsx
+++ b/app/components/Exchange/ExchangeHeader.jsx
@@ -313,7 +313,7 @@ export default class ExchangeHeader extends React.Component {
                                     <PriceStatWithLabel
                                         ignoreColorChange={true}
                                         toolTip={counterpart.translate(
-                                            "tooltip.settle_price"
+                                            "tooltip.feed_price"
                                         )}
                                         ready={marketReady}
                                         className="hide-order-3"


### PR DESCRIPTION
# Fixes Issue #1516

Exchange header tooltip wasn't correct for the feed price, as it showed the value of settle price.