### PR TITLE
Issue 1534 - Use correct asset precision for Core Exchange Rate update

### DIFF
--- a/app/components/Account/AccountAssetUpdate.jsx
+++ b/app/components/Account/AccountAssetUpdate.jsx
@@ -616,9 +616,7 @@ class AccountAssetUpdate extends React.Component {
 
         amount.amount = utils.limitByPrecision(
             amount.amount,
-            type === "quote"
-                ? this.props.asset.get("precision")
-                : this.props.core.get("precision")
+            amount.asset.get("precision")
         );
 
         let {core_exchange_rate} = this.state;


### PR DESCRIPTION
# Fixes Issue #1534


Use the correct assets precision for CER

![bitshares-assetprecision](https://user-images.githubusercontent.com/12114550/40271443-a676128e-5b9d-11e8-8d1a-0a8b368c41fe.gif)

