### PR TITLE
#1816 Replace Explorer Tabs for new Ant Tabs

### DIFF
--- a/app/components/Explorer/Explorer.jsx
+++ b/app/components/Explorer/Explorer.jsx
@@ -70,7 +70,7 @@ class Explorer extends React.Component {
             <Tabs
                 activeKey={this.props.location.pathname}
                 animated={false}
-                style={{display: "table", height: "100%"}}
+                style={{display: "table", height: "100%", width: "100%"}}
                 onChange={onChange}
             >
                 {this.state.tabs.map(tab => {

--- a/app/components/Explorer/Explorer.jsx
+++ b/app/components/Explorer/Explorer.jsx
@@ -1,12 +1,13 @@
 import React from "react";
-import {Tabs, Tab} from "../Utility/Tabs";
 import Witnesses from "./Witnesses";
 import CommitteeMembers from "./CommitteeMembers";
 import FeesContainer from "../Blockchain/FeesContainer";
 import BlocksContainer from "./BlocksContainer";
 import AssetsContainer from "./AssetsContainer";
 import AccountsContainer from "./AccountsContainer";
+import counterpart from "counterpart";
 import MarketsContainer from "../Exchange/MarketsContainer";
+import {Tabs} from "bitshares-ui-style-guide";
 
 class Explorer extends React.Component {
     constructor(props) {
@@ -61,34 +62,31 @@ class Explorer extends React.Component {
     }
 
     render() {
-        let {tab} = this.props.match.params;
-        let defaultActiveTab = this.state.tabs.findIndex(t => t.name === tab);
-
-        let tabs = [];
-
-        for (var i = 0; i < this.state.tabs.length; i++) {
-            let currentTab = this.state.tabs[i];
-
-            let TabContent = currentTab.content;
-            let isLinkTo = defaultActiveTab == i ? "" : currentTab.link;
-
-            tabs.push(
-                <Tab key={i} title={currentTab.translate} isLinkTo={isLinkTo}>
-                    <TabContent />
-                </Tab>
-            );
-        }
+        const onChange = value => {
+            this.props.history.push(value);
+        };
 
         return (
             <Tabs
-                defaultActiveTab={defaultActiveTab}
-                segmented={false}
-                setting="explorer-tabs"
-                className="account-tabs"
-                tabsClass="account-overview bordered-header content-block"
-                contentClass="tab-content explorer-tab-content padding"
+                activeKey={this.props.location.pathname}
+                animated={false}
+                style={{display: "table", height: "100%"}}
+                onChange={onChange}
             >
-                {tabs}
+                {this.state.tabs.map(tab => {
+                    const TabContent = tab.content;
+
+                    return (
+                        <Tabs.TabPane
+                            key={tab.link}
+                            tab={counterpart.translate(tab.translate)}
+                        >
+                            <div className="padding">
+                                <TabContent />
+                            </div>
+                        </Tabs.TabPane>
+                    );
+                })}
             </Tabs>
         );
     }


### PR DESCRIPTION
Tested on MacOS:

- [x] Chrome 
- [x] Opera
- [x] Firefox

Issue #1816 

**Description**

Replace old Tabs for Tabs from Style Guide (Ant Tabs)

<img width="1440" alt="screenshot 2018-09-27 05 08 25" src="https://user-images.githubusercontent.com/35899973/46121409-e8297b80-c213-11e8-820a-38ee3f5fe116.png">
<img width="1440" alt="screenshot 2018-09-27 05 07 31" src="https://user-images.githubusercontent.com/35899973/46121410-e8297b80-c213-11e8-8cbf-3c77873a3e57.png">
<img width="1440" alt="screenshot 2018-09-27 05 07 17" src="https://user-images.githubusercontent.com/35899973/46121412-e8297b80-c213-11e8-8f99-b9e549dca358.png">



