### PR TITLE
Fix AccountSelector not propagating change to empty string

### DIFF
--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -115,7 +115,8 @@ class AccountSelector extends React.Component {
         }
 
         // Synchronous onChange for input change
-        if (!!onChange && !!_accountName) onChange(_accountName);
+        if (!!onChange && (!!_accountName || _accountName === ""))
+            onChange(_accountName);
 
         // asynchronous onAccountChanged for checking on chain
         if (!!onAccountChanged) {


### PR DESCRIPTION
The AccountSelector does not allow for empty strings without this.
I would recommend merging this at the same time as #1806 since it improves the proxy change user-friendliness.