### PR TITLE
Fixing issue #2369 - correct spelling of "bridge"

### DIFF
--- a/app/assets/locales/locale-de.json
+++ b/app/assets/locales/locale-de.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1290,7 +1290,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-es.json
+++ b/app/assets/locales/locale-es.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-fr.json
+++ b/app/assets/locales/locale-fr.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-it.json
+++ b/app/assets/locales/locale-it.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-ja.json
+++ b/app/assets/locales/locale-ja.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-ko.json
+++ b/app/assets/locales/locale-ko.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-tr.json
+++ b/app/assets/locales/locale-tr.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",

--- a/app/assets/locales/locale-zh.json
+++ b/app/assets/locales/locale-zh.json
@@ -1284,7 +1284,7 @@
     "modal": {
         "buy": {
             "asset": "Asset",
-            "bridge": "Brdige",
+            "bridge": "Bridge",
             "title": "Buy"
         },
         "cancel": "cancel",


### PR DESCRIPTION
Closes #2369 

All were changed to the correct spelling except for RU. The word for "bridge" is in Russian.