### PR TITLE
Issue 1676 - Asset decimal offset and table fixes

### DIFF
--- a/app/components/Account/RecentTransactions.jsx
+++ b/app/components/Account/RecentTransactions.jsx
@@ -300,8 +300,8 @@ class RecentTransactions extends React.Component {
               ];
         display_history.push(
             <tr className="total-value" key="total_value">
-                <td className="column-hide-tiny" />
-                <td style={alignRight}>
+                
+                <td style={{textAlign: "center"}}>
                     {historyCount > 0 ? (
                         <span>
                             <a
@@ -321,7 +321,8 @@ class RecentTransactions extends React.Component {
                         </span>
                     ) : null}
                 </td>
-                <td style={{textAlign: "center"}}>
+                <td className="column-hide-tiny" />
+                <td colSpan="2" style={{textAlign: "center"}}>
                     &nbsp;{(this.props.showMore &&
                         historyCount > this.props.limit) ||
                     (20 && limit < historyCount) ? (

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -1006,12 +1006,7 @@ class Operation extends React.Component {
                                                     amount: receivedAmount,
                                                     asset_id: amount.asset_id
                                                 },
-                                                arg: "amount",
-                                                decimalOffset:
-                                                    op[1].receives.asset_id ===
-                                                    "1.3.0"
-                                                        ? 3
-                                                        : null
+                                                arg: "amount"
                                             },
                                             {
                                                 type: "price",


### PR DESCRIPTION
# Resolves Issue #1676 
- Remove asset decimal offset on account activity
- Fixes activity table visual issue

![bitshares-accountassetprecission](https://user-images.githubusercontent.com/12114550/42418483-e87949e6-82a1-11e8-813a-badcb2cdcd38.gif)
