### PR TITLE
Relative path needed for file:// protocol

### DIFF
--- a/app/components/Exchange/TradingViewPriceChart.jsx
+++ b/app/components/Exchange/TradingViewPriceChart.jsx
@@ -37,7 +37,7 @@ export default class TradingViewPriceChart extends React.Component {
             symbol: props.quoteSymbol + "_" + props.baseSymbol,
             interval: getResolutionsFromBuckets([props.bucketSize])[0],
             library_path: `${
-                __ELECTRON__ ? __BASE_URL__ : ""
+                __ELECTRON__ ? __BASE_URL__ : "."
             }/charting_library/`,
             datafeed: dataFeed,
             container_id: "tv_chart",


### PR DESCRIPTION
A path starting with "/" in file:// protocol try to access the root which result in error.