### PR TITLE
Return missing styles back

### DIFF
--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -964,7 +964,20 @@
     input[type="search"]#{$ant-fix},
     textarea#{$ant-fix},
     input[role="combobox"]#{$ant-fix},
-    select[role="combobox"]#{$ant-fix},
+    select[role="combobox"]#{$ant-fix} {
+        background-color: $input-background;
+        border: 0;
+        color: $primary-text-color;
+        &:hover,
+        &:focus,
+        &:active,
+        &:disabled {
+            background-color: $input-background;
+        }
+        &:focus {
+            border-color: #aaa;
+        }
+    }
     input[type="range"] {
         /* These need to be independent selectors */
         &::-moz-range-thumb {


### PR DESCRIPTION
Closes #2344 
Seems like the styles were accidentally removed by commit:
https://github.com/bitshares/bitshares-ui/commit/cc2ecfa85812fdb9a340c80dc3ba71ed501cf8a9#diff-300e3a80c04e0dc255cd3f2f95a9d366 

@gibbsfromncis , please take a look and confirm I'm not losing anything.