### PR TITLE
More nodes and connectivity bugfix

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -153,7 +153,6 @@ export const settingsAPIs = {
             operator: "Witness: sc-ol",
             contact: "telegram:startail"
         },
-        {url: "wss://ws.gdex.io", location: "Japan"},
         {
             url: "wss://ws.gdex.top",
             region: "Eastern Asia",
@@ -168,14 +167,20 @@ export const settingsAPIs = {
             operator: "Witness: rnglab"
         },
         {
-            url: "wss://dexnode.net/ws",
-            location: "Dallas, USA",
-            operator: "Witness: Sahkan"
+            url: "wss://la.dexnode.net/ws",
+            region: "Northern America",
+            country: "USA",
+            location: "Los Angeles",
+            operator: "Witness: Sahkan",
+            contact: "telegram:Sahkan_bitshares"
         },
         {
-            url: "wss://la.dexnode.net/ws",
-            location: "LA, USA",
-            operator: "Witness: Sahkan"
+            url: "wss://dexnode.net/ws",
+            region: "Northern America",
+            country: "USA",
+            location: "Dallas",
+            operator: "Witness: Sahkan",
+            contact: "telegram:Sahkan_bitshares"
         },
         {
             url: "wss://kc-us-dex.xeldal.com/ws",
@@ -263,7 +268,7 @@ export const settingsAPIs = {
             region: "Southeastern Asia",
             location: "Singapore",
             operator: "Witness: winex.witness",
-            contact: "telegram: zmaxin"
+            contact: "telegram:zmaxin"
         },
         {
             url: "wss://api.bts.mobi/ws",
@@ -300,12 +305,15 @@ export const settingsAPIs = {
             region: "Northern America",
             country: "Canada",
             operator: "Witness: bhuz",
-            contact: "telegram: bhuzor"
+            contact: "telegram:bhuzor"
         },
         {
             url: "wss://bts-api.lafona.net/ws",
-            location: "USA",
-            operator: "Witness: delegate-1.lafona"
+            region: "Northern America",
+            country: "Canada",
+            location: "Montreal",
+            operator: "Witness: delegate-1.lafona",
+            contact: "telegram:lafona"
         },
         {
             url: "wss://kimziv.com/ws",
@@ -313,7 +321,7 @@ export const settingsAPIs = {
             country: "USA",
             location: "New Jersey",
             operator: "Witness: witness.yao",
-            contact: "telegram: imyao"
+            contact: "telegram:imyao"
         },
         {
             url: "wss://api.btsgo.net/ws",
@@ -360,11 +368,21 @@ export const settingsAPIs = {
             contact: "telegram:eggplant"
         },
         {
-            url: "wss://api.bts.ai/",
-            location: "Beijing, China",
-            operator: "Witness: witness.hiblockchain"
+            url: "wss://api.bts.ai",
+            region: "Eastern Asia",
+            country: "China",
+            location: "Beijing",
+            operator: "Witness: witness.hiblockchain",
+            contact: "telegram:vianull;wechat:strugglingl"
         },
-        {url: "wss://ws.hellobts.com/", location: "Japan"},
+        {
+            url: "wss://ws.hellobts.com",
+            region: "Eastern Asia",
+            country: "Japan",
+            location: "Tokyo",
+            operator: "Witness: xman",
+            contact: "wechat:hidpos;email:hellobts@qq.com"
+        },
         {
             url: "wss://bitshares.cyberit.io",
             region: "Eastern Asia",

--- a/app/components/Layout/Footer.jsx
+++ b/app/components/Layout/Footer.jsx
@@ -241,7 +241,7 @@ class Footer extends React.Component {
             // handling out of sync state within this one call
 
             let forceReconnectAfterSeconds = this._getForceReconnectAfterSeconds();
-            let askToReconnectAfterSeconds = 5;
+            let askToReconnectAfterSeconds = 10;
 
             // Trigger automatic reconnect after X seconds
             setTimeout(() => {

--- a/app/routerTransition.js
+++ b/app/routerTransition.js
@@ -177,52 +177,18 @@ class RouterTransitioner {
     /**
      * Updates the latency of all target nodes
      *
-     * @param nodeUrls list of string nodes to update
-     * @returns {Promise}
-     */
-    doQuickLatencyUpdate(nodeUrls) {
-        return new Promise((resolve, reject) => {
-            let url = this._connectionManager.url;
-            let urls = this._connectionManager.urls;
-
-            if (typeof nodeUrls === "string") {
-                nodeUrls = [nodeUrls];
-            }
-            this._connectionManager.url = nodeUrls[0];
-            this._connectionManager.urls = nodeUrls.slice(1, nodeUrls.length);
-
-            this._connectionManager
-                .checkConnections()
-                .then(res => {
-                    console.log("Following nodes have been pinged:", res);
-                    // update the latencies object
-                    const apiLatencies = SettingsStore.getState().apiLatencies;
-                    for (var nodeUrl in res) {
-                        apiLatencies[nodeUrl] = res[nodeUrl];
-                    }
-                    SettingsActions.updateLatencies(apiLatencies);
-                })
-                .catch(err => {
-                    console.log("doLatencyUpdate error", err);
-                })
-                .finally(() => {
-                    this._connectionManager.url = url;
-                    this._connectionManager.urls = urls;
-                    resolve();
-                });
-        });
-    }
-
-    /**
-     * Updates the latency of all target nodes
-     *
      * @param refresh boolean true reping all existing nodes
      *                        false only reping all reachable nodes
-     * @param beSatisfiedWith integer if nodes with less than this integer latency are found, pinging is stopped
+     * @param beSatisfiedWith integer if appropriate number of nodes for each of the keys in this latency map are found, pinging is stopped.
+     *                                Values correspond to AccessSettings display (low, medium latency)
      * @param range integer ping range amount of nodes at the same time, default 5
      * @returns {Promise}
      */
-    doLatencyUpdate(refresh = true, beSatisfiedWith = 200, range = 5) {
+    doLatencyUpdate(
+        refresh = true,
+        beSatisfiedWith = {instant: 200, low: 400, medium: 800},
+        range = 5
+    ) {
         this.updateTransitionTarget(
             counterpart.translate("app_init.check_latency")
         );
@@ -247,6 +213,8 @@ class RouterTransitioner {
             }
 
             function local_ping(thiz, range = null) {
+                let counter = {instant: 0, low: 0, medium: 0};
+                let selectedOneWasPinged = false;
                 if (current < urls.length) {
                     thiz._connectionManager.url = urls[current];
                     thiz._connectionManager.urls = urls.slice(
@@ -273,21 +241,45 @@ class RouterTransitioner {
                             const apiLatencies = SettingsStore.getState()
                                 .apiLatencies;
                             for (var nodeUrl in res) {
+                                if (nodeUrl == url) {
+                                    selectedOneWasPinged = true;
+                                }
                                 apiLatencies[nodeUrl] = res[nodeUrl];
-                                // if we find a node that has less than beSatisfiedWith ms latency we stop pinging
-                                if (
-                                    beSatisfiedWith != null &&
-                                    res[nodeUrl] < beSatisfiedWith
-                                ) {
-                                    console.log(
-                                        "Found node " +
-                                            nodeUrl +
-                                            " with less than " +
-                                            beSatisfiedWith +
-                                            "ms, stopping latency update"
-                                    );
-                                    current = urls.length;
-                                    break;
+                                // we stop the pinging if
+                                //  - not autoselection and the selcted node has been pinged
+                                //  - a node that has low_latency (less than beSatisfiedWith ms) is found
+                                //  - at least 3 nodes with medium_latency have been found
+                                if (beSatisfiedWith != null) {
+                                    if (
+                                        res[nodeUrl] < beSatisfiedWith.instant
+                                    ) {
+                                        counter.instant = counter.instant + 1;
+                                    } else if (
+                                        res[nodeUrl] < beSatisfiedWith.low
+                                    ) {
+                                        counter.low = counter.low + 1;
+                                    } else if (
+                                        res[nodeUrl] < beSatisfiedWith.medium
+                                    ) {
+                                        counter.medium = counter.medium + 1;
+                                    }
+                                    if (
+                                        thiz.isAutoSelection() ||
+                                        selectedOneWasPinged
+                                    ) {
+                                        // only stop pinging if the selected one was pinged, if not autoSelect
+                                        if (
+                                            counter.instant > 0 ||
+                                            counter.low >= 2 ||
+                                            counter.medium >= 3
+                                        ) {
+                                            console.log(
+                                                "Found nodes with sufficient latency, stopping latency update"
+                                            );
+                                            current = urls.length;
+                                            break;
+                                        }
+                                    }
                                 }
                             }
                             thiz._updateLatencies(res);
@@ -307,9 +299,22 @@ class RouterTransitioner {
             }
 
             function done_pinging(thiz) {
-                thiz._connectionManager.url = url;
                 // resort the api nodes with the new pings
                 thiz._connectionManager.urls = thiz._getNodesToConnectTo();
+                if (
+                    thiz.isAutoSelection() &&
+                    url !== thiz._connectionManager.urls[0]
+                ) {
+                    thiz._connectionManager.url =
+                        thiz._connectionManager.urls[0];
+                    console.log(
+                        "auto selecting to " +
+                            thiz._connectionManager.url +
+                            " after latency update"
+                    );
+                } else {
+                    thiz._connectionManager.url = url;
+                }
                 thiz._transitionDone(resolve);
             }
             local_ping(this, range);


### PR DESCRIPTION
#1521
- remove duplicate doQuickLatencyUpdate
- remove bug that you dont connect to your selected one if not autoselction

Members of chinese community gave feedback on connection strategy, adjustments were made:
- askToReconnectAfterSeconds in footer increased to 10 seconds
- beSatisfiedWith is now a map according to AccessSettings display and accepts worse ping to stop pinging all

Signed-off-by: Stefan Schiessl <stefan.schiessl@blockchainprojectsbv.com>