### PR TITLE
Issue 2319 - Fix paperwallet naming

### DIFF
--- a/app/lib/common/paperWallet.js
+++ b/app/lib/common/paperWallet.js
@@ -104,8 +104,8 @@ const _createPaperWalletAsPDF = function(
     Promise.all(content).then(() => {
         pdf.save(
             "bitshares" +
-                (locked ? "-public" : "") +
-                "-paper-wallet" +
+                "-paper-wallet-" +
+                (locked ? "public-" : "private-") +
                 accountName +
                 ".pdf"
         );


### PR DESCRIPTION
Closes #2319 

- Changed order of naming.
- Adding private to private key wallet by default.
