### PR TITLE
Issue 1628 - BlockTrades Withdrawl Issue

### DIFF
--- a/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -336,6 +336,7 @@ class ButtonWithdraw extends React.Component {
             )
         ) {
             if (
+                this.props.amount_to_withdraw &&
                 !(this.props.amount_to_withdraw.indexOf(" ") >= 0) &&
                 !isNaN(this.props.amount_to_withdraw) &&
                 this.props.amount_to_withdraw > 0 &&


### PR DESCRIPTION
# Resolves Issue #1628 
A missing checker for `amount_to_withdraw` made any user input on the withdraw section of BlockTrades impossible. 

Took some time to find this trigger in the code.