### PR TITLE
#1448 Display walkthrough when user opens exchange for the first time

### DIFF
--- a/app/actions/SettingsActions.js
+++ b/app/actions/SettingsActions.js
@@ -68,6 +68,10 @@ class SettingsActions {
     setExchangeLastExpiration(value) {
         return value;
     }
+
+    setExchangeTutorialShown(value) {
+        return value;
+    }
 }
 
 export default alt.createActions(SettingsActions);

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {PropTypes} from "react";
 import MarketsActions from "actions/MarketsActions";
+import SettingsStore from "stores/SettingsStore";
 import {MyOpenOrders} from "./MyOpenOrders";
 import OrderBook from "./OrderBook";
 import MarketHistory from "./MarketHistory";
@@ -29,6 +30,8 @@ import {Apis} from "bitsharesjs-ws";
 import {checkFeeStatusAsync} from "common/trxHelper";
 import LoadingIndicator from "../LoadingIndicator";
 import moment from "moment";
+import guide from "intro.js";
+import translator from "counterpart";
 
 Highcharts.setOptions({
     global: {
@@ -328,8 +331,50 @@ class Exchange extends React.Component {
         }
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps, prevState) {
         this._initPsContainer();
+
+        if (
+            !this.state.isTutorialShown &&
+            prevProps.coreAsset &&
+            prevState.feeStatus
+        ) {
+            if (!this.props.exchange.get("tutorialShown")) {
+                // use setState to immediately block
+                // new help hint because
+                // settingsStore takes effect with a little delay
+                this.setState({
+                    isTutorialShown: true
+                });
+
+                const theme = SettingsStore.getState().settings.get("themes");
+
+                guide
+                    .introJs()
+                    .setOptions({
+                        tooltipClass: theme,
+                        highlightClass: theme,
+                        showBullets: false,
+                        hideNext: true,
+                        hidePrev: true,
+                        nextLabel: translator.translate(
+                            "walkthrough.next_label"
+                        ),
+                        prevLabel: translator.translate(
+                            "walkthrough.prev_label"
+                        ),
+                        skipLabel: translator.translate(
+                            "walkthrough.skip_label"
+                        ),
+                        doneLabel: translator.translate(
+                            "walkthrough.done_label"
+                        )
+                    })
+                    .start();
+
+                SettingsActions.setExchangeTutorialShown(true);
+            }
+        }
     }
 
     _initPsContainer() {

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -347,7 +347,7 @@ class Exchange extends React.Component {
                     isTutorialShown: true
                 });
 
-                const theme = SettingsStore.getState().settings.get("themes");
+                const theme = this.props.settings.get("themes");
 
                 guide
                     .introJs()

--- a/app/stores/SettingsStore.js
+++ b/app/stores/SettingsStore.js
@@ -24,6 +24,8 @@ class SettingsStore {
         this.bindListeners({
             onSetExchangeLastExpiration:
                 SettingsActions.setExchangeLastExpiration,
+            onSetExchangeTutorialShown:
+                SettingsActions.setExchangeTutorialShown,
             onChangeSetting: SettingsActions.changeSetting,
             onChangeViewSetting: SettingsActions.changeViewSetting,
             onChangeMarketDirection: SettingsActions.changeMarketDirection,
@@ -492,6 +494,10 @@ class SettingsStore {
 
     onSetExchangeLastExpiration(value) {
         this.setExchangeSettings("lastExpiration", fromJS(value));
+    }
+
+    onSetExchangeTutorialShown(value) {
+        this.setExchangeSettings("tutorialShown", value);
     }
 
     getExhchangeLastExpiration() {


### PR DESCRIPTION
**Tested on MacOS:**

- [x] Firefox
- [x] Chrome
- [x] Opera

**Issue:** #1448