### PR TITLE
#2101 Update style-guide version to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
         "alt-react": "git+https://github.com/bitshares/alt-react.git#d91addef51f58e41e9857ebb0dd9177cfbd3b583",
         "bignumber.js": "^4.0.0",
         "bitshares-report": "^0.2.0",
-        "bitshares-ui-style-guide": "git+https://github.com/bitshares/bitshares-ui-style-guide.git#7431607d3642a65318d69fe982a0b7fb33e2ad18",
+        "bitshares-ui-style-guide": "git+https://github.com/bitshares/bitshares-ui-style-guide.git#3f03dc64c5745767ac6b90642b6c3ac666e44cfc",
         "bitsharesjs": "^1.8.3",
         "browser-locale": "^1.0.3",
         "classnames": "^2.2.1",


### PR DESCRIPTION
Closes #2101 

Commits:
https://github.com/bitshares/bitshares-ui-style-guide/commit/3cd9497870a1bc6ae94aca735c5a189522a8ea71
https://github.com/bitshares/bitshares-ui-style-guide/commit/3f03dc64c5745767ac6b90642b6c3ac666e44cfc

New AddonBefore & AddonAfter:

<img width="990" alt="screenshot 2018-12-10 18 24 29" src="https://user-images.githubusercontent.com/35899973/49749907-cf285680-fca9-11e8-91e7-63798cfb8b53.png">
<img width="972" alt="screenshot 2018-12-10 18 24 24" src="https://user-images.githubusercontent.com/35899973/49749908-cf285680-fca9-11e8-963d-da7f9b0ef75a.png">
<img width="971" alt="screenshot 2018-12-10 18 24 20" src="https://user-images.githubusercontent.com/35899973/49749909-cf285680-fca9-11e8-9c3d-6657f1d45158.png">
