### PR TITLE
#1529 Expiration Time display in Open Orders

### DIFF
--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -140,6 +140,7 @@ class OrderRow extends React.Component {
         let quoteColor = !isBid ? "value negative" : "value positive";
         let baseColor = isBid ? "value negative" : "value positive";
 
+        console.log("#1529.expiration.test.1: " + new Date(order.expiration));
         return !dashboard ? (
             <tr key={order.id}>
                 <td className={tdClass} style={{paddingLeft: 10}}>
@@ -198,9 +199,7 @@ class OrderRow extends React.Component {
             </tr>
         ) : (
             <tr key={order.id} className="clickable">
-                <td style={leftAlign}>
-                    #{order.id.substring(4)}
-                </td>
+                <td style={leftAlign}>#{order.id.substring(4)}</td>
                 <td colSpan="4" style={leftAlign} onClick={this.props.onFlip}>
                     {isBid ? (
                         <Translate

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -141,6 +141,10 @@ class OrderRow extends React.Component {
         let baseColor = isBid ? "value negative" : "value positive";
 
         console.log("#1529.expiration.test.1: " + new Date(order.expiration));
+        console.log(
+            "#1529.expiration.test.2: " +
+                new Date(utils.format_time(order.expiration))
+        );
         return !dashboard ? (
             <tr key={order.id}>
                 <td className={tdClass} style={{paddingLeft: 10}}>
@@ -172,7 +176,7 @@ class OrderRow extends React.Component {
                 <td
                     style={{width: "25%", textAlign: "right"}}
                     className="tooltip"
-                    data-tip={new Date(order.expiration)}
+                    data-tip={new Date(utils.format_time(order.expiration))}
                 >
                     {isCall
                         ? null

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -140,11 +140,6 @@ class OrderRow extends React.Component {
         let quoteColor = !isBid ? "value negative" : "value positive";
         let baseColor = isBid ? "value negative" : "value positive";
 
-        console.log("#1529.expiration.test.1: " + new Date(order.expiration));
-        console.log(
-            "#1529.expiration.test.2: " +
-                new Date(utils.format_time(order.expiration))
-        );
         return !dashboard ? (
             <tr key={order.id}>
                 <td className={tdClass} style={{paddingLeft: 10}}>


### PR DESCRIPTION
Opted for using `time_format` from utils.js since it's already imported; manual integration testing passed.