### PR TITLE
Update permission_utils.js

### DIFF
--- a/app/lib/common/permission_utils.js
+++ b/app/lib/common/permission_utils.js
@@ -160,6 +160,7 @@ let permissionUtils = {
         let map = [];
         accounts.forEach(id => {
             let fullAccount = ChainStore.getAccount(id);
+            if (!fullAccount) return;
             let currentPermission = this.unravel(
                 new this.AccountPermission(fullAccount, null, type),
                 type


### PR DESCRIPTION
when `fullAccount` is 'undefined',`new this.AccountPermission(fullAccount, null, type)` will throw an error  and cause page broken.  here add `if (!fullAccount) return`  to fix this error.