### PR TITLE
Fix #1517 - Remove hardcoded network fee percentage

### DIFF
--- a/app/components/Blockchain/Fees.jsx
+++ b/app/components/Blockchain/Fees.jsx
@@ -47,6 +47,7 @@ class FeeGroup extends React.Component {
         const core_asset = ChainStore.getAsset("1.3.0");
 
         let current_fees = globalObject.parameters.current_fees;
+        let network_fee = globalObject.parameters.network_percent_of_fee / 1e4;
         let scale = current_fees.scale;
         let feesRaw = current_fees.parameters;
         let preferredUnit = settings.get("unit") || core_asset.get("symbol");
@@ -69,11 +70,10 @@ class FeeGroup extends React.Component {
             let operation_name = ops[opId];
             let feename = trxTypes[operation_name];
 
-            let feeRateForLTM = 0.2;
+            let feeRateForLTM = network_fee;
             if (opId === 10) {
-                // Asset creation fee for LTM is 60% of standart user
                 // See https://github.com/bitshares/bitshares-ui/issues/996
-                feeRateForLTM = 0.6;
+                feeRateForLTM = 0.5 + 0.5 * network_fee;
             }
 
             let rows = [];


### PR DESCRIPTION
Since the fee percentage the network keeps is dynamic and settable in global properties, it should be read from the global properties object (2.0.0).