### PR TITLE
Issue 1605 - Missing orderId for notifications

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1271,10 +1271,10 @@
             "{account} sold {amount} at {price} for order #%(order)s",
         "lifetime_upgrade_account": "{account} was upgraded to lifetime member",
         "limit_order_buy":
-            "{account} placed order #%(order)s to buy {amount} at {price}",
+            "{account} placed order %(order)s to buy {amount} at {price}",
         "limit_order_cancel": "{account} cancelled order #%(order)s",
         "limit_order_sell":
-            "{account} placed order #%(order)s to sell {amount} at {price}",
+            "{account} placed order %(order)s to sell {amount} at {price}",
         "no_recent": "No recent transactions",
         "override_transfer":
             "{issuer} transferred {amount} from {from} to {to}",
@@ -1328,11 +1328,11 @@
         "feed_producer":
             "Update the feed producers for the asset {asset} using the account {account}",
         "limit_order_buy":
-            "Place order #%(order)s to buy {amount} at {price} for {account}",
+            "Place order %(order)s to buy {amount} at {price} for {account}",
         "limit_order_create":
             "Place an order to buy %(buy_amount)s for %(sell_amount)s for %(account)s",
         "limit_order_sell":
-            "Place order #%(order)s to sell {amount} at {price} for {account}",
+            "Place order %(order)s to sell {amount} at {price} for {account}",
         "override_transfer":
             "Transfer {amount} from {from} to {to} by authority of {issuer}",
         "proposals": "Proposals",

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -204,7 +204,7 @@ class Operation extends React.Component {
     }
 
     render() {
-        let {op, current, block, result} = this.props;
+        let {op, current, block} = this.props;
         let line = null,
             column = null,
             color = "info";
@@ -327,7 +327,7 @@ class Operation extends React.Component {
                                             }
                                         ]}
                                         params={{
-                                            order: result[1].substring(4)
+                                            order: this.props.result ? "#" + this.props.result[1].substring(4) : ""
                                         }}
                                     />
                                 );

--- a/app/components/Blockchain/Transaction.jsx
+++ b/app/components/Blockchain/Transaction.jsx
@@ -49,11 +49,11 @@ class OpType extends React.Component {
             <tr>
                 <td>
                     <span className={labelClass}>
-                        {trxTypes[ops[this.props.type]]} (<Translate
-                            component="span"
-                            content="explorer.block.trx"
-                        />{" "}
-                        #{this.props.txIndex})
+                        {trxTypes[ops[this.props.type]]} 
+                        {this.props.txIndex > 0 
+                            ? <span><Translate content="explorer.block.trx" />{this.props.txIndex}</span> 
+                            : ""
+                        }
                     </span>
                 </td>
                 <td />


### PR DESCRIPTION
# Resolves Issue #1605 for `2.0.180629-rc1`

Fixes issue when order ID is not yet available for notification component
Removes TX ID #x label on transactions without TX IDs.