### PR TITLE
Empty table TR doesn't show when markets table is empty

### DIFF
--- a/app/components/Dashboard/MarketsTable.jsx
+++ b/app/components/Dashboard/MarketsTable.jsx
@@ -361,13 +361,13 @@ class MarketsTable extends React.Component {
                         </tr>
                     }
                     rows={
-                        !marketRows.length ? (
-                            <tr className="table-empty">
+                        !marketRows.length ? [(
+                            <tr className="table-empty" key={"tr-table-empty"}>
                                 <td colSpan={showFlip ? 7 : 6}>
                                     <Translate content="dashboard.table_empty" />
                                 </td>
                             </tr>
-                        ) : (
+                        )] : (
                             marketRows
                         )
                     }


### PR DESCRIPTION
The empty table TR doesn't show in the markets table when the table is empty