### PR TITLE
#2168 Switch ES exporter to infrastructure nodes, remote ui reference

### DIFF
--- a/app/components/Account/RecentTransactions.jsx
+++ b/app/components/Account/RecentTransactions.jsx
@@ -182,7 +182,12 @@ class RecentTransactions extends React.Component {
         let recordData = {};
 
         while (true) {
-            let res = await report.getAccountHistoryES(account, limit, start);
+            let res = await report.getAccountHistoryES(
+                account,
+                limit,
+                start,
+                "https://wrapper.elasticsearch.bitshares.ws"
+            );
             if (!res.length) break;
 
             await report.resolveBlockTimes(res);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,9 +82,7 @@ module.exports = function(env) {
             __ELECTRON__: !!env.electron,
             __HASH_HISTORY__: !!env.hash,
             __BASE_URL__: JSON.stringify(baseUrl),
-            __UI_API__: JSON.stringify(
-                env.apiUrl || "https://ui.bitshares.eu/api"
-            ),
+            __UI_API__: JSON.stringify(env.apiUrl),
             __TESTNET__: !!env.testnet,
             __DEPRECATED__: !!env.deprecated,
             DEFAULT_SYMBOL: "BTS",


### PR DESCRIPTION
Closes #2168

After investigation I realized the URL is hardcoded in bitshares-report. Either case, it is now pointing to infrastructure ES cluster.

Took 0.5

Signed-off-by: Stefan Schiessl <stefan.schiessl@blockchainprojectsbv.com>