### PR TITLE
#1927 - ANT AssetSelector replacement: add AssetInput and AssetSelect

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1902,7 +1902,9 @@
         "total_x_assets": "Total of %(count)s assets",
         "total_x_items": "Total of %(count)s items",
         "total_x_markets": "Total of %(count)s markets",
-        "total_x_operations": "Total of %(count)s operations"
+        "total_x_operations": "Total of %(count)s operations",
+        "asset_select_placeholder": "Select asset",
+        "asset_input_placeholder": "Enter asset symbol"
     },
     "walkthrough": {
         "buy_form": "Place buy orders using this form.",

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -1,45 +1,47 @@
 label.horizontal {
-  > input {
-    display: inline;
-    width: auto;
-  }
+    > input {
+        display: inline;
+        width: auto;
+    }
 }
 
 .form-label.select {
-  padding: 0;
-  border: none;
-
-  select {
-    margin: 0;
+    padding: 0;
     border: none;
-    padding-top: 0.2rem;
-    padding-bottom: 0.2rem;
-    font-size: 0.875rem;
-  }
 
+    select {
+        margin: 0;
+        border: none;
+        padding-top: 0.2rem;
+        padding-bottom: 0.2rem;
+        font-size: 0.875rem;
+    }
 }
 
-.has-error input, .has-error select, .has-error textarea {
-  border-color: #a94442;
+.has-error input,
+.has-error select,
+.has-error textarea {
+    border-color: #a94442;
 }
 
 .autocomplete > .action-sheet-container {
-  display: flex;
-  > .action-sheet {
-    left: 6em;
-  }
+    display: flex;
+    > .action-sheet {
+        left: 6em;
+    }
 }
 
-td > input, td > .autocomplete input {
-  margin: 0 !important;
+td > input,
+td > .autocomplete input {
+    margin: 0 !important;
 }
 
 .form-group {
-  margin-bottom: 2rem;
+    margin-bottom: 2rem;
 }
 
 .account-select {
-  width: auto;
+    width: auto;
 }
 
 div.account-image {
@@ -49,49 +51,75 @@ div.account-image {
     }
 }
 
+.asset-select {
+    .ant-select {
+        width: 100%;
+    }
+}
+
+.asset-input.with-action {
+    .ant-input {
+        width: auto;
+    }
+}
+
 .asset-selector {
     .error-area {
         position: absolute;
     }
 }
-.account-selector, .pubkey-input {
-  clear: right;
-  input {
-    display: block;
-    flex: auto;
-  }
 
-  .tooltip{
-    &:hover {
-      cursor:pointer;
+.asset-input.ant-form-item {
+    .ant-form-item-control {
+        max-width: none;
     }
-  }
-
-  .header-area {
-      margin-left: 3.5rem;
-  }
-  .error-area {
-      position: absolute;
-      padding-left: 3.5rem;
-  }
-  .account-image {
-    float: left;
-    width: 3.5rem;
-    > canvas, .icon.key > svg {
-        height: 2.4rem !important;
-        width: 2.4rem !important;
+    .ant-form-item-label {
+        label {
+            text-transform: uppercase;
+        }
     }
-  }
-  > .content-area {
-    //width: 100%;
-    position: relative;
-    width: 100%;
-    display: inline-block;
+}
 
-    @include breakpoint(small only) {
+.account-selector,
+.pubkey-input {
+    clear: right;
+    input {
+        display: block;
+        flex: auto;
+    }
+
+    .tooltip {
+        &:hover {
+            cursor: pointer;
+        }
+    }
+
+    .header-area {
+        margin-left: 3.5rem;
+    }
+    .error-area {
+        position: absolute;
+        padding-left: 3.5rem;
+    }
+    .account-image {
+        float: left;
+        width: 3.5rem;
+        > canvas,
+        .icon.key > svg {
+            height: 2.4rem !important;
+            width: 2.4rem !important;
+        }
+    }
+    > .content-area {
+        //width: 100%;
+        position: relative;
         width: 100%;
+        display: inline-block;
+
+        @include breakpoint(small only) {
+            width: 100%;
+        }
     }
-  }
 }
 
 .error-area {
@@ -100,11 +128,12 @@ div.account-image {
     line-height: normal;
 }
 
-.right-label, .left-label {
-  font-size: 90%;
-  text-transform: uppercase;
-  font-variant: small-caps;
-  padding-bottom: 5px;
+.right-label,
+.left-label {
+    font-size: 90%;
+    text-transform: uppercase;
+    font-variant: small-caps;
+    padding-bottom: 5px;
 }
 
 .right-label {
@@ -112,49 +141,46 @@ div.account-image {
 }
 
 div.transfer-input {
-  //width: 100%;
-  width: 100%;
-  display: inline-block;
+    //width: 100%;
+    width: 100%;
+    display: inline-block;
 
-  &.fee-row {
-      border-top: 1px solid $border-color;
-      padding-top: 2rem;
-      position: relative;
-  }
+    &.fee-row {
+        border-top: 1px solid $border-color;
+        padding-top: 2rem;
+        position: relative;
+    }
 
-  &.fee-row {
-      > .amount-selector {
-          width: calc(100% - 6.6rem);
-      }
-      &.proposal > .amount-selector {
-          width: calc(100% - 9rem);
-      }
-      > button {
-          position: absolute;
-          right: 0;
-          bottom: 0;
-          font-size: 1.3rem;
-          border-radius: 5px;
-      }
-  }
-
-  @include breakpoint(small only) {
-      width: 100%;
-
-      &.fee-row {
+    &.fee-row {
         > .amount-selector {
-            width: 100%;
-            padding-bottom: 20px;
+            width: calc(100% - 6.6rem);
         }
-
+        &.proposal > .amount-selector {
+            width: calc(100% - 9rem);
+        }
         > button {
-            position: inherit;
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            font-size: 1.3rem;
+            border-radius: 5px;
         }
-      }
+    }
 
+    @include breakpoint(small only) {
+        width: 100%;
 
+        &.fee-row {
+            > .amount-selector {
+                width: 100%;
+                padding-bottom: 20px;
+            }
 
-  }
+            > button {
+                position: inherit;
+            }
+        }
+    }
 }
 
 .dropdown-wrapper {
@@ -189,7 +215,7 @@ div.transfer-input {
     }
 
     &.active .dropdown {
-        border-bottom: 1px solid rgba(0,0,0,0.2);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.2);
         max-height: 400px;
     }
 
@@ -205,7 +231,7 @@ div.transfer-input {
         /* Styles */
         background: #fff;
         border-radius: 0 0 5px 5px;
-        border: 1px solid rgba(0,0,0,0.2);
+        border: 1px solid rgba(0, 0, 0, 0.2);
         border-top: none;
         border-bottom: none;
         list-style: none;
@@ -239,7 +265,8 @@ div.transfer-input {
         }
     }
 }
-.dropdown-wrapper:after { /* Little arrow */
+.dropdown-wrapper:after {
+    /* Little arrow */
     content: "";
     width: 0;
     height: 0;
@@ -276,7 +303,8 @@ div.ok-indicator {
 }
 
 div.dropdown-wrapper.upper-case {
-    > div, > ul > li {
+    > div,
+    > ul > li {
         text-transform: uppercase;
     }
 }
@@ -287,10 +315,12 @@ form.full-width {
     }
 }
 
-#send_modal_header, #send_modal_portfolio {
+#send_modal_header,
+#send_modal_portfolio {
     padding-left: 20px;
     padding-right: 20px;
-    .right-label, .left-label {
+    .right-label,
+    .left-label {
         padding-bottom: 0px;
     }
     .dropdown-wrapper.active .dropdown {
@@ -299,14 +329,20 @@ form.full-width {
     #txFeeSelector .dropdown-wrapper.active .dropdown {
         max-height: 100px;
     }
-    .account-selector .error-area { display: none; }
-    .account-select { width: 100%; }
+    .account-selector .error-area {
+        display: none;
+    }
+    .account-select {
+        width: 100%;
+    }
 }
 
-#send_modal_header, #send_modal_portfolio {
+#send_modal_header,
+#send_modal_portfolio {
     padding-left: 20px;
     padding-right: 20px;
-    .right-label, .left-label {
+    .right-label,
+    .left-label {
         padding-bottom: 0px;
     }
     .dropdown-wrapper.active .dropdown {
@@ -315,49 +351,61 @@ form.full-width {
     #txFeeSelector .dropdown-wrapper.active .dropdown {
         max-height: 100px;
     }
-    .account-selector .error-area { display: none; }
+    .account-selector .error-area {
+        display: none;
+    }
 }
 
-button.red, button.green, button.blue {
+button.red,
+button.green,
+button.blue {
     padding: 10px 0px 10px 0px;
     width: 8rem;
     color: rgb(242, 242, 242);
     font-size: 0.875rem;
     font-weight: normal;
 }
-button.red { background-color: rgb(245, 27, 27); }
-button.green { background-color: rgb(48, 185, 14); }
-button.blue { background-color: rgb(65, 116, 184); }
-button.disabled { background-color: rgb(77, 94, 116); }
+button.red {
+    background-color: rgb(245, 27, 27);
+}
+button.green {
+    background-color: rgb(48, 185, 14);
+}
+button.blue {
+    background-color: rgb(65, 116, 184);
+}
+button.disabled {
+    background-color: rgb(77, 94, 116);
+}
 
 .button.hollow {
-  background-color: transparent;
-  @include RobotoCondensed;
+    background-color: transparent;
+    @include RobotoCondensed;
 
-  &:hover {
-    color: #fff;
-  }
+    &:hover {
+        color: #fff;
+    }
 }
 
 a.button span {
-  color: #fff;
+    color: #fff;
 }
 
 .button.hollow.primary {
-  border-color: $bs-blue;
-  color: $bs-blue!important;
-  background: transparent;
+    border-color: $bs-blue;
+    color: $bs-blue !important;
+    background: transparent;
 
     &:hover {
-        color: #fff!important;
-    }  
+        color: #fff !important;
+    }
 }
 
 .market-button {
-  margin: 1rem 0;
+    margin: 1rem 0;
 }
 
-input[type=text].input-button {
-  border-top-right-radius: 0!important;
-  border-bottom-right-radius: 0!important;
+input[type="text"].input-button {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
 }

--- a/app/components/Utility/AmountSelectorStyleGuide.jsx
+++ b/app/components/Utility/AmountSelectorStyleGuide.jsx
@@ -6,47 +6,7 @@ import AssetWrapper from "./AssetWrapper";
 import PropTypes from "prop-types";
 import {DecimalChecker} from "./DecimalChecker";
 import {Form, Input, Select} from "bitshares-ui-style-guide";
-
-class AssetSelector extends React.Component {
-    static propTypes = {
-        value: PropTypes.string, // asset id
-        onChange: PropTypes.func,
-        scroll_length: PropTypes.number
-    };
-
-    shouldComponentUpdate(np) {
-        return (
-            !utils.are_equal_shallow(np.assets, this.props.assets) ||
-            np.value !== this.props.value ||
-            np.scroll_length !== this.props.scroll_length
-        );
-    }
-
-    render() {
-        if (!this.props.assets.length) return null;
-
-        return (
-            <Select
-                showSearch
-                style={this.props.style || {}}
-                value={this.props.value}
-                onChange={this.props.onChange}
-            >
-                {this.props.assets
-                    .filter(asset => asset && asset.get)
-                    .map(asset => {
-                        return (
-                            <Select.Option key={asset.get("symbol")}>
-                                {asset.get("symbol")}
-                            </Select.Option>
-                        );
-                    })}
-            </Select>
-        );
-    }
-}
-
-AssetSelector = AssetWrapper(AssetSelector, {asList: true});
+import AssetSelect from "./AssetSelect";
 
 class AmountSelector extends DecimalChecker {
     static propTypes = {
@@ -142,8 +102,9 @@ class AmountSelector extends DecimalChecker {
                     />
 
                     {!this.props.isPrice ? (
-                        <AssetSelector
+                        <AssetSelect
                             style={{width: "130px"}}
+                            selectStyle={{width: "100%"}}
                             value={this.props.asset.get("symbol")}
                             assets={Immutable.List(this.props.assets)}
                             onChange={this.onAssetChange.bind(this)}

--- a/app/components/Utility/AssetInput.jsx
+++ b/app/components/Utility/AssetInput.jsx
@@ -86,13 +86,15 @@ class ControlledAssetInput extends PureComponent {
     };
 
     getValidateStatus = () => {
-        const {validateStatus, asset, resolved} = this.props;
+        const {validateStatus, asset, resolved, value} = this.props;
         return typeof validateStatus === "string"
             ? validateStatus
             : resolved
             ? Map.isMap(asset)
                 ? "success"
-                : "error"
+                : value
+                ? "error"
+                : undefined
             : "validating";
     };
 

--- a/app/components/Utility/AssetInput.jsx
+++ b/app/components/Utility/AssetInput.jsx
@@ -1,0 +1,194 @@
+import React, {Fragment, PureComponent} from "react";
+import PropTypes from "prop-types";
+import counterpart from "counterpart";
+import {Form, Input, Button} from "bitshares-ui-style-guide";
+import ChainTypes from "../Utility/ChainTypes";
+import BindToChainState from "../Utility/BindToChainState";
+import Translate from "react-translate-component";
+import {Map} from "immutable";
+
+const AssetInputView = ({
+    label,
+    hasAction,
+    onChange,
+    placeholder,
+    style,
+    inputStyle,
+    value,
+    validateStatus,
+    onAction,
+    actionLabel,
+    disableActionButton,
+    help
+}) => (
+    <Fragment>
+        <Form.Item
+            colon={false}
+            label={<Translate content={label} />}
+            style={style}
+            className={"asset-input" + (hasAction ? " with-action" : "")}
+            validateStatus={validateStatus}
+            hasFeedback
+            help={help}
+        >
+            <Input
+                value={value}
+                onChange={onChange}
+                style={inputStyle}
+                placeholder={placeholder}
+            />
+        </Form.Item>
+        {hasAction && (
+            <Form.Item>
+                <Button
+                    type="primary"
+                    disabled={disableActionButton}
+                    onClick={onAction}
+                >
+                    <Translate content={actionLabel} />
+                </Button>
+            </Form.Item>
+        )}
+    </Fragment>
+);
+
+class ControlledAssetInput extends PureComponent {
+    static propTypes = {
+        asset: ChainTypes.ChainAsset // the selected asset
+    };
+
+    checkFound = prevAsset => {
+        const {onFound, asset, resolved} = this.props;
+        if (
+            resolved &&
+            asset !== undefined &&
+            typeof onFound === "function" &&
+            (Map.isMap(prevAsset) && Map.isMap(asset)
+                ? prevAsset.get("id") !== asset.get("id")
+                : prevAsset != asset)
+        ) {
+            onFound(Map.isMap(asset) ? asset : null);
+        }
+    };
+
+    componentDidMount() {
+        this.checkFound();
+    }
+
+    componentDidUpdate(prevProps) {
+        this.checkFound(prevProps.asset);
+    }
+
+    handleChange = event => {
+        const {onChange} = this.props;
+        if (typeof onChange === "function")
+            onChange(event.target.value.toUpperCase());
+    };
+
+    getValidateStatus = () => {
+        const {validateStatus, asset, resolved} = this.props;
+        return typeof validateStatus === "string"
+            ? validateStatus
+            : resolved
+            ? Map.isMap(asset)
+                ? "success"
+                : "error"
+            : "validating";
+    };
+
+    handleAction = () => {
+        const {asset, onAction} = this.props;
+        onAction(asset);
+    };
+
+    render() {
+        const {
+            label,
+            placeholder,
+            inputStyle,
+            style,
+            value,
+            actionLabel,
+            help,
+            onAction
+        } = this.props;
+        const validateStatus = this.getValidateStatus();
+        const hasAction = typeof onAction === "function";
+        return (
+            <AssetInputView
+                label={label}
+                onChange={this.handleChange}
+                hasAction={hasAction}
+                onAction={this.handleAction}
+                actionLabel={actionLabel}
+                placeholder={counterpart.translate(
+                    placeholder || "utility.asset_input_placeholder"
+                )}
+                disableActionButton={validateStatus !== "success"}
+                inputStyle={inputStyle}
+                style={style}
+                value={value}
+                validateStatus={validateStatus}
+                help={help ? <Translate content={help} /> : ""}
+            />
+        );
+    }
+}
+
+const BoundAssetInput = BindToChainState(ControlledAssetInput);
+
+// wrapper so you only need to hook onFound and provide a defaultValue
+class AssetInput extends PureComponent {
+    static propTypes = {
+        // common
+        label: PropTypes.string, // a translation key for the label
+        placeholder: PropTypes.string, // the placeholder text to be displayed when there is no input
+        // default to "utility.asset_input_placeholder"
+        onFound: PropTypes.func, // a method to be called when a valid asset is found, the asset object is passed as argument.
+        // is called with null when the input is changed from a valid to an invalid asset name
+        style: PropTypes.object, // style to pass to the containing component (Form.Item)
+        inputStyle: PropTypes.object, // Input component style
+        onAction: PropTypes.func, // if provided, an action button will be displayed and this method will be called when the button is clicked
+        actionLabel: PropTypes.string, // translation key for the action button
+        validateStatus: PropTypes.string, // "succes", "error" or "validating" the action button will be disabled if set to "error"
+        // if not provided, it is derived from the validity of the current value
+        help: PropTypes.string, // a translation key for the help
+
+        // automatic mode (no onChange callback provided)
+        defaultValue: PropTypes.string, // pre-entered value
+
+        // controlled mode
+        onChange: PropTypes.func, // a method to be called when the input changes, the input is passed as argument
+        value: PropTypes.string // the current value of the asset selector, the string the user enters (only used if an onChange callback is provided)
+    };
+
+    state = {
+        value: undefined
+    };
+
+    static getDerivedStateFromProps = (props, state) => ({
+        value:
+            typeof state.value === "undefined"
+                ? props.defaultValue || ""
+                : state.value
+    });
+
+    handleChange = value => {
+        this.setState({value});
+    };
+
+    render() {
+        const {onChange} = this.props;
+        const childProps =
+            typeof onChange === "function"
+                ? this.props
+                : {
+                      ...this.props,
+                      value: this.state.value,
+                      onChange: this.handleChange
+                  };
+        return <BoundAssetInput asset={childProps.value} {...childProps} />;
+    }
+}
+
+export default AssetInput;

--- a/app/components/Utility/AssetSelect.jsx
+++ b/app/components/Utility/AssetSelect.jsx
@@ -1,0 +1,67 @@
+import React, {PureComponent} from "react";
+import Translate from "react-translate-component";
+import PropTypes from "prop-types";
+import {Form, Select} from "bitshares-ui-style-guide";
+import ChainTypes from "../Utility/ChainTypes";
+import BindToChainState from "../Utility/BindToChainState";
+import {Map} from "immutable";
+
+const AssetSelectView = ({
+    label,
+    assets,
+    selectStyle,
+    formItemStyle,
+    style,
+    placeholder,
+    ...props
+}) => {
+    const select = (
+        <Select
+            showSearch
+            style={selectStyle}
+            placeholder={
+                <Translate
+                    content={placeholder || "utility.asset_select_placeholder"}
+                />
+            }
+            {...props}
+        >
+            {assets.filter(Map.isMap).map(asset => (
+                <Select.Option key={asset.get("symbol")}>
+                    {asset.get("symbol")}
+                </Select.Option>
+            ))}
+        </Select>
+    );
+    return (
+        <div className={"asset-select"} style={style}>
+            {label ? (
+                <Form.Item
+                    colon={false}
+                    label={<Translate content={label} />}
+                    style={formItemStyle}
+                >
+                    {select}
+                </Form.Item>
+            ) : (
+                select
+            )}
+        </div>
+    );
+};
+
+AssetSelectView.propTypes = {
+    assets: ChainTypes.ChainAssetsList, // an array of assets
+    placeholder: PropTypes.string, // a translation key for the placeholder text to be displayed when there is no preselected value
+    // defaults to "utility.asset_select_placeholder"
+    label: PropTypes.string, // translation key for the label
+    style: PropTypes.object, // container div style
+    formItemStyle: PropTypes.object, // Form.Item component style (used only if a label is passed)
+    selectStyle: PropTypes.object // Select style
+
+    // all other props are passed to the Select component
+};
+
+const AssetSelect = BindToChainState(AssetSelectView);
+
+export default AssetSelect;


### PR DESCRIPTION
Closes #1927 

I chose to split the AssetSelector component since it was doing two different thing with no real functionality overlap.

### AssetInput
![asset_input_quote_selection_demo2](https://user-images.githubusercontent.com/35779885/48303749-a9732a80-e50e-11e8-9eaa-fa7c2f15420f.gif)
### AssetSelect
![asset_select_deposit_demo](https://user-images.githubusercontent.com/35779885/48302938-e2f26880-e503-11e8-9385-28594ba84683.gif)

See demo integration here (https://github.com/kapeer42/bitshares-ui/tree/1927_split3_demo). In the branch there the AssetSelector is fully removed.

This PR only contains the new components code, not the integration.

The AssetInput can be used in uncontrolled mode where you just provide a default value and an `onFound` callback that will be called with the asset object when a valid asset name is entered.

@wmbutler I ended up spending a lot more than 6 hours on this issue, the component was used in 10 places. I tested the replacements everywhere, retained the full functionality and sanitized the interface.
