### PR TITLE
Issue 2324 - Fixes Switching Accounts In Spotlight Crashes

### DIFF
--- a/app/components/Showcases/ShowcaseGrid.jsx
+++ b/app/components/Showcases/ShowcaseGrid.jsx
@@ -20,7 +20,7 @@ class ShowcaseGrid extends Component {
     componentWillReceiveProps(np) {
         if (np.currentAccount !== this.props.currentAccount) {
             this.setState({
-                currentAccount: ChainStore.getAccount(np.props.currentAccount)
+                currentAccount: ChainStore.getAccount(np.currentAccount)
             });
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/bitshares/bitshares-ui/issues/2324 . On [this](https://github.com/bitshares/bitshares-ui/blob/develop/app/components/Showcases/ShowcaseGrid.jsx#L23) line it calls np.props.currentAccount, but it is actually np.currentAccount, as np stands for next props. I removed the .props, and everything works as expected.