### PR TITLE
#2088 Fix missing property message to empty

### DIFF
--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -153,7 +153,9 @@ class TransactionConfirm extends React.Component {
 
         if (this.props.error || this.props.included) {
             header = this.props.error
-                ? counterpart.translate("transaction.broadcast_fail")
+                ? counterpart.translate("transaction.broadcast_fail", {
+                      message: ""
+                  })
                 : counterpart.translate("transaction.transaction_confirmed");
 
             footer = [


### PR DESCRIPTION
The fix is pretty simple. The issue is when I work on Modals replacement I did replace of `<Translate>` to `counterpart.translate`. 

`counterpart` do crash if property needed for translaction is missed. `<Translate>` doesn't. 

Issue: #2088 