### PR TITLE
Issue #1566 - UI Update for BSIP-0037

### DIFF
--- a/app/components/Account/AccountAssetCreate.jsx
+++ b/app/components/Account/AccountAssetCreate.jsx
@@ -477,7 +477,7 @@ class AccountAssetCreate extends React.Component {
                 // Enforce uppercase
                 const symbol = target.value.toUpperCase();
                 // Enforce characters
-                let regexp = new RegExp("^[.A-Z]+$");
+                let regexp = new RegExp("^[.A-Z0-9]+$");
                 if (symbol !== "" && !regexp.test(symbol)) {
                     break;
                 }


### PR DESCRIPTION
# Resolves Issue #1566
- Allow numbers in asset name

Requires BitsharesJS PR https://github.com/bitshares/bitsharesjs/pull/22

![bitshares-bsip0037](https://user-images.githubusercontent.com/12114550/41376156-a81b3708-6f58-11e8-8a08-9d565c3fbc2d.gif)

