### PR TITLE
[STAGING] Issue 1620 - Missing Order ID on data from nodes

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -36,3 +36,7 @@
 .linethrough {
     text-decoration: line-through;
 }
+
+.fixed-height-2rem tr {
+    height: 2.5rem;
+}

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -298,6 +298,10 @@ class Operation extends React.Component {
                                 const amount = isBid
                                     ? op[1].min_to_receive
                                     : op[1].amount_to_sell;
+                                let orderId = this.props.result 
+                                    ? typeof this.props.result[1] == "string"
+                                        ? "#" + this.props.result[1].substring(4) : ""
+                                    : "";
 
                                 return (
                                     <TranslateWithLinks
@@ -327,7 +331,7 @@ class Operation extends React.Component {
                                             }
                                         ]}
                                         params={{
-                                            order: this.props.result ? "#" + this.props.result[1].substring(4) : ""
+                                            order: orderId
                                         }}
                                     />
                                 );

--- a/app/components/Explorer/Blocks.jsx
+++ b/app/components/Explorer/Blocks.jsx
@@ -513,7 +513,7 @@ class Blocks extends React.Component {
                                 <div className="block-content-header">
                                     <Translate content="account.recent" />
                                 </div>
-                                <table className="table">
+                                <table className="table fixed-height-2rem">
                                     <thead>
                                         <tr>
                                             <th>
@@ -531,7 +531,7 @@ class Blocks extends React.Component {
                                 }}
                                 ref="operations"
                             >
-                                <table className="table">
+                                <table className="table fixed-height-2rem">
                                     <tbody>{transactions}</tbody>
                                 </table>
                             </div>
@@ -558,7 +558,7 @@ class Blocks extends React.Component {
                                 }}
                                 ref="blocks"
                             >
-                                <table className="table">
+                                <table className="table fixed-height-2rem">
                                     <thead>
                                         <tr>
                                             <th>


### PR DESCRIPTION
# Resolves Issue #1620 
Order ID is not always populated, or even has the correct data sent.

- Only handle order ID when there is a string to work with.
- Starting cleaning tables on block explorer, set to a common height.

![bild](https://user-images.githubusercontent.com/12114550/41902276-537dbc36-7933-11e8-8273-543cabf16859.png)

This is not a final result, as when the info details takes more than one row will expand and cause the tables to look "unpretty" again. But this will make sure they look better and are easier to find in as a start.