### PR TITLE
Issue 1575 - Adding UI for Target CR on Modal

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -430,6 +430,8 @@
         "call_limit": "Market Call Limit",
         "close": "Close position",
         "coll_ratio": "Ratio",
+        "target_collateral_ratio": "Target Collateral Ratio",
+        "enable_target_collateral_ratio": "Use Target Collateral Ratio",
         "errors": {
             "below":
                 "Your collateral ratio is below %(mr)s which is not allowed.",
@@ -1580,6 +1582,8 @@
         "sync_no":
             "The current node is out of sync with the blockchain, try switching to another one",
         "sync_yes": "The current node is in sync with the blockchain",
+        "target_collateral_ratio":
+            "Setting a target collateral ratio can help with not selling all of the posision at once.<br /><br /><strong>Sell as little by setting target below MCR (ex. 1.5)</strong><br /><br /><strong>Sell as little but decrease possible margin calls again by setting it higher than MCR (ex. 3)",
         "transfer_actions":
             "Click here to make a transfer, or to deposit/withdraw those assets that support it.",
         "update_position":

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -430,6 +430,7 @@
         "call_limit": "Market Call Limit",
         "close": "Close position",
         "coll_ratio": "Ratio",
+        "coll_ratio_target": "Target Ratio",
         "target_collateral_ratio": "Target Collateral Ratio",
         "enable_target_collateral_ratio": "Use Target Collateral Ratio",
         "errors": {

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1022,6 +1022,9 @@ class Asset extends React.Component {
                             </span>
                         ) : null}
                     </th>
+                    <th>
+                        <Translate content="borrow.coll_ratio_target" />
+                    </th>
                     <th
                         className="clickable"
                         onClick={this._toggleSortOrder.bind(this, "ratio")}
@@ -1060,6 +1063,9 @@ class Asset extends React.Component {
                             quote_asset={c.call_price.quote.asset_id}
                             hide_symbols
                         />
+                    </td>
+                    <td style={{textAlign: "right", paddingRight: 10}}>
+                        {!!c.order.target_collateral_ratio ? (c.order.target_collateral_ratio / 1000).toFixed(3) : "-"}
                     </td>
                     <td className={c.getStatus()} style={{textAlign: "right"}}>
                         {c.getRatio().toFixed(3)}

--- a/app/components/Modal/BorrowModal.jsx
+++ b/app/components/Modal/BorrowModal.jsx
@@ -440,7 +440,7 @@ class BorrowModalContent extends React.Component {
         let extensionsProp = false;
 
         if(isTCR) {
-            extensionsProp = { target_collateral_ratio: this.state.target_collateral_ratio * 100 };
+            extensionsProp = { target_collateral_ratio: parseInt(this.state.target_collateral_ratio * 100, 10) };
         }
 
         var tr = WalletApi.new_transaction();

--- a/app/components/Modal/BorrowModal.jsx
+++ b/app/components/Modal/BorrowModal.jsx
@@ -58,15 +58,23 @@ class BorrowModalContent extends React.Component {
                 currentPosition.collateral,
                 props.backing_asset
             );
+
+            let target_collateral_ratio = !isNaN(currentPosition.target_collateral_ratio) 
+                ? currentPosition.target_collateral_ratio / 100
+                : 0;
+
             return {
                 short_amount: debt ? debt.toString() : null,
                 collateral: collateral ? collateral.toString() : null,
                 collateral_ratio: this._getCollateralRatio(debt, collateral),
+                target_collateral_ratio: target_collateral_ratio,
                 errors: this._getInitialErrors(),
                 isValid: false,
+                useTargetCollateral: target_collateral_ratio > 0 ? true : false,
                 original_position: {
                     debt: debt,
-                    collateral: collateral
+                    collateral: collateral,
+                    target_collateral_ratio: target_collateral_ratio
                 }
             };
         } else {
@@ -74,8 +82,10 @@ class BorrowModalContent extends React.Component {
                 short_amount: 0,
                 collateral: 0,
                 collateral_ratio: this._getInitialCollateralRatio(props),
+                target_collateral_ratio: 0,
                 errors: this._getInitialErrors(),
                 isValid: false,
+                useTargetCollateral: false,
                 original_position: {
                     debt: 0,
                     collateral: 0
@@ -195,6 +205,22 @@ class BorrowModalContent extends React.Component {
         this.setState(newState);
         this._validateFields(newState);
         this._setUpdatedPosition(newState);
+    }
+
+    _onTargetRatioChange(e) {
+        let target = e.target;
+
+        // Ensure input is valid
+        const regexp_numeral = new RegExp(/[[:digit:]]/);
+        if (!regexp_numeral.test(target.value)) {
+            target.value = target.value.replace(/[^0-9.]/g, "");
+        }
+
+        let ratio = target.value;
+
+        this.setState({
+            target_collateral_ratio: ratio
+        });
     }
 
     _onRatioChange(e) {
@@ -405,30 +431,69 @@ class BorrowModalContent extends React.Component {
         );
         let currentPosition = this._getCurrentPosition(this.props);
 
+        let isTCR = typeof(this.state.target_collateral_ratio) !== "undefined" 
+            && this.state.target_collateral_ratio > 0 
+            && this.state.useTargetCollateral
+            ? true 
+            : false;
+        
+        let extensionsProp = false;
+
+        if(isTCR) {
+            extensionsProp = { target_collateral_ratio: this.state.target_collateral_ratio * 100 };
+        }
+
         var tr = WalletApi.new_transaction();
-        tr.add_type_operation("call_order_update", {
-            fee: {
-                amount: 0,
-                asset_id: 0
-            },
-            funding_account: this.props.account.get("id"),
-            delta_collateral: {
-                amount: parseInt(
-                    this.state.collateral * backingPrecision -
-                        currentPosition.collateral,
-                    10
-                ),
-                asset_id: this.props.backing_asset.get("id")
-            },
-            delta_debt: {
-                amount: parseInt(
-                    this.state.short_amount * quotePrecision -
-                        currentPosition.debt,
-                    10
-                ),
-                asset_id: this.props.quote_asset.get("id")
-            }
-        });
+        if(extensionsProp) {
+            tr.add_type_operation("call_order_update", {
+                fee: {
+                    amount: 0,
+                    asset_id: 0
+                },
+                funding_account: this.props.account.get("id"),
+                delta_collateral: {
+                    amount: parseInt(
+                        this.state.collateral * backingPrecision -
+                            currentPosition.collateral,
+                        10
+                    ),
+                    asset_id: this.props.backing_asset.get("id")
+                },
+                delta_debt: {
+                    amount: parseInt(
+                        this.state.short_amount * quotePrecision -
+                            currentPosition.debt,
+                        10
+                    ),
+                    asset_id: this.props.quote_asset.get("id")
+                },
+                extensions: extensionsProp
+            });
+        } else {
+            tr.add_type_operation("call_order_update", {
+                fee: {
+                    amount: 0,
+                    asset_id: 0
+                },
+                funding_account: this.props.account.get("id"),
+                delta_collateral: {
+                    amount: parseInt(
+                        this.state.collateral * backingPrecision -
+                            currentPosition.collateral,
+                        10
+                    ),
+                    asset_id: this.props.backing_asset.get("id")
+                },
+                delta_debt: {
+                    amount: parseInt(
+                        this.state.short_amount * quotePrecision -
+                            currentPosition.debt,
+                        10
+                    ),
+                    asset_id: this.props.quote_asset.get("id")
+                },
+            });
+        }
         WalletDb.process_transaction(tr, null, true).catch(err => {
             // console.log("unlock failed:", err);
         });
@@ -504,6 +569,12 @@ class BorrowModalContent extends React.Component {
         return props.quote_asset.getIn(["bitasset", "is_prediction_market"]);
     }
 
+    _setUseTargetCollateral() {
+        this.setState({
+            useTargetCollateral: !this.state.useTargetCollateral
+        });
+    }
+
     render() {
         let {
             quote_asset,
@@ -515,6 +586,7 @@ class BorrowModalContent extends React.Component {
             short_amount,
             collateral,
             collateral_ratio,
+            target_collateral_ratio,
             errors,
             original_position
         } = this.state;
@@ -613,6 +685,66 @@ class BorrowModalContent extends React.Component {
                 <a onClick={this._maximizeCollateral.bind(this)}>
                     <Translate content="borrow.use_max" />
                 </a>
+            </span>
+        );
+
+        let updateTargetCollateral = (
+            <span>
+                <label>
+                    <Translate content="borrow.target_collateral_ratio" />&nbsp;&nbsp;
+                    <span
+                        className="tooltip"
+                        data-html={true}
+                        data-tip={counterpart.translate(
+                        "tooltip.target_collateral_ratio"
+                    )}>
+                        <Icon
+                            name="question-circle"
+                            title="icons.question_circle"
+                        />
+                    </span>
+                </label>
+                <div style={{marginBottom: "1em"}}>
+                    <input 
+                        type="checkbox" 
+                        onClick={this._setUseTargetCollateral.bind(this)} 
+                        checked={this.state.useTargetCollateral ? "checked=checked" : ""} /> 
+                    &nbsp;&nbsp;
+                    <Translate content="borrow.enable_target_collateral_ratio" />
+                </div>
+                {this.state.useTargetCollateral ? 
+                    <span>
+                        <input 
+                            value={
+                                isNaN(target_collateral_ratio) 
+                                    ? "0"
+                                    : target_collateral_ratio
+                            }
+                            onChange={this._onTargetRatioChange.bind(
+                                this
+                            )}
+                            type="text"
+                            style={{
+                                float: "right",
+                                marginTop: -10,
+                                width: "12%",
+                            }}
+                        />
+                        <input
+                            style={{width: "85%"}}
+                            min="0"
+                            max="6"
+                            step="0.01"
+                            onChange={this._onTargetRatioChange.bind(
+                                this
+                            )}
+                            value={isNaN(target_collateral_ratio)
+                                ? "0"
+                                : target_collateral_ratio}
+                            type="range"
+                        />
+                    </span>
+                    : null}
             </span>
         );
 
@@ -898,6 +1030,12 @@ class BorrowModalContent extends React.Component {
                                             {errors.close_maintenance}
                                         </div>
                                     ) : null}
+                                </div>
+                                <div
+                                    className={"form-group"}
+                                    style={{marginBottom: "3.5rem"}}
+                                >
+                                    {updateTargetCollateral}
                                 </div>
                             </div>
                         ) : null}


### PR DESCRIPTION
# Resolves Issue #1575 

Applies BSIP 38 to the UI to allow `Target Collateral Ratio`.

### CR needs to be changed in order for the TX to be approved. 
An update of the CR still requires the CR to be changed, either in Collateral or Debt.
Below is a view of the new update, including the error mentioned.

![bitshares-targetcr](https://user-images.githubusercontent.com/12114550/43024151-a10f5d4a-8c6d-11e8-85cb-6e30e9643df5.gif)
