### PR TITLE
2327

### DIFF
--- a/app/assets/stylesheets/components/_account.scss
+++ b/app/assets/stylesheets/components/_account.scss
@@ -469,6 +469,22 @@ div.tabs-container {
     }
 }
 
+.account-treemap--legend {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    .legend-item {
+        display: flex;
+        margin-right: 10px;
+        margin-bottom: 10px;
+        .legend-square {
+            height: 16px;
+            width: 16px;
+            margin-right: 5px;
+        }
+    }
+}
+
 .account-input-style-guide--account-status {
     float: right;
     color: $success-color;

--- a/app/components/Account/AccountTreemap.jsx
+++ b/app/components/Account/AccountTreemap.jsx
@@ -10,6 +10,7 @@ import AltContainer from "alt-container";
 import MarketUtils from "common/market_utils";
 import MarketsStore from "stores/MarketsStore";
 import SettingsStore from "stores/SettingsStore";
+import {Link, withRouter} from "react-router-dom";
 
 Treemap(ReactHighcharts.Highcharts);
 Heatmap(ReactHighcharts.Highcharts);
@@ -37,7 +38,8 @@ class AccountTreemap extends React.Component {
             balanceObjects,
             core_asset,
             marketStats,
-            preferredAsset
+            preferredAsset,
+            history
         } = this.props;
 
         let accountBalances = null;
@@ -107,6 +109,7 @@ class AccountTreemap extends React.Component {
 
                     return finalValue >= 1
                         ? {
+                              symbol: asset.get("symbol"),
                               name: `${asset.get("symbol")} (${
                                   totalValue === 0 ? 0 : percent.toFixed(2)
                               }%)`,
@@ -159,6 +162,17 @@ class AccountTreemap extends React.Component {
                             )} ${preferredAsset.get("symbol")}`;
                         }
                     }
+                },
+                series: {
+                    cursor: "pointer",
+                    point: {
+                        events: {
+                            click: function() {
+                                const link = `/asset/${this.symbol}`;
+                                history.push(link);
+                            }
+                        }
+                    }
                 }
             },
             series: [
@@ -186,15 +200,17 @@ class AccountTreemap extends React.Component {
         return (
             <div className="account-treemap">
                 <div className="account-treemap--legend">
-                    {accountBalances.map(({name, color}, key) => {
+                    {accountBalances.map(({name, symbol, color}, key) => {
                         return (
-                            <div className="legend-item" key={key}>
-                                <div
-                                    className="legend-square"
-                                    style={{backgroundColor: color}}
-                                />{" "}
-                                {name}
-                            </div>
+                            <Link to={`/asset/${symbol}`}>
+                                <div className="legend-item" key={key}>
+                                    <div
+                                        className="legend-square"
+                                        style={{backgroundColor: color}}
+                                    />
+                                    {name}
+                                </div>
+                            </Link>
                         );
                     })}
                 </div>
@@ -233,7 +249,7 @@ class AccountTreemapBalanceWrapper extends React.Component {
 
 AccountTreemapBalanceWrapper = BindToChainState(AccountTreemapBalanceWrapper);
 
-export default class AccountTreemapWrapper extends React.Component {
+class AccountTreemapWrapper extends React.Component {
     render() {
         return (
             <AltContainer
@@ -255,3 +271,5 @@ export default class AccountTreemapWrapper extends React.Component {
         );
     }
 }
+
+export default withRouter(AccountTreemapWrapper);

--- a/app/components/Account/AccountTreemap.jsx
+++ b/app/components/Account/AccountTreemap.jsx
@@ -106,18 +106,18 @@ class AccountTreemap extends React.Component {
                 * the total value of the account
                 */
                     if (percent < 0.5) return null;
-
-                    return finalValue >= 1
-                        ? {
-                              symbol: asset.get("symbol"),
-                              name: `${asset.get("symbol")} (${
-                                  totalValue === 0 ? 0 : percent.toFixed(2)
-                              }%)`,
-                              value: finalValue,
-                              color: ReactHighcharts.Highcharts.getOptions()
-                                  .colors[index]
-                          }
-                        : null;
+                    if (finalValue < 1) return null;
+                    const symbol = asset.get("symbol");
+                    return {
+                        symbol: symbol,
+                        name: `${symbol} (${
+                            totalValue === 0 ? 0 : percent.toFixed(2)
+                        }%)`,
+                        value: finalValue,
+                        color: ReactHighcharts.Highcharts.getOptions().colors[
+                            index
+                        ]
+                    };
                 })
                 .filter(n => !!n);
         }

--- a/app/components/Account/AccountTreemap.jsx
+++ b/app/components/Account/AccountTreemap.jsx
@@ -185,6 +185,19 @@ class AccountTreemap extends React.Component {
 
         return (
             <div className="account-treemap">
+                <div className="account-treemap--legend">
+                    {accountBalances.map(({name, color}, key) => {
+                        return (
+                            <div className="legend-item" key={key}>
+                                <div
+                                    className="legend-square"
+                                    style={{backgroundColor: color}}
+                                />{" "}
+                                {name}
+                            </div>
+                        );
+                    })}
+                </div>
                 <ReactHighcharts config={config} />
             </div>
         );

--- a/app/components/Account/AccountTreemap.jsx
+++ b/app/components/Account/AccountTreemap.jsx
@@ -202,8 +202,8 @@ class AccountTreemap extends React.Component {
                 <div className="account-treemap--legend">
                     {accountBalances.map(({name, symbol, color}, key) => {
                         return (
-                            <Link to={`/asset/${symbol}`}>
-                                <div className="legend-item" key={key}>
+                            <Link key={key} to={`/asset/${symbol}`}>
+                                <div className="legend-item">
                                     <div
                                         className="legend-square"
                                         style={{backgroundColor: color}}


### PR DESCRIPTION
<h2>General</h2>
Closes #2327

- add legend to AccountTreemap
- add link to legend and tree map

Test

Given I have navigate to Dashboard-> Portfolio
When I click Visual
Then I should see Legend on top of the tree map chart
When I click on one of the legends
Then I should navigate to the asset page
When I go back and click on the tree map chart
Then I should navigate to the asset page

<h2>General</h2>
lease make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at 
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [x] Light
- [x] Midnight

_Please provide screenshots/licecap of your changes below_

![2327](https://user-images.githubusercontent.com/912025/54232407-f6790480-44e0-11e9-88f1-986c73a6ba0a.gif)
