### PR TITLE
Issue 2322 - Enables the enter key for login and confirm modals

### DIFF
--- a/app/components/Blockchain/TransactionConfirm.jsx
+++ b/app/components/Blockchain/TransactionConfirm.jsx
@@ -32,6 +32,8 @@ class TransactionConfirm extends React.Component {
         this.onCloseClick = this.onCloseClick.bind(this);
 
         this.onConfirmClick = this.onConfirmClick.bind(this);
+
+        this.onKeyUp = this.onKeyUp.bind(this);
     }
 
     shouldComponentUpdate(nextProps) {
@@ -60,6 +62,11 @@ class TransactionConfirm extends React.Component {
         this.setState({
             isModalVisible: false
         });
+    }
+
+    onKeyUp(e) {
+        if (e.keyCode === 13) this.onConfirmClick(e);
+        else e.preventDefault();
     }
 
     onConfirmClick(e) {
@@ -201,7 +208,7 @@ class TransactionConfirm extends React.Component {
         }
 
         return (
-            <div ref="transactionConfirm">
+            <div ref="transactionConfirm" onKeyUp={this.onKeyUp}>
                 <Modal
                     wrapClassName="modal--transaction-confirm"
                     title={header}

--- a/app/components/Wallet/WalletUnlockModal.jsx
+++ b/app/components/Wallet/WalletUnlockModal.jsx
@@ -485,6 +485,7 @@ class WalletUnlockModal extends React.Component {
                                     type="password"
                                     value={this.state.password}
                                     onChange={this.handlePasswordChange}
+                                    onPressEnter={this.handleLogin}
                                 />
                             </Form.Item>
                         </div>
@@ -561,6 +562,7 @@ class WalletUnlockModal extends React.Component {
                                         "wallet.enter_password"
                                     )}
                                     onChange={this.handlePasswordChange}
+                                    onPressEnter={this.handleLogin}
                                 />
                             </Form.Item>
                         </div>


### PR DESCRIPTION
<h2>General</h2>
Closes #2322 

I fixed the feature to use the enter key for the login and confirm modals. On the login modal it will submit only when you click the submit button, or if your typing in the private key/password field and hit the enter key, using the built in onPressEnter for Antd's Input Component. On the confirm modal I added a onkeyup event listener to listen for a keyCode 13, or the enter key, and when it get's a 13 code it will confirm the transaction.

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [x] Opera
- [x] Firefox