### PR TITLE
#2216 Fix login modal zIndex

### DIFF
--- a/app/components/Wallet/WalletUnlockModal.jsx
+++ b/app/components/Wallet/WalletUnlockModal.jsx
@@ -452,7 +452,7 @@ class WalletUnlockModal extends React.Component {
                 onCancel={this.handleModalClose}
                 leftHeader
                 footer={footer}
-                zIndex={100000} // always on top
+                zIndex={1001} // always on top
             >
                 <Form className="full-width" layout="vertical">
                     <LoginTypeSelector />


### PR DESCRIPTION
Closes #2216 

It was a little bit hard to discover why ant select is not showing but finally I found issue in `z-index`. The select dropdown `z-index` was lower than modal `z-index`. Btw I use custom `z-index` for Login modal to show it over other modals when user try to do any operation when his account is not unlocked.  