### PR TITLE
Fix gateway enabling

### DIFF
--- a/app/branding.js
+++ b/app/branding.js
@@ -261,7 +261,7 @@ export function getAssetHideNamespaces() {
  * @returns {boolean}
  */
 export function allowedGateway(gateway) {
-    return gateway in ["OPEN", "RUDEX", "WIN", "BRIDGE", "GDEX"];
+    return ["OPEN", "RUDEX", "WIN", "BRIDGE", "GDEX"].indexOf(gateway) >= 0;
 }
 
 export function getSupportedLanguages() {


### PR DESCRIPTION
Looks like this code is not correct

`"RUDEX" in ["OPEN", "RUDEX", "WIN", "BRIDGE", "GDEX"]`

returns false.

Because of this bug RuDEX and OpenLedger gateways have empty tabs on this page - https://develop.bitshares.org/#/deposit-withdraw

http://prntscr.com/k9lymf

