### PR TITLE
Fixes 1905 - Buy Modal error

### DIFF
--- a/app/lib/common/gatewayMethods.js
+++ b/app/lib/common/gatewayMethods.js
@@ -279,7 +279,7 @@ export function requestDepositAddress({
 }) {
 
     let gatewayStatus = availableGateways[selectedGateway];
-    inputCoinType = !!gatewayStatus.assetWithdrawlAlias 
+    inputCoinType = !!gatewayStatus && gatewayStatus.assetWithdrawlAlias 
         ? gatewayStatus.assetWithdrawlAlias[inputCoinType.toLowerCase()] || inputCoinType.toLowerCase()
         : inputCoinType;
 


### PR DESCRIPTION
# Resolves Issue #1905 
When `assetWithdrawlAlias` was missing in the `gatewayStatus` object the function to fetch new deposit addresses would fail.

This would be noticed when a new address was requested for BlockTrades in-wallet transactions on the Buy Modal.
