### PR TITLE
Issue #1547 - Support New OPs 47 + 48

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1252,9 +1252,11 @@
         "asset_reserve": "{account} burned (reserved) {amount}",
         "asset_settle": "{account} requested settlement of {amount}",
         "asset_settle_cancel": "{account} cancelled settlement of {amount}",
+        "asset_claim_pool": "{account} claimed {amount} for {asset}", 
         "asset_update": "{account} updated the asset {asset}",
         "asset_update_feed_producers":
             "{account} updated the feed producers for the asset {asset}",
+        "asset_update_issuer": "{from_account} transfered {asset} to {to_account}",
         "balance_claim": "{account} claimed a balance of {amount}",
         "blacklisted_by": "{lister} blacklisted the account {listee}",
         "call_order_update":
@@ -1637,6 +1639,7 @@
             "all": "Show all",
             "assert": "Assert operation",
             "asset_claim_fees": "Claim asset fees",
+            "asset_claim_pool": "Claim pool asset",
             "asset_create": "Create asset",
             "asset_fund_fee_pool": "Fund asset fee pool",
             "asset_global_settle": "Global asset settlement",
@@ -1648,6 +1651,7 @@
             "asset_update": "Update asset",
             "asset_update_bitasset": "Update SmartCoin",
             "asset_update_feed_producers": "Update asset feed producers",
+            "asset_update_issuer": "Update asset issuer",
             "balance_claim": "Claim balance",
             "blind_transfer": "Blinded transfer",
             "call_order_update": "Update margin",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1252,11 +1252,11 @@
         "asset_reserve": "{account} burned (reserved) {amount}",
         "asset_settle": "{account} requested settlement of {amount}",
         "asset_settle_cancel": "{account} cancelled settlement of {amount}",
-        "asset_claim_pool": "{account} claimed {amount} for {asset}", 
+        "asset_claim_pool": "{account} claimed {amount} from asset {asset}'s fee pool", 
         "asset_update": "{account} updated the asset {asset}",
         "asset_update_feed_producers":
             "{account} updated the feed producers for the asset {asset}",
-        "asset_update_issuer": "{from_account} transfered {asset} to {to_account}",
+        "asset_update_issuer": "{from_account} transferred {asset} to {to_account}",
         "balance_claim": "{account} claimed a balance of {amount}",
         "blacklisted_by": "{lister} blacklisted the account {listee}",
         "call_order_update":
@@ -1639,7 +1639,7 @@
             "all": "Show all",
             "assert": "Assert operation",
             "asset_claim_fees": "Claim asset fees",
-            "asset_claim_pool": "Claim pool asset",
+            "asset_claim_pool": "Claim asset fee pool",
             "asset_create": "Create asset",
             "asset_fund_fee_pool": "Fund asset fee pool",
             "asset_global_settle": "Global asset settlement",

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -1299,6 +1299,56 @@ class Operation extends React.Component {
                     />
                 );
                 break;
+            
+            case "asset_claim_pool": 
+                column = (
+                    <TranslateWithLinks
+                        string="operation.asset_claim_pool"
+                        keys={[
+                            {
+                                type: "account",
+                                value: op[1].issuer,
+                                arg: "account"
+                            },
+                            {
+                                type: "asset",
+                                value: op[1].asset_id,
+                                arg: "asset"
+                            },
+                            {
+                                type: "amount",
+                                value: op[1].amount_to_claim,
+                                arg: "amount"
+                            }
+                        ]}
+                    />
+                );
+                break;
+
+            case "asset_update_issuer":
+                column = (
+                    <TranslateWithLinks
+                        string="operation.asset_update_issuer"
+                        keys={[
+                            {
+                                type: "account",
+                                value: op[1].issuer,
+                                arg: "from_account"
+                            },
+                            {
+                                type: "account",
+                                value: op[1].new_issuer,
+                                arg: "to_account"
+                            },
+                            {
+                                type: "asset",
+                                value: op[1].asset_to_update,
+                                arg: "asset"
+                            }
+                        ]}
+                    />
+                );
+                break;
 
             default:
                 console.log("unimplemented op:", op);

--- a/app/components/Blockchain/Transaction.jsx
+++ b/app/components/Blockchain/Transaction.jsx
@@ -1933,6 +1933,96 @@ class Transaction extends React.Component {
 
                     break;
 
+                case "asset_claim_pool":
+                    rows.push(
+                        <tr key={key++}>
+                            <td>
+                                <Translate
+                                    component="span"
+                                    content="account.name"
+                                />
+                            </td>
+                            <td>
+                                <LinkToAccountById account={op[1].issuer} />
+                            </td>
+                        </tr>
+                    );
+                    rows.push(
+                        <tr key={key++}>
+                            <td>
+                                <Translate
+                                    component="span"
+                                    content="explorer.asset.title"
+                                />
+                            </td>
+                            <td>
+                                <LinkToAssetById asset={op[1].asset_id} />
+                            </td>
+                        </tr>
+                    );
+
+                    rows.push(
+                        <tr key={key++}>
+                            <td>
+                                <Translate
+                                    component="span"
+                                    content="transfer.amount"
+                                />
+                            </td>
+                            <td>
+                                <FormattedAsset 
+                                    amount={op[1].amount_to_claim.amount}
+                                    asset={op[1].amount_to_claim.asset_id} />
+                                </td>
+                        </tr>
+                    );
+                break;
+
+                case "asset_update_issuer":
+                    rows.push(
+                        <tr key={key++}>
+                            <td>
+                                <Translate
+                                    component="span"
+                                    content="transfer.from"
+                                />
+                            </td>
+                            <td>
+                                <LinkToAccountById account={op[1].issuer} />
+                            </td>
+                        </tr>
+                    );
+
+                    rows.push(
+                        <tr key={key++}>
+                            <td>
+                                <Translate
+                                    component="span"
+                                    content="transfer.to"
+                                />
+                            </td>
+                            <td>
+                                <LinkToAccountById account={op[1].new_issuer} />
+                            </td>
+                        </tr>
+                    );
+
+                    rows.push(
+                        <tr key={key++}>
+                            <td>
+                                <Translate
+                                    component="span"
+                                    content="explorer.asset.title"
+                                />
+                            </td>
+                            <td>
+                                <LinkToAssetById asset={op[1].asset_to_update} />
+                            </td>
+                        </tr>
+                    );
+
+                    break;
+
                 default:
                     console.log("unimplemented op:", op);
 


### PR DESCRIPTION
# Issue #1547
Adds support for the following new OPs
- asset_claim_pool: 47
- asset_update_issuer: 48