### PR TITLE
Issue 1557 - Use order ID consistently

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1261,14 +1261,14 @@
             "{account} changed {debtSymbol} debt by {debt} and collateral by {collateral}",
         "committee_member_update_global_parameters":
             "{account} updated the global committee parameters",
-        "fill_order_buy": "{account} bought {amount} at {price}",
-        "fill_order_sell": "{account} sold {amount} at {price}",
+        "fill_order_buy": "{account} bought {amount} at {price} for order #%(order)s",
+        "fill_order_sell": "{account} sold {amount} at {price} for order #%(order)s",
         "lifetime_upgrade_account": "{account} was upgraded to lifetime member",
         "limit_order_buy":
-            "{account} placed an order to buy {amount} at {price}",
+            "{account} placed order #%(order)s to buy {amount} at {price}",
         "limit_order_cancel": "{account} cancelled order #%(order)s",
         "limit_order_sell":
-            "{account} placed an order to sell {amount} at {price}",
+            "{account} placed order #%(order)s to sell {amount} at {price}",
         "no_recent": "No recent transactions",
         "override_transfer":
             "{issuer} transferred {amount} from {from} to {to}",
@@ -1322,11 +1322,11 @@
         "feed_producer":
             "Update the feed producers for the asset {asset} using the account {account}",
         "limit_order_buy":
-            "Place an order to buy {amount} at {price} for {account}",
+            "Place order #%(order)s to buy {amount} at {price} for {account}",
         "limit_order_create":
-            "Place order to buy %(buy_amount)s for %(sell_amount)s for %(account)s",
+            "Place an order to buy %(buy_amount)s for %(sell_amount)s for %(account)s",
         "limit_order_sell":
-            "Place an order to sell {amount} at {price} for {account}",
+            "Place order #%(order)s to sell {amount} at {price} for {account}",
         "override_transfer":
             "Transfer {amount} from {from} to {to} by authority of {issuer}",
         "proposals": "Proposals",

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -204,7 +204,7 @@ class Operation extends React.Component {
     }
 
     render() {
-        let {op, current, block} = this.props;
+        let {op, current, block, result} = this.props;
         let line = null,
             column = null,
             color = "info";
@@ -326,6 +326,9 @@ class Operation extends React.Component {
                                                 arg: "price"
                                             }
                                         ]}
+                                        params={{
+                                            order: result[1].substring(4)
+                                        }}
                                     />
                                 );
                             }}
@@ -1013,6 +1016,9 @@ class Operation extends React.Component {
                                                 arg: "price"
                                             }
                                         ]}
+                                        params={{
+                                            order: o.order_id.substring(4)
+                                        }}
                                     />
                                 );
                             }}

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -67,7 +67,10 @@ class TableHeader extends React.Component {
         ) : (
             <thead>
                 <tr>
-                    <th style={leftAlign} colSpan="5">
+                    <th style={leftAlign}>
+                        <Translate content="transaction.order_id" />
+                    </th>
+                    <th style={leftAlign} colSpan="4">
                         <Translate content="exchange.description" />
                     </th>
                     <th style={leftAlign}>
@@ -195,7 +198,10 @@ class OrderRow extends React.Component {
             </tr>
         ) : (
             <tr key={order.id} className="clickable">
-                <td colSpan="5" style={leftAlign} onClick={this.props.onFlip}>
+                <td style={leftAlign}>
+                    #{order.id.substring(4)}
+                </td>
+                <td colSpan="4" style={leftAlign} onClick={this.props.onFlip}>
                     {isBid ? (
                         <Translate
                             content="exchange.buy_description"


### PR DESCRIPTION
# Resolves Issue #1557
Adds order id consistantly on open orders and transactions history.