### PR TITLE
Issue 1535 - Enable asset links in transactions

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1449,7 +1449,7 @@
     "transaction": {
         "amount_sell": "Amount to sell",
         "asset_claim_fees":
-            "claimed asset fees of %(balance_amount)s from %(asset)s fee pool",
+            "claimed asset fees of {balance_amount} from {asset} fee pool",
         "asset_reserve": "burned asset amount",
         "at": "at",
         "balance_id": "Balance ID",

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -1189,14 +1189,12 @@ class Operation extends React.Component {
                             asset={op[1].amount_to_claim.asset_id}
                         >
                             {({asset}) => (
-                                <Translate
-                                    component="span"
-                                    content="transaction.asset_claim_fees"
-                                    balance_amount={utils.format_asset(
-                                        op[1].amount_to_claim.amount,
-                                        asset
-                                    )}
-                                    asset={asset.get("symbol")}
+                                <TranslateWithLinks
+                                    string="transaction.asset_claim_fees"
+                                    keys={[
+                                        {type: "amount", value: op[1].amount_to_claim, arg: "balance_amount"},
+                                        {type: "asset", value: asset.get("id"), arg: "asset"}
+                                    ]}
                                 />
                             )}
                         </BindToChainState.Wrapper>

--- a/app/components/Blockchain/ProposedOperation.jsx
+++ b/app/components/Blockchain/ProposedOperation.jsx
@@ -1117,14 +1117,12 @@ class ProposedOperation extends React.Component {
                             asset={op[1].amount_to_claim.asset_id}
                         >
                             {({asset}) => (
-                                <Translate
-                                    component="span"
-                                    content="proposal.asset_claim_fees"
-                                    balance_amount={utils.format_asset(
-                                        op[1].amount_to_claim.amount,
-                                        asset
-                                    )}
-                                    asset={asset.get("symbol")}
+                                <TranslateWithLinks
+                                    string="transaction.asset_claim_fees"
+                                    keys={[
+                                        {type: "amount", value: op[1].amount_to_claim, arg: "balance_amount"},
+                                        {type: "asset", value: asset.get("id"), arg: "asset"}
+                                    ]}
                                 />
                             )}
                         </BindToChainState.Wrapper>

--- a/app/components/Utility/TranslateWithLinks.jsx
+++ b/app/components/Utility/TranslateWithLinks.jsx
@@ -82,12 +82,16 @@ export default class TranslateWithLinks extends React.Component {
 
                     case "amount":
                         value = (
-                            <FormattedAsset
-                                amount={key.value.amount}
-                                asset={key.value.asset_id}
-                                decimalOffset={key.decimalOffset}
-                            />
-                        );
+                            <span>
+                                <FormattedAsset
+                                    amount={key.value.amount}
+                                    asset={key.value.asset_id}
+                                    decimalOffset={key.decimalOffset}
+                                    hide_asset
+                                />&nbsp;
+                                {this.linkToAsset(key.value.asset_id)}
+                            </span>);
+                        
                         break;
 
                     case "price":


### PR DESCRIPTION
# Fixes Issue #1535 

Includes Asset links inside transaction translations for accounts.

![image](https://user-images.githubusercontent.com/12114550/40270933-1f3b5830-5b96-11e8-956d-d4cb5f1ee566.png)
