### PR TITLE
fix WSOD on asset page

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -167,14 +167,15 @@ class Asset extends React.Component {
 
         /* Prediction markets don't need feeds for shorting, so the settlement price can be set to 1:1 */
         if (
-            isPredictionMarket &&
+            // isPredictionMarket &&
             settlePrice.getIn(["base", "asset_id"]) ===
-                settlePrice.getIn(["quote", "asset_id"])
+            settlePrice.getIn(["quote", "asset_id"])
         ) {
-            if (!assets[this.props.backingAsset.get("id")])
+            if (!assets[this.props.backingAsset.get("id")]) {
                 assets[this.props.backingAsset.get("id")] = {
                     precision: this.props.asset.get("precision")
                 };
+            }
             settlePrice = settlePrice.setIn(["base", "amount"], 1);
             settlePrice = settlePrice.setIn(
                 ["base", "asset_id"],


### PR DESCRIPTION
I have found out that this bug arises in assets, where settlement_price's " asset_id" key, in base and quote, are equal.
I've fixed the bug, but it requires review due to the fact that it affects a lot of related components.