### PR TITLE
Issue 2329 - Adds the word testnet to the node access pop up

### DIFF
--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -2009,6 +2009,9 @@
     }
     .footer {
         div.footer-status {
+            > span.testnet {
+                font-size: 0.85rem;
+            }
             > span.success {
                 color: $success-color;
             }

--- a/app/components/Layout/Footer.jsx
+++ b/app/components/Layout/Footer.jsx
@@ -183,16 +183,14 @@ class Footer extends React.Component {
         return currentNode;
     }
 
-    getNode(node = {url: "", operator: "", region: ""}) {
+    getNode(node = {url: "", operator: ""}) {
         if (!node || !node.url) {
             throw "Node is undefined of has no url";
         }
 
         const {props} = this;
 
-        let testNet;
-        if (node.region) testNet = node.region.startsWith("TESTNET");
-        else testNet = false;
+        const testNet = node.url.indexOf("testnet") !== -1;
 
         let title = node.operator + " " + !!node.location ? node.location : "";
         if ("country" in node) {

--- a/app/components/Layout/Footer.jsx
+++ b/app/components/Layout/Footer.jsx
@@ -183,12 +183,16 @@ class Footer extends React.Component {
         return currentNode;
     }
 
-    getNode(node = {url: "", operator: ""}) {
+    getNode(node = {url: "", operator: "", region: ""}) {
         if (!node || !node.url) {
             throw "Node is undefined of has no url";
         }
 
         const {props} = this;
+
+        let testNet;
+        if (node.region) testNet = node.region.startsWith("TESTNET");
+        else testNet = false;
 
         let title = node.operator + " " + !!node.location ? node.location : "";
         if ("country" in node) {
@@ -201,7 +205,8 @@ class Footer extends React.Component {
             ping:
                 node.url in props.apiLatencies
                     ? props.apiLatencies[node.url]
-                    : -1
+                    : -1,
+            testNet
         };
     }
 
@@ -592,6 +597,11 @@ class Footer extends React.Component {
                                         }}
                                     >
                                         <div className="footer-status">
+                                            {connected && activeNode.testNet && (
+                                                <span className="testnet">
+                                                    <Translate content="settings.testnet_nodes" />{" "}
+                                                </span>
+                                            )}
                                             {!connected ? (
                                                 <span className="warning">
                                                     <Translate content="footer.disconnected" />
@@ -611,9 +621,8 @@ class Footer extends React.Component {
                                                 {!connected
                                                     ? "-"
                                                     : !activeNode.ping
-                                                        ? "-"
-                                                        : activeNode.ping +
-                                                          "ms"}
+                                                    ? "-"
+                                                    : activeNode.ping + "ms"}
                                                 &nbsp;/&nbsp;
                                                 <span className="footer-block-title">
                                                     <Translate content="footer.block" />


### PR DESCRIPTION
Fixes https://github.com/bitshares/bitshares-ui/issues/2329 by checking if the node region starts with TESTNET. This is how it is indicated in the WS_NODE_LIST array for example:

{ "region": "TESTNET - Northern Europe", }
If the node has a property of region and it starts with TESTNET, as well as being connected, then show the word TESTNET next the the node name in the footer. The word is 0.85rem, which is a little smaller that the node name in the footer.