### PR TITLE
#1785 - Add instant settlement description in account activities

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -455,8 +455,7 @@
         "buy": "Buy",
         "buy_sell": "Buy/Sell",
         "buy_quick": "Quick Buy",
-        "buy_description":
-            "Buy %(baseAsset)s %(baseName)s for %(quoteAsset)s %(quoteName)s",
+        "buy_description": "Buy %(baseAsset)s %(baseName)s for %(quoteAsset)s %(quoteName)s",
         "buy_min": "Buy at least",
         "buysell_formatter": "{direction} {asset}",
         "call": "Call Price",
@@ -1233,6 +1232,7 @@
         "asset_reserve": "{account} burned (reserved) {amount}",
         "asset_settle": "{account} requested settlement of {amount}",
         "asset_settle_cancel": "{account} cancelled settlement of {amount}",
+        "asset_settle_instant": "{account} settled {amount} instantly at {price}",
         "asset_update": "{account} updated the asset {asset}",
         "asset_update_feed_producers": "{account} updated the feed producers for the asset {asset}",
         "asset_update_issuer": "{from_account} transferred {asset} to {to_account}",

--- a/app/components/Blockchain/Operation.jsx
+++ b/app/components/Blockchain/Operation.jsx
@@ -77,10 +77,12 @@ class Row extends React.Component {
         if (!hidePending && block > last_irreversible_block_num) {
             pending = (
                 <span>
-                    (<Translate
+                    (
+                    <Translate
                         content="operation.pending"
                         blocks={block - last_irreversible_block_num}
-                    />)
+                    />
+                    )
                 </span>
             );
         }
@@ -661,25 +663,65 @@ class Operation extends React.Component {
 
             case "asset_settle":
                 color = "warning";
-                column = (
-                    <span>
-                        <TranslateWithLinks
-                            string="operation.asset_settle"
-                            keys={[
-                                {
-                                    type: "account",
-                                    value: op[1].account,
-                                    arg: "account"
-                                },
-                                {
-                                    type: "amount",
-                                    value: op[1].amount,
-                                    arg: "amount"
-                                }
-                            ]}
-                        />
-                    </span>
-                );
+
+                const baseAmount = op[1].amount;
+                const {
+                    result: [resultCode, quoteAmount]
+                } = this.props;
+                const instantSettleCode = 2;
+
+                switch (resultCode) {
+                    case instantSettleCode:
+                        column = (
+                            <span>
+                                <TranslateWithLinks
+                                    string="operation.asset_settle_instant"
+                                    keys={[
+                                        {
+                                            type: "account",
+                                            value: op[1].account,
+                                            arg: "account"
+                                        },
+                                        {
+                                            type: "amount",
+                                            value: baseAmount,
+                                            arg: "amount"
+                                        },
+                                        {
+                                            type: "price",
+                                            value: {
+                                                base: baseAmount,
+                                                quote: quoteAmount
+                                            },
+                                            arg: "price"
+                                        }
+                                    ]}
+                                />
+                            </span>
+                        );
+                        break;
+                    default:
+                        column = (
+                            <span>
+                                <TranslateWithLinks
+                                    string="operation.asset_settle"
+                                    keys={[
+                                        {
+                                            type: "account",
+                                            value: op[1].account,
+                                            arg: "account"
+                                        },
+                                        {
+                                            type: "amount",
+                                            value: op[1].amount,
+                                            arg: "amount"
+                                        }
+                                    ]}
+                                />
+                            </span>
+                        );
+                }
+
                 break;
 
             case "asset_global_settle":
@@ -778,7 +820,8 @@ class Operation extends React.Component {
                                 component="span"
                                 content="transaction.witness_pay"
                             />
-                            &nbsp;<FormattedAsset
+                            &nbsp;
+                            <FormattedAsset
                                 amount={op[1].amount}
                                 asset={"1.3.0"}
                             />
@@ -786,7 +829,8 @@ class Operation extends React.Component {
                                 component="span"
                                 content="transaction.to"
                             />
-                            &nbsp;{this.linkToAccount(op[1].witness_account)}
+                            &nbsp;
+                            {this.linkToAccount(op[1].witness_account)}
                         </span>
                     );
                 } else {
@@ -796,7 +840,8 @@ class Operation extends React.Component {
                                 component="span"
                                 content="transaction.received"
                             />
-                            &nbsp;<FormattedAsset
+                            &nbsp;
+                            <FormattedAsset
                                 amount={op[1].amount}
                                 asset={"1.3.0"}
                             />
@@ -804,7 +849,8 @@ class Operation extends React.Component {
                                 component="span"
                                 content="transaction.from"
                             />
-                            &nbsp;{this.linkToAccount(op[1].witness_account)}
+                            &nbsp;
+                            {this.linkToAccount(op[1].witness_account)}
                         </span>
                     );
                 }
@@ -823,7 +869,8 @@ class Operation extends React.Component {
                                         arg: "account"
                                     }
                                 ]}
-                            />:
+                            />
+                            :
                         </span>
                         <div>
                             {op[1].proposed_ops.map((o, index) => {
@@ -880,9 +927,11 @@ class Operation extends React.Component {
                             component="span"
                             content="transaction.withdraw_permission_create"
                         />
-                        &nbsp;{this.linkToAccount(op[1].withdraw_from_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].withdraw_from_account)}
                         <Translate component="span" content="transaction.to" />
-                        &nbsp;{this.linkToAccount(op[1].authorized_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].authorized_account)}
                     </span>
                 );
                 break;
@@ -894,9 +943,11 @@ class Operation extends React.Component {
                             component="span"
                             content="transaction.withdraw_permission_update"
                         />
-                        &nbsp;{this.linkToAccount(op[1].withdraw_from_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].withdraw_from_account)}
                         <Translate component="span" content="transaction.to" />
-                        &nbsp;{this.linkToAccount(op[1].authorized_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].authorized_account)}
                     </span>
                 );
                 break;
@@ -908,9 +959,11 @@ class Operation extends React.Component {
                             component="span"
                             content="transaction.withdraw_permission_claim"
                         />
-                        &nbsp;{this.linkToAccount(op[1].withdraw_from_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].withdraw_from_account)}
                         <Translate component="span" content="transaction.to" />
-                        &nbsp;{this.linkToAccount(op[1].withdraw_to_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].withdraw_to_account)}
                     </span>
                 );
                 break;
@@ -922,9 +975,11 @@ class Operation extends React.Component {
                             component="span"
                             content="transaction.withdraw_permission_delete"
                         />
-                        &nbsp;{this.linkToAccount(op[1].withdraw_from_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].withdraw_from_account)}
                         <Translate component="span" content="transaction.to" />
-                        &nbsp;{this.linkToAccount(op[1].authorized_account)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].authorized_account)}
                     </span>
                 );
                 break;
@@ -1042,16 +1097,19 @@ class Operation extends React.Component {
             case "vesting_balance_create":
                 column = (
                     <span>
-                        &nbsp;{this.linkToAccount(op[1].creator)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].creator)}
                         <Translate
                             component="span"
                             content="transaction.vesting_balance_create"
                         />
-                        &nbsp;<FormattedAsset
+                        &nbsp;
+                        <FormattedAsset
                             amount={op[1].amount.amount}
                             asset={op[1].amount.asset_id}
                         />
-                        &nbsp;{this.linkToAccount(op[1].owner)}
+                        &nbsp;
+                        {this.linkToAccount(op[1].owner)}
                     </span>
                 );
                 break;
@@ -1140,9 +1198,8 @@ class Operation extends React.Component {
                             component="span"
                             content="transaction.committee_member_create"
                         />
-                        &nbsp;{this.linkToAccount(
-                            op[1].committee_member_account
-                        )}
+                        &nbsp;
+                        {this.linkToAccount(op[1].committee_member_account)}
                     </span>
                 );
                 break;
@@ -1151,11 +1208,13 @@ class Operation extends React.Component {
                 column = (
                     <span>
                         {this.linkToAccount(op[1].from)}
-                        &nbsp;<Translate
+                        &nbsp;
+                        <Translate
                             component="span"
                             content="transaction.sent"
                         />
-                        &nbsp;<FormattedAsset
+                        &nbsp;
+                        <FormattedAsset
                             amount={op[1].amount.amount}
                             asset={op[1].amount.asset_id}
                         />
@@ -1167,11 +1226,13 @@ class Operation extends React.Component {
                 column = (
                     <span>
                         {this.linkToAccount(op[1].to)}
-                        &nbsp;<Translate
+                        &nbsp;
+                        <Translate
                             component="span"
                             content="transaction.received"
                         />
-                        &nbsp;<FormattedAsset
+                        &nbsp;
+                        <FormattedAsset
                             amount={op[1].amount.amount}
                             asset={op[1].amount.asset_id}
                         />
@@ -1187,7 +1248,8 @@ class Operation extends React.Component {
                 );
                 column = (
                     <span>
-                        {this.linkToAccount(op[1].issuer)}&nbsp;
+                        {this.linkToAccount(op[1].issuer)}
+                        &nbsp;
                         <BindToChainState.Wrapper
                             asset={op[1].amount_to_claim.asset_id}
                         >
@@ -1405,15 +1467,18 @@ class Operation extends React.Component {
     }
 }
 
-Operation = connect(Operation, {
-    listenTo() {
-        return [SettingsStore];
-    },
-    getProps() {
-        return {
-            marketDirections: SettingsStore.getState().marketDirections
-        };
+Operation = connect(
+    Operation,
+    {
+        listenTo() {
+            return [SettingsStore];
+        },
+        getProps() {
+            return {
+                marketDirections: SettingsStore.getState().marketDirections
+            };
+        }
     }
-});
+);
 
 export default Operation;


### PR DESCRIPTION
Closes #1785

Thanks @abitmore 

Instant settlement (the feature to implement):
![instant-settle-demo](https://user-images.githubusercontent.com/35779885/45419740-6e788600-b688-11e8-9fd4-9bc0d67945ab.png)

Normal settlement for comparison:
![normal-settle-demo](https://user-images.githubusercontent.com/35779885/45419787-8b14be00-b688-11e8-8a5f-7a7f9f3eabb2.png)

