### PR TITLE
Issue 2292 - Disable Borrow on Dashbaord for GS Assets

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1735,7 +1735,7 @@
     },
     "tooltip": {
         "borrow": "Borrow %(asset)s from the network. This creates a smart contract that locks your collateral until you either modify the position or a margin call is required.",
-        "borrow_disabled": "Asset %(asset)s is in global settlement. Margin updates are not allowed",
+        "borrow_disabled": "%(asset)s is in global settlement. Margin positions can't be created until it is revived. See asset details page for more information",
         "bridge": "Bridges allow deposit of any external assets and instant trade into the desired gateway asset",
         "bridge_TRADE": "BlockTrades is a bridge which supports instant trade of assets. Details and terms can be found on https://blocktrades.us",
         "buy_min": "You will receive at minimum this amount. If there are matching orders with a cheaper price than you specified, you will receive more than this amount.",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1735,6 +1735,7 @@
     },
     "tooltip": {
         "borrow": "Borrow %(asset)s from the network. This creates a smart contract that locks your collateral until you either modify the position or a margin call is required.",
+        "borrow_disabled": "Asset %(asset)s is in global settlement. Margin updates are not allowed",
         "bridge": "Bridges allow deposit of any external assets and instant trade into the desired gateway asset",
         "bridge_TRADE": "BlockTrades is a bridge which supports instant trade of assets. Details and terms can be found on https://blocktrades.us",
         "buy_min": "You will receive at minimum this amount. If there are matching orders with a cheaper price than you specified, you will receive more than this amount.",

--- a/app/components/Account/AccountPortfolioList.jsx
+++ b/app/components/Account/AccountPortfolioList.jsx
@@ -689,15 +689,20 @@ class AccountPortfolioList extends React.Component {
                     <td>
                         {isBitAsset && borrowLink ? (
                             <Tooltip 
-                                title={counterpart.translate(
-                                    "tooltip.borrow",
-                                    {asset: symbol}
+                                title={counterpart.translate("tooltip.borrow", {
+                                    asset: isAssetBitAsset
+                                        ? "bit" + symbol
+                                        : symbol}
                                 )}
                             >
                                 {borrowLink}
                             </Tooltip>
                         ) : isBitAsset && !borrowLink ? ( 
-                            <Tooltip title={counterpart.translate("tooltip.borrow_disabled",  {asset: symbol})}>
+                            <Tooltip title={counterpart.translate("tooltip.borrow_disabled",  {
+                                asset: isAssetBitAsset ? 
+                                    "bit" + symbol : 
+                                    symbol
+                            })}>
                                 <AntIcon type={"question-circle"} />
                             </Tooltip>
                         ) : (

--- a/app/components/Account/AccountPortfolioList.jsx
+++ b/app/components/Account/AccountPortfolioList.jsx
@@ -23,14 +23,13 @@ import SendModal from "../Modal/SendModal";
 import SettingsActions from "actions/SettingsActions";
 import SettleModal from "../Modal/SettleModal";
 import DepositModal from "../Modal/DepositModal";
-import SimpleDepositWithdraw from "../Dashboard/SimpleDepositWithdraw";
 import SimpleDepositBlocktradesBridge from "../Dashboard/SimpleDepositBlocktradesBridge";
 import WithdrawModal from "../Modal/WithdrawModalNew";
 import ZfApi from "react-foundation-apps/src/utils/foundation-api";
 import ReserveAssetModal from "../Modal/ReserveAssetModal";
-import BaseModal from "../Modal/BaseModal";
 import PaginatedList from "../Utility/PaginatedList";
 import MarketUtils from "common/market_utils";
+import {Tooltip, Icon as AntIcon} from "bitshares-ui-style-guide";
 
 class AccountPortfolioList extends React.Component {
     constructor() {
@@ -396,23 +395,11 @@ class AccountPortfolioList extends React.Component {
 
         const renderBorrow = (asset, account) => {
             let isBitAsset = asset && asset.has("bitasset_data_id");
-            let modalRef = "cp_modal_" + asset.get("id");
+            let isGlobalSettled = isBitAsset && asset.getIn(["bitasset","settlement_fund"]) > 0 ? true : false;
+
             return {
                 isBitAsset,
-                borrowModal: !isBitAsset ? null : (
-                    <BorrowModal
-                        ref={modalRef}
-                        modalId={"borrow_modal_" + asset.get("id")}
-                        quote_asset={asset.get("id")}
-                        backing_asset={asset.getIn([
-                            "bitasset",
-                            "options",
-                            "short_backing_asset"
-                        ])}
-                        account={account}
-                    />
-                ),
-                borrowLink: !isBitAsset ? null : (
+                borrowLink: !isBitAsset || isGlobalSettled ? null : (
                     <a
                         onClick={() => {
                             ReactTooltip.hide();
@@ -493,7 +480,7 @@ class AccountPortfolioList extends React.Component {
                 </a>
             );
 
-            let {isBitAsset, borrowModal, borrowLink} = renderBorrow(
+            let {isBitAsset, borrowLink} = renderBorrow(
                 asset,
                 this.props.account
             );
@@ -700,17 +687,19 @@ class AccountPortfolioList extends React.Component {
                     </td>
                     <td>{directMarketLink}</td>
                     <td>
-                        {isBitAsset ? (
-                            <div
-                                className="inline-block"
-                                data-place="bottom"
-                                data-tip={counterpart.translate(
+                        {isBitAsset && borrowLink ? (
+                            <Tooltip 
+                                title={counterpart.translate(
                                     "tooltip.borrow",
                                     {asset: symbol}
                                 )}
                             >
                                 {borrowLink}
-                            </div>
+                            </Tooltip>
+                        ) : isBitAsset && !borrowLink ? ( 
+                            <Tooltip title={counterpart.translate("tooltip.borrow_disabled",  {asset: symbol})}>
+                                <AntIcon type={"question-circle"} />
+                            </Tooltip>
                         ) : (
                             emptyCell
                         )}
@@ -1029,8 +1018,6 @@ class AccountPortfolioList extends React.Component {
             return null;
         }
 
-        console.log("render borrow modal");
-
         return (
             <BorrowModal
                 visible={this.state.isBorrowModalVisible}
@@ -1058,10 +1045,6 @@ class AccountPortfolioList extends React.Component {
     }
 
     render() {
-        const currentWithdrawAsset =
-            this.props.backedCoins.get("OPEN", []).find(c => {
-                return c.symbol === this.state.withdrawAsset;
-            }) || {};
         const currentBridges =
             this.props.bridgeCoins.get(this.state.bridgeAsset) || null;
 


### PR DESCRIPTION
Closes #2292 

- Disable Borrow link when in GS. Shows information tooltip instead.
- Inludes various code cleaning and testing with new Tooltip from Style Guide. 

An asset in GS can't be updated, nor borrowed, and `Borrow` on Dashboard should be disbaled for such assets.

![bitshares-margindisabled](https://user-images.githubusercontent.com/12114550/49696181-7e7c0500-fba6-11e8-973f-9ee2d2ab0fc1.gif)

