### PR TITLE
#1125 Fix file restore on Safari

### DIFF
--- a/app/actions/BackupActions.js
+++ b/app/actions/BackupActions.js
@@ -11,7 +11,8 @@ class BackupActions {
             reader.onload = evt => {
                 let contents = new Buffer(evt.target.result, "binary");
                 let name = file.name;
-                let last_modified = file.lastModifiedDate.toString();
+
+                let last_modified = new Date(file.lastModified).toString();
 
                 dispatch({name, contents, last_modified});
             };


### PR DESCRIPTION
**Description**

Issue was in missed field in Safari because of browsers specification

**Tested on the following browsers**:

_Please make sure you tested your feature in all following browsers_

- [x] Chrome 
- [x] Opera
- [ ] Firefox (cannot open because of nodes issue)
- [x] Safari

Issue: #1125 