### PR TITLE
Issue 2290 - Add prop "ignorePriceFeed" to FormattedPrice

### DIFF
--- a/app/components/Blockchain/BidCollateralOperation.jsx
+++ b/app/components/Blockchain/BidCollateralOperation.jsx
@@ -137,6 +137,7 @@ class BidCollateralOperation extends React.Component {
                                 quote_amount={this.state.debtAmount / 1}
                                 quote_asset={asset.get("id")}
                                 noPopOver
+                                ignorePriceFeed
                             />
                         </div>
                     )}

--- a/app/components/Utility/FormattedPrice.jsx
+++ b/app/components/Utility/FormattedPrice.jsx
@@ -157,7 +157,7 @@ class FormattedPrice extends React.Component {
 
         let formatted_value = "";
         if (!this.props.hide_value) {
-            let value = price.toReal();
+            let value = !this.props.ignorePriceFeed ? price.toReal() : quote_amount / base_amount;
             if (this.props.factor) {
                 if(this.props.negative_invert) {
                     value = inverted ? value * (this.props.factor) : value / (this.props.factor);    


### PR DESCRIPTION
Closes #2290 

Adds ignorePriceFeed prop to ignore current price for asset pair when doing collateral debt visual price

![bild](https://user-images.githubusercontent.com/12114550/50029733-0d987b00-fff4-11e8-9fcb-0efcc681c550.png)
