### PR TITLE
Issue 2359 - Catch invalid SettlePrice object

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -97,47 +97,49 @@ class Asset extends React.Component {
 
             let feedPrice = this._getFeedPrice();
 
-            try {
-                Apis.instance()
-                    .db_api()
-                    .exec("get_call_orders", [this.props.asset.get("id"), 300])
-                    .then(call_orders => {
-                        let callOrders = call_orders.map(c => {
-                            return new CallOrder(
-                                c,
-                                assets,
-                                this.props.asset.get("id"),
-                                feedPrice,
-                                isPredictionMarket
-                            );
+            if(feedPrice) {
+                try {
+                    Apis.instance()
+                        .db_api()
+                        .exec("get_call_orders", [this.props.asset.get("id"), 300])
+                        .then(call_orders => {
+                            let callOrders = call_orders.map(c => {
+                                return new CallOrder(
+                                    c,
+                                    assets,
+                                    this.props.asset.get("id"),
+                                    feedPrice,
+                                    isPredictionMarket
+                                );
+                            });
+                            this.setState({callOrders});
                         });
-                        this.setState({callOrders});
-                    });
-            } catch (e) {
-                // console.log(err);
-            }
-
-            try {
-                Apis.instance()
-                    .db_api()
-                    .exec("get_collateral_bids", [
-                        this.props.asset.get("id"),
-                        100,
-                        0
-                    ])
-                    .then(coll_orders => {
-                        let collateralBids = coll_orders.map(c => {
-                            return new CollateralBid(
-                                c,
-                                assets,
-                                this.props.asset.get("id"),
-                                feedPrice
-                            );
+                } catch (e) {
+                    // console.log(err);
+                }
+    
+                try {
+                    Apis.instance()
+                        .db_api()
+                        .exec("get_collateral_bids", [
+                            this.props.asset.get("id"),
+                            100,
+                            0
+                        ])
+                        .then(coll_orders => {
+                            let collateralBids = coll_orders.map(c => {
+                                return new CollateralBid(
+                                    c,
+                                    assets,
+                                    this.props.asset.get("id"),
+                                    feedPrice
+                                );
+                            });
+                            this.setState({collateralBids});
                         });
-                        this.setState({collateralBids});
-                    });
-            } catch (e) {
-                console.log("get_collateral_bids Error: ", e);
+                } catch (e) {
+                    console.log("get_collateral_bids Error: ", e);
+                }
             }
         }
     }
@@ -162,9 +164,9 @@ class Asset extends React.Component {
             "current_feed",
             "settlement_price"
         ]);
-
+        
         let feedPrice;
-
+        
         /* Prediction markets don't need feeds for shorting, so the settlement price can be set to 1:1 */
         if (
             isPredictionMarket &&
@@ -188,6 +190,12 @@ class Asset extends React.Component {
             sqr = 1000;
         }
 
+        // Catch Invalid SettlePrice object
+        if(settlePrice.toJS) {
+            let settleObject = settlePrice.toJS();
+            if (!assets[settleObject.base.asset_id]) return;
+        } 
+        
         feedPrice = new FeedPrice({
             priceObject: settlePrice,
             market_base: this.props.asset.get("id"),


### PR DESCRIPTION
Closes #2359 
When an asset has no feeds (ABIT.CNY in this case) there will be an invalid SettlePrice object, making the application crash.

Line 100 on `Asset.jsx` was added to hide warning about failing object creation of `CallOrder` when feedPrice was missing.
