### PR TITLE
Fix vertical orderbook centering when orders are grouped

### DIFF
--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -399,7 +399,11 @@ class OrderBook extends React.Component {
             const singleAskHeight = elemHeight(
                 this.queryStickyTable(".order-row")
             );
-            const asksHeight = this.props.combinedAsks.length * singleAskHeight;
+            const asks =
+                this.props.currentGroupOrderLimit !== 0
+                    ? this.props.groupedAsks
+                    : this.props.combinedAsks;
+            const asksHeight = asks.length * singleAskHeight;
 
             const scrollableContainerHeight =
                 elemHeight(scrollableContainer) - elemHeight(header);


### PR DESCRIPTION
Closes #1914 

Please consider adding this to current release candidate (181010) since this is a fix to a commit included in it (https://github.com/bitshares/bitshares-ui/pull/1930/commits/3be9d91343e80756dde03bb6f3a2f45706d94fab)