### PR TITLE
Slight Operations Table Display Fix

### DIFF
--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -202,7 +202,7 @@ table > tbody > tr.control-row > td {
 }
 
 .op-table > tbody > tr > td:first-child {
-    min-width: 12rem;
+    width: 17rem;
 }
 
 .button-group > .button {


### PR DESCRIPTION
Op table first td had a min-width. Rendered width depended on content of second td leading to misalignment:
![image](https://user-images.githubusercontent.com/6826762/41590272-4eada456-73bf-11e8-9b54-bbe5cc296af8.png)

Changed to fixed width:17rem which should be ok:
![image](https://user-images.githubusercontent.com/6826762/41590309-64cbf51c-73bf-11e8-854f-18a56fc41919.png)
