### PR TITLE
#1856 - Fix wallet password change form

### DIFF
--- a/app/components/Settings/Settings.jsx
+++ b/app/components/Settings/Settings.jsx
@@ -97,7 +97,7 @@ class Settings extends React.Component {
         menuEntries.push("general");
         if (!props.settings.get("passwordLogin")) menuEntries.push("wallet");
         menuEntries.push("accounts");
-        menuEntries.push("password");
+        if (!props.settings.get("passwordLogin")) menuEntries.push("password");
         if (!props.settings.get("passwordLogin")) menuEntries.push("backup");
         if (!props.settings.get("passwordLogin")) menuEntries.push("restore");
         menuEntries.push("access");

--- a/app/components/Wallet/WalletChangePassword.jsx
+++ b/app/components/Wallet/WalletChangePassword.jsx
@@ -147,7 +147,7 @@ class WalletPassword extends Component {
                                 "wallet.current_pass"
                             )}
                             type="password"
-                            id="current-password"
+                            id="password"
                             autoComplete="current-password"
                             onChange={this.formChange.bind(this)}
                             value={this.state.password}


### PR DESCRIPTION
Closes #1856 

I also removed the "Password" entry from the settings menu when using password login as `WalletDb.changePassword` only supports local wallet.