### PR TITLE
#2497 scaled orders improvements

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -476,6 +476,8 @@
         "top_markets": "Top Markets"
     },
     "exchange": {
+        "limit": "Limit",
+        "scaled": "Scaled",
         "add_quote": "Add",
         "asks": "Sell orders",
         "atr": "Average True Range",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1480,6 +1480,7 @@
             "flat": "Flat"
         },
         "order_count": "Order Count",
+        "order_s": "Order(s)",
         "action": {
             "title": "Action",
             "buy": "Buy",

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1456,7 +1456,7 @@
             "urlNamed": "%(name)s should be url",
             "oneOf": "The field should be one of: %(list)s",
             "oneOfNamed": "%(name)s should be one of: %(list)s",
-            "balance": "Insufficient balance. Available only: %(balance)s",
+            "balance": "Insufficient balance. Available only: %(balance)s %(symbol)s",
 
             "test": ""
         }

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -221,6 +221,18 @@ form.order-form {
     }
 }
 
+.buy-form {
+    > div.ant-tabs-bar {
+        border-bottom: 1px solid #258a14 !important;
+    }
+}
+
+.sell-form {
+    > div.ant-tabs-bar {
+        border-bottom: 1px solid #ea340b !important;
+    }
+}
+
 #market-charts {
     > div.Stockcharts__wrapper {
         overflow: hidden;

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -211,6 +211,16 @@ form.order-form {
     }
 }
 
+.exchange--buy-sell-form {
+    // override "Extra" of Ant.Tabs (Buy/Sell Asset) to put it
+    // on left side instead of right
+    .ant-tabs-extra-content {
+        float: left !important;
+        padding: 0 15px;
+        margin-right: 12px;
+    }
+}
+
 #market-charts {
     > div.Stockcharts__wrapper {
         overflow: hidden;
@@ -585,7 +595,6 @@ input[type="number"]::-webkit-outer-spin-button {
     font-size: 1rem;
     font-weight: 500;
     text-transform: uppercase;
-    padding: 10px 5px 12px 10px;
     overflow: hidden;
 }
 

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -184,6 +184,27 @@ p.order-table-title {
 
 form.order-form {
     padding: 10px;
+
+    .ant-form-item {
+        margin-bottom: 0;
+    }
+
+    .ant-form-item-label {
+        text-align: left;
+        font-family: Roboto Medium, Monospaced Number, Chinese Quote,
+            -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, PingFang SC,
+            Hiragino Sans GB, Microsoft YaHei, Helvetica Neue, Helvetica, Arial,
+            sans-serif;
+
+        label {
+            font-size: 90% !important;
+        }
+    }
+
+    .ant-input-group-addon {
+        text-align: left;
+        width: 60% !important;
+    }
 }
 
 #market-charts {

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -189,6 +189,10 @@ form.order-form {
         margin-bottom: 0;
     }
 
+    .ant-input {
+        text-align: right;
+    }
+
     .ant-form-item-label {
         text-align: left;
         font-family: Roboto Medium, Monospaced Number, Chinese Quote,

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1422,13 +1422,6 @@
     }
     .exchange-content-header {
         color: $light-text-color;
-        border-bottom: 1px solid $button-bg-color;
-        &.bid {
-            border-bottom: 1px solid $bid-color;
-        }
-        &.ask {
-            border-bottom: 1px solid $ask-color;
-        }
     }
 
     .exchange-content-header--buy-sell-form {

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -2175,6 +2175,12 @@
         }
     }
     .expiration-datetime-picker {
+        &.scaled-orders {
+            > div {
+                margin-top: -5px;
+            }
+        }
+
         > div {
             float: left;
             min-width: 145px;

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -1430,6 +1430,11 @@
             border-bottom: 1px solid $ask-color;
         }
     }
+
+    .exchange-content-header--buy-sell-form {
+        border-bottom: 0 !important;
+    }
+
     // .block-content-header {
     // //text-transform: uppercase;
     // @include RobotoLight;

--- a/app/components/Exchange/BuySell.jsx
+++ b/app/components/Exchange/BuySell.jsx
@@ -974,7 +974,12 @@ class BuySell extends React.Component {
                     //data-intro={dataIntro}
                 >
                     {!hideHeader ? (
-                        <div className={"exchange-content-header " + type}>
+                        <div
+                            className={
+                                "exchange-content-header exchange-content-header--buy-sell-form " +
+                                type
+                            }
+                        >
                             <span>
                                 <TranslateWithLinks
                                     string="exchange.buysell_formatter"
@@ -997,36 +1002,6 @@ class BuySell extends React.Component {
                                         }
                                     ]}
                                 />
-                            </span>
-                            <span style={{float: "right"}}>
-                                {currentAccount ? (
-                                    <a
-                                        href="javascript:void(0);"
-                                        onClick={
-                                            this.props.showScaledOrderModal
-                                        }
-                                        style={{textTransform: "none"}}
-                                    >
-                                        {counterpart.translate(
-                                            "scaled_orders.title"
-                                        )}
-                                    </a>
-                                ) : (
-                                    <Tooltip
-                                        title={counterpart.translate(
-                                            "scaled_orders.please_log_in"
-                                        )}
-                                    >
-                                        <a
-                                            href="javascript:void(0);"
-                                            style={{textTransform: "none"}}
-                                        >
-                                            {counterpart.translate(
-                                                "scaled_orders.title"
-                                            )}
-                                        </a>
-                                    </Tooltip>
-                                )}
                             </span>
                             {/* <span>{buttonText} <AssetName dataPlace="top" name={quote.get("symbol")} /></span> */}
                             {this.props.onFlip &&

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -2189,6 +2189,17 @@ class Exchange extends React.Component {
                     key={"scaled"}
                 >
                     <ScaledOrderTab
+                        expirationType={expirationType["bid"]}
+                        expirations={this.EXPIRATIONS}
+                        expirationCustomTime={expirationCustomTime["bid"]}
+                        onExpirationTypeChange={this._handleExpirationChange.bind(
+                            this,
+                            "bid"
+                        )}
+                        onExpirationCustomChange={this._handleCustomExpirationChange.bind(
+                            this,
+                            "bid"
+                        )}
                         currentPrice={lowestAsk.getPrice()}
                         lastClickedPrice={
                             this.state.ask && this.state.ask.priceText
@@ -2347,6 +2358,17 @@ class Exchange extends React.Component {
                     key={"scaled"}
                 >
                     <ScaledOrderTab
+                        expirationType={expirationType["ask"]}
+                        expirations={this.EXPIRATIONS}
+                        expirationCustomTime={expirationCustomTime["ask"]}
+                        onExpirationTypeChange={this._handleExpirationChange.bind(
+                            this,
+                            "ask"
+                        )}
+                        onExpirationCustomChange={this._handleCustomExpirationChange.bind(
+                            this,
+                            "ask"
+                        )}
                         currentPrice={highestBid.getPrice()}
                         lastClickedPrice={
                             this.state.ask && this.state.ask.priceText

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -124,6 +124,12 @@ class Exchange extends React.Component {
         this.psInit = true;
     }
 
+    handleOrderTypeTabChange(type, value) {
+        SettingsActions.changeViewSetting({
+            [`order-form-${type}`]: value
+        });
+    }
+
     handlePriceAlertSave(savedRules = []) {
         // add info about market asset pair
         savedRules = savedRules.map(rule => ({
@@ -2056,8 +2062,12 @@ class Exchange extends React.Component {
         !this.state.mobileKey.includes("buySellTab") ? null : (
             <Tabs
                 animated={false}
+                activeKey={
+                    this.props.viewSettings.get("order-form-bid") || "limit"
+                }
+                onChange={this.handleOrderTypeTabChange.bind(this, "bid")}
                 tabBarExtraContent={<div>{buySellTitle(true)}</div>}
-                defaultActiveKey={"scaled"}
+                defaultActiveKey={"limit"}
                 className={cnames(
                     "exchange--buy-sell-form",
                     verticalOrderForm && !smallScreen
@@ -2217,9 +2227,13 @@ class Exchange extends React.Component {
         let sellForm = isFrozen ? null : tinyScreen &&
         !this.state.mobileKey.includes("buySellTab") ? null : (
             <Tabs
+                activeKey={
+                    this.props.viewSettings.get("order-form-ask") || "limit"
+                }
+                onChange={this.handleOrderTypeTabChange.bind(this, "ask")}
                 animated={false}
                 tabBarExtraContent={<div>{buySellTitle(false)}</div>}
-                defaultActiveKey={"scaled"}
+                defaultActiveKey={"limit"}
                 className={cnames(
                     "exchange--buy-sell-form",
                     verticalOrderForm && !smallScreen

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -42,7 +42,6 @@ import SimpleDepositWithdraw from "../Dashboard/SimpleDepositWithdraw";
 import SimpleDepositBlocktradesBridge from "../Dashboard/SimpleDepositBlocktradesBridge";
 import {Notification} from "bitshares-ui-style-guide";
 import PriceAlert from "./PriceAlert";
-import ScaledOrder from "./ScaledOrder";
 import counterpart from "counterpart";
 
 class Exchange extends React.Component {
@@ -3583,14 +3582,6 @@ class Exchange extends React.Component {
                     visible={this.state.isPriceAlertModalVisible}
                     showModal={this.showPriceAlertModal}
                     hideModal={this.hidePriceAlertModal}
-                />
-
-                <ScaledOrder
-                    createScaledOrder={this._createScaledOrder}
-                    visible={this.state.isScaledOrderModalVisible}
-                    hideModal={this.hideScaledOrderModal}
-                    quoteAsset={this.props.quoteAsset.get("id")}
-                    baseAsset={this.props.baseAsset.get("id")}
                 />
             </div>
         );

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -2168,6 +2168,7 @@ class Exchange extends React.Component {
                     key={"scaled"}
                 >
                     <ScaledOrderTab
+                        currentPrice={lowestAsk.getPrice()}
                         lastClickedPrice={
                             this.state.ask && this.state.ask.priceText
                         }
@@ -2327,6 +2328,7 @@ class Exchange extends React.Component {
                     key={"scaled"}
                 >
                     <ScaledOrderTab
+                        currentPrice={highestBid.getPrice()}
                         lastClickedPrice={
                             this.state.ask && this.state.ask.priceText
                         }

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -2168,6 +2168,9 @@ class Exchange extends React.Component {
                     key={"scaled"}
                 >
                     <ScaledOrderTab
+                        lastClickedPrice={
+                            this.state.ask && this.state.ask.priceText
+                        }
                         currentAccount={currentAccount}
                         createScaledOrder={this._createScaledOrder}
                         type={"bid"}
@@ -2324,6 +2327,9 @@ class Exchange extends React.Component {
                     key={"scaled"}
                 >
                     <ScaledOrderTab
+                        lastClickedPrice={
+                            this.state.ask && this.state.ask.priceText
+                        }
                         currentAccount={currentAccount}
                         createScaledOrder={this._createScaledOrder}
                         type="ask"

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -23,6 +23,7 @@ import {Asset, Price, LimitOrderCreate} from "common/MarketClasses";
 import {checkFeeStatusAsync} from "common/trxHelper";
 import utils from "common/utils";
 import BuySell from "./BuySell";
+import ScaledOrderTab from "./ScaledOrderTab";
 import ExchangeHeader from "./ExchangeHeader";
 import {MyOpenOrders} from "./MyOpenOrders";
 import {OrderBook} from "./OrderBook";
@@ -2030,23 +2031,9 @@ class Exchange extends React.Component {
 
         let buyForm = isFrozen ? null : tinyScreen &&
         !this.state.mobileKey.includes("buySellTab") ? null : (
-            <BuySell
-                showScaledOrderModal={this.showScaledOrderModal}
-                key={`actionCard_${actionCardIndex++}`}
-                onBorrow={baseIsBitAsset ? this._borrowBase.bind(this) : null}
-                onBuy={this._onBuy.bind(this, "bid")}
-                onDeposit={this._onDeposit.bind(this, "bid")}
-                currentAccount={currentAccount}
-                backedCoin={this.props.backedCoins.find(
-                    a => a.symbol === base.get("symbol")
-                )}
-                currentBridges={
-                    this.props.bridgeCoins.get(base.get("symbol")) || null
-                }
-                isOpen={this.state.buySellOpen}
-                onToggleOpen={this._toggleOpenBuySell.bind(this)}
-                parentWidth={centerContainerWidth}
-                styles={{padding: 5, paddingRight: mirrorPanels ? 15 : 5}}
+            <Tabs
+                animated={false}
+                defaultKey={"limit"}
                 className={cnames(
                     verticalOrderForm && !smallScreen
                         ? ""
@@ -2064,97 +2051,132 @@ class Exchange extends React.Component {
                               buySellTop ? 1 : 4
                           } buy-form`
                 )}
-                type="bid"
-                hideHeader={
-                    tinyScreen || (!smallScreen && verticalOrderForm)
-                        ? true
-                        : false
-                }
-                expirationType={expirationType["bid"]}
-                expirations={this.EXPIRATIONS}
-                expirationCustomTime={expirationCustomTime["bid"]}
-                onExpirationTypeChange={this._handleExpirationChange.bind(
-                    this,
-                    "bid"
-                )}
-                onExpirationCustomChange={this._handleCustomExpirationChange.bind(
-                    this,
-                    "bid"
-                )}
-                amount={bid.toReceiveText}
-                price={bid.priceText}
-                total={bid.forSaleText}
-                quote={quote}
-                base={base}
-                amountChange={this._onInputReceive.bind(this, "bid", true)}
-                priceChange={this._onInputPrice.bind(this, "bid")}
-                setPrice={this._currentPriceClick.bind(this)}
-                totalChange={this._onInputSell.bind(this, "bid", false)}
-                clearForm={this._clearForms.bind(this, "bid")}
-                balance={baseBalance}
-                balanceId={base.get("id")}
-                onSubmit={this._createLimitOrderConfirm.bind(
-                    this,
-                    quote,
-                    base,
-                    baseBalance,
-                    coreBalance,
-                    buyFeeAsset,
-                    "buy"
-                )}
-                balancePrecision={base.get("precision")}
-                quotePrecision={quote.get("precision")}
-                totalPrecision={base.get("precision")}
-                currentPrice={lowestAsk.getPrice()}
-                currentPriceObject={lowestAsk}
-                account={currentAccount.get("name")}
-                fee={buyFee}
-                hasFeeBalance={this.state.feeStatus[buyFee.asset_id].hasBalance}
-                feeAssets={buyFeeAssets}
-                feeAsset={buyFeeAsset}
-                onChangeFeeAsset={this.onChangeFeeAsset.bind(this, "buy")}
-                isPredictionMarket={base.getIn([
-                    "bitasset",
-                    "is_prediction_market"
-                ])}
-                onFlip={!flipBuySell ? this._flipBuySell.bind(this) : null}
-                onTogglePosition={
-                    this.state.buySellTop && !verticalOrderBook
-                        ? this._toggleBuySellPosition.bind(this)
-                        : null
-                }
-                moveOrderForm={
-                    !smallScreen && (!flipBuySell || verticalOrderForm)
-                        ? this._moveOrderForm.bind(this)
-                        : null
-                }
-                verticalOrderForm={!smallScreen ? verticalOrderForm : false}
-                isPanelActive={isPanelActive}
-                activePanels={activePanels}
-                singleColumnOrderForm={singleColumnOrderForm}
-                hideFunctionButtons={hideFunctionButtons}
-            />
+            >
+                <Tabs.TabPane
+                    tab={counterpart.translate("exchange.limit")}
+                    key={"limit"}
+                >
+                    <BuySell
+                        showScaledOrderModal={this.showScaledOrderModal}
+                        key={`actionCard_${actionCardIndex++}`}
+                        onBorrow={
+                            baseIsBitAsset ? this._borrowBase.bind(this) : null
+                        }
+                        onBuy={this._onBuy.bind(this, "bid")}
+                        onDeposit={this._onDeposit.bind(this, "bid")}
+                        currentAccount={currentAccount}
+                        backedCoin={this.props.backedCoins.find(
+                            a => a.symbol === base.get("symbol")
+                        )}
+                        currentBridges={
+                            this.props.bridgeCoins.get(base.get("symbol")) ||
+                            null
+                        }
+                        isOpen={this.state.buySellOpen}
+                        onToggleOpen={this._toggleOpenBuySell.bind(this)}
+                        parentWidth={centerContainerWidth}
+                        styles={{
+                            padding: 5,
+                            paddingRight: mirrorPanels ? 15 : 5
+                        }}
+                        type="bid"
+                        hideHeader={
+                            tinyScreen || (!smallScreen && verticalOrderForm)
+                                ? true
+                                : false
+                        }
+                        expirationType={expirationType["bid"]}
+                        expirations={this.EXPIRATIONS}
+                        expirationCustomTime={expirationCustomTime["bid"]}
+                        onExpirationTypeChange={this._handleExpirationChange.bind(
+                            this,
+                            "bid"
+                        )}
+                        onExpirationCustomChange={this._handleCustomExpirationChange.bind(
+                            this,
+                            "bid"
+                        )}
+                        amount={bid.toReceiveText}
+                        price={bid.priceText}
+                        total={bid.forSaleText}
+                        quote={quote}
+                        base={base}
+                        amountChange={this._onInputReceive.bind(
+                            this,
+                            "bid",
+                            true
+                        )}
+                        priceChange={this._onInputPrice.bind(this, "bid")}
+                        setPrice={this._currentPriceClick.bind(this)}
+                        totalChange={this._onInputSell.bind(this, "bid", false)}
+                        clearForm={this._clearForms.bind(this, "bid")}
+                        balance={baseBalance}
+                        balanceId={base.get("id")}
+                        onSubmit={this._createLimitOrderConfirm.bind(
+                            this,
+                            quote,
+                            base,
+                            baseBalance,
+                            coreBalance,
+                            buyFeeAsset,
+                            "buy"
+                        )}
+                        balancePrecision={base.get("precision")}
+                        quotePrecision={quote.get("precision")}
+                        totalPrecision={base.get("precision")}
+                        currentPrice={lowestAsk.getPrice()}
+                        currentPriceObject={lowestAsk}
+                        account={currentAccount.get("name")}
+                        fee={buyFee}
+                        hasFeeBalance={
+                            this.state.feeStatus[buyFee.asset_id].hasBalance
+                        }
+                        feeAssets={buyFeeAssets}
+                        feeAsset={buyFeeAsset}
+                        onChangeFeeAsset={this.onChangeFeeAsset.bind(
+                            this,
+                            "buy"
+                        )}
+                        isPredictionMarket={base.getIn([
+                            "bitasset",
+                            "is_prediction_market"
+                        ])}
+                        onFlip={
+                            !flipBuySell ? this._flipBuySell.bind(this) : null
+                        }
+                        onTogglePosition={
+                            this.state.buySellTop && !verticalOrderBook
+                                ? this._toggleBuySellPosition.bind(this)
+                                : null
+                        }
+                        moveOrderForm={
+                            !smallScreen && (!flipBuySell || verticalOrderForm)
+                                ? this._moveOrderForm.bind(this)
+                                : null
+                        }
+                        verticalOrderForm={
+                            !smallScreen ? verticalOrderForm : false
+                        }
+                        isPanelActive={isPanelActive}
+                        activePanels={activePanels}
+                        singleColumnOrderForm={singleColumnOrderForm}
+                        hideFunctionButtons={hideFunctionButtons}
+                    />
+                </Tabs.TabPane>
+                <Tabs.TabPane
+                    tab={counterpart.translate("exchange.scaled")}
+                    key={"scaled"}
+                >
+                    <ScaledOrderTab />
+                </Tabs.TabPane>
+            </Tabs>
         );
 
         let sellForm = isFrozen ? null : tinyScreen &&
         !this.state.mobileKey.includes("buySellTab") ? null : (
-            <BuySell
-                showScaledOrderModal={this.showScaledOrderModal}
-                key={`actionCard_${actionCardIndex++}`}
-                onBorrow={quoteIsBitAsset ? this._borrowQuote.bind(this) : null}
-                onBuy={this._onBuy.bind(this, "ask")}
-                onDeposit={this._onDeposit.bind(this, "ask")}
-                currentAccount={currentAccount}
-                backedCoin={this.props.backedCoins.find(
-                    a => a.symbol === quote.get("symbol")
-                )}
-                currentBridges={
-                    this.props.bridgeCoins.get(quote.get("symbol")) || null
-                }
-                isOpen={this.state.buySellOpen}
-                onToggleOpen={this._toggleOpenBuySell.bind(this)}
-                parentWidth={centerContainerWidth}
-                styles={{padding: 5, paddingRight: mirrorPanels ? 15 : 5}}
+            <Tabs
+                animated={false}
+                defaultKey={"limit"}
                 className={cnames(
                     verticalOrderForm && !smallScreen
                         ? ""
@@ -2172,78 +2194,132 @@ class Exchange extends React.Component {
                               buySellTop ? 2 : 5
                           } sell-form`
                 )}
-                type="ask"
-                hideHeader={
-                    tinyScreen || (!smallScreen && verticalOrderForm)
-                        ? true
-                        : false
-                }
-                amount={ask.forSaleText}
-                price={ask.priceText}
-                total={ask.toReceiveText}
-                quote={quote}
-                base={base}
-                expirationType={expirationType["ask"]}
-                expirations={this.EXPIRATIONS}
-                expirationCustomTime={expirationCustomTime["ask"]}
-                onExpirationTypeChange={this._handleExpirationChange.bind(
-                    this,
-                    "ask"
-                )}
-                onExpirationCustomChange={this._handleCustomExpirationChange.bind(
-                    this,
-                    "ask"
-                )}
-                amountChange={this._onInputSell.bind(this, "ask", false)}
-                priceChange={this._onInputPrice.bind(this, "ask")}
-                setPrice={this._currentPriceClick.bind(this)}
-                totalChange={this._onInputReceive.bind(this, "ask", true)}
-                clearForm={this._clearForms.bind(this, "ask")}
-                balance={quoteBalance}
-                balanceId={quote.get("id")}
-                onSubmit={this._createLimitOrderConfirm.bind(
-                    this,
-                    base,
-                    quote,
-                    quoteBalance,
-                    coreBalance,
-                    sellFeeAsset,
-                    "sell"
-                )}
-                balancePrecision={quote.get("precision")}
-                quotePrecision={quote.get("precision")}
-                totalPrecision={base.get("precision")}
-                currentPrice={highestBid.getPrice()}
-                currentPriceObject={highestBid}
-                account={currentAccount.get("name")}
-                fee={sellFee}
-                hasFeeBalance={
-                    this.state.feeStatus[sellFee.asset_id].hasBalance
-                }
-                feeAssets={sellFeeAssets}
-                feeAsset={sellFeeAsset}
-                onChangeFeeAsset={this.onChangeFeeAsset.bind(this, "sell")}
-                isPredictionMarket={quote.getIn([
-                    "bitasset",
-                    "is_prediction_market"
-                ])}
-                onFlip={flipBuySell ? this._flipBuySell.bind(this) : null}
-                onTogglePosition={
-                    this.state.buySellTop && !verticalOrderBook
-                        ? this._toggleBuySellPosition.bind(this)
-                        : null
-                }
-                moveOrderForm={
-                    !smallScreen && (flipBuySell || verticalOrderForm)
-                        ? this._moveOrderForm.bind(this)
-                        : null
-                }
-                verticalOrderForm={!smallScreen ? verticalOrderForm : false}
-                isPanelActive={isPanelActive}
-                activePanels={activePanels}
-                singleColumnOrderForm={singleColumnOrderForm}
-                hideFunctionButtons={hideFunctionButtons}
-            />
+            >
+                <Tabs.TabPane
+                    tab={counterpart.translate("exchange.limit")}
+                    key={"limit"}
+                >
+                    <BuySell
+                        showScaledOrderModal={this.showScaledOrderModal}
+                        key={`actionCard_${actionCardIndex++}`}
+                        onBorrow={
+                            quoteIsBitAsset
+                                ? this._borrowQuote.bind(this)
+                                : null
+                        }
+                        onBuy={this._onBuy.bind(this, "ask")}
+                        onDeposit={this._onDeposit.bind(this, "ask")}
+                        currentAccount={currentAccount}
+                        backedCoin={this.props.backedCoins.find(
+                            a => a.symbol === quote.get("symbol")
+                        )}
+                        currentBridges={
+                            this.props.bridgeCoins.get(quote.get("symbol")) ||
+                            null
+                        }
+                        isOpen={this.state.buySellOpen}
+                        onToggleOpen={this._toggleOpenBuySell.bind(this)}
+                        parentWidth={centerContainerWidth}
+                        styles={{
+                            padding: 5,
+                            paddingRight: mirrorPanels ? 15 : 5
+                        }}
+                        type="ask"
+                        hideHeader={
+                            tinyScreen || (!smallScreen && verticalOrderForm)
+                                ? true
+                                : false
+                        }
+                        amount={ask.forSaleText}
+                        price={ask.priceText}
+                        total={ask.toReceiveText}
+                        quote={quote}
+                        base={base}
+                        expirationType={expirationType["ask"]}
+                        expirations={this.EXPIRATIONS}
+                        expirationCustomTime={expirationCustomTime["ask"]}
+                        onExpirationTypeChange={this._handleExpirationChange.bind(
+                            this,
+                            "ask"
+                        )}
+                        onExpirationCustomChange={this._handleCustomExpirationChange.bind(
+                            this,
+                            "ask"
+                        )}
+                        amountChange={this._onInputSell.bind(
+                            this,
+                            "ask",
+                            false
+                        )}
+                        priceChange={this._onInputPrice.bind(this, "ask")}
+                        setPrice={this._currentPriceClick.bind(this)}
+                        totalChange={this._onInputReceive.bind(
+                            this,
+                            "ask",
+                            true
+                        )}
+                        clearForm={this._clearForms.bind(this, "ask")}
+                        balance={quoteBalance}
+                        balanceId={quote.get("id")}
+                        onSubmit={this._createLimitOrderConfirm.bind(
+                            this,
+                            base,
+                            quote,
+                            quoteBalance,
+                            coreBalance,
+                            sellFeeAsset,
+                            "sell"
+                        )}
+                        balancePrecision={quote.get("precision")}
+                        quotePrecision={quote.get("precision")}
+                        totalPrecision={base.get("precision")}
+                        currentPrice={highestBid.getPrice()}
+                        currentPriceObject={highestBid}
+                        account={currentAccount.get("name")}
+                        fee={sellFee}
+                        hasFeeBalance={
+                            this.state.feeStatus[sellFee.asset_id].hasBalance
+                        }
+                        feeAssets={sellFeeAssets}
+                        feeAsset={sellFeeAsset}
+                        onChangeFeeAsset={this.onChangeFeeAsset.bind(
+                            this,
+                            "sell"
+                        )}
+                        isPredictionMarket={quote.getIn([
+                            "bitasset",
+                            "is_prediction_market"
+                        ])}
+                        onFlip={
+                            flipBuySell ? this._flipBuySell.bind(this) : null
+                        }
+                        onTogglePosition={
+                            this.state.buySellTop && !verticalOrderBook
+                                ? this._toggleBuySellPosition.bind(this)
+                                : null
+                        }
+                        moveOrderForm={
+                            !smallScreen && (flipBuySell || verticalOrderForm)
+                                ? this._moveOrderForm.bind(this)
+                                : null
+                        }
+                        verticalOrderForm={
+                            !smallScreen ? verticalOrderForm : false
+                        }
+                        isPanelActive={isPanelActive}
+                        activePanels={activePanels}
+                        singleColumnOrderForm={singleColumnOrderForm}
+                        hideFunctionButtons={hideFunctionButtons}
+                    />
+                </Tabs.TabPane>
+
+                <Tabs.TabPane
+                    tab={counterpart.translate("exchange.scaled")}
+                    key={"scaled"}
+                >
+                    <ScaledOrderTab />
+                </Tabs.TabPane>
+            </Tabs>
         );
 
         let myMarkets =

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -2033,7 +2033,7 @@ class Exchange extends React.Component {
         !this.state.mobileKey.includes("buySellTab") ? null : (
             <Tabs
                 animated={false}
-                defaultKey={"limit"}
+                defaultActiveKey={"scaled"}
                 className={cnames(
                     verticalOrderForm && !smallScreen
                         ? ""
@@ -2167,7 +2167,13 @@ class Exchange extends React.Component {
                     tab={counterpart.translate("exchange.scaled")}
                     key={"scaled"}
                 >
-                    <ScaledOrderTab />
+                    <ScaledOrderTab
+                        currentAccount={currentAccount}
+                        createScaledOrder={this._createScaledOrder}
+                        type={"bid"}
+                        quoteAsset={quote}
+                        baseAsset={base}
+                    />
                 </Tabs.TabPane>
             </Tabs>
         );
@@ -2176,7 +2182,7 @@ class Exchange extends React.Component {
         !this.state.mobileKey.includes("buySellTab") ? null : (
             <Tabs
                 animated={false}
-                defaultKey={"limit"}
+                defaultActiveKey={"scaled"}
                 className={cnames(
                     verticalOrderForm && !smallScreen
                         ? ""
@@ -2317,7 +2323,13 @@ class Exchange extends React.Component {
                     tab={counterpart.translate("exchange.scaled")}
                     key={"scaled"}
                 >
-                    <ScaledOrderTab />
+                    <ScaledOrderTab
+                        currentAccount={currentAccount}
+                        createScaledOrder={this._createScaledOrder}
+                        type="ask"
+                        baseAsset={base}
+                        quoteAsset={quote}
+                    />
                 </Tabs.TabPane>
             </Tabs>
         );

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -2028,12 +2028,38 @@ class Exchange extends React.Component {
          */
         let actionCardIndex = 0;
 
+        const buySellTitle = isBid => {
+            return (
+                <div className="exchange-content-header">
+                    <TranslateWithLinks
+                        string="exchange.buysell_formatter"
+                        noLink
+                        noTip
+                        keys={[
+                            {
+                                type: "asset",
+                                value: this.props.quoteAsset.get("symbol"),
+                                arg: "asset"
+                            },
+                            {
+                                type: "translate",
+                                value: isBid ? "exchange.buy" : "exchange.sell",
+                                arg: "direction"
+                            }
+                        ]}
+                    />
+                </div>
+            );
+        };
+
         let buyForm = isFrozen ? null : tinyScreen &&
         !this.state.mobileKey.includes("buySellTab") ? null : (
             <Tabs
                 animated={false}
+                tabBarExtraContent={<div>{buySellTitle(true)}</div>}
                 defaultActiveKey={"scaled"}
                 className={cnames(
+                    "exchange--buy-sell-form",
                     verticalOrderForm && !smallScreen
                         ? ""
                         : centerContainerWidth > 1200
@@ -2079,11 +2105,7 @@ class Exchange extends React.Component {
                             paddingRight: mirrorPanels ? 15 : 5
                         }}
                         type="bid"
-                        hideHeader={
-                            tinyScreen || (!smallScreen && verticalOrderForm)
-                                ? true
-                                : false
-                        }
+                        hideHeader={true}
                         expirationType={expirationType["bid"]}
                         expirations={this.EXPIRATIONS}
                         expirationCustomTime={expirationCustomTime["bid"]}
@@ -2185,8 +2207,10 @@ class Exchange extends React.Component {
         !this.state.mobileKey.includes("buySellTab") ? null : (
             <Tabs
                 animated={false}
+                tabBarExtraContent={<div>{buySellTitle(false)}</div>}
                 defaultActiveKey={"scaled"}
                 className={cnames(
+                    "exchange--buy-sell-form",
                     verticalOrderForm && !smallScreen
                         ? ""
                         : centerContainerWidth > 1200
@@ -2234,11 +2258,7 @@ class Exchange extends React.Component {
                             paddingRight: mirrorPanels ? 15 : 5
                         }}
                         type="ask"
-                        hideHeader={
-                            tinyScreen || (!smallScreen && verticalOrderForm)
-                                ? true
-                                : false
-                        }
+                        hideHeader={true}
                         amount={ask.forSaleText}
                         price={ask.priceText}
                         total={ask.toReceiveText}

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -62,6 +62,43 @@ class ScaledOrderForm extends Component {
         }
     }
 
+    isFormValid() {
+        const formValues = this._getFormValues();
+
+        if (!formValues) return false;
+
+        if (
+            !formValues.priceLower ||
+            isNaN(Number(formValues.priceLower)) ||
+            Number(formValues.priceLower) <= 0
+        )
+            return false;
+
+        if (
+            !formValues.amount ||
+            isNaN(Number(formValues.amount)) ||
+            Number(formValues.amount) <= 0
+        )
+            return false;
+
+        if (
+            !formValues.priceUpper ||
+            isNaN(Number(formValues.priceUpper)) ||
+            Number(formValues.priceUpper) <= 0 ||
+            Number(formValues.priceUpper) <= Number(formValues.priceLower)
+        )
+            return false;
+
+        if (
+            !formValues.orderCount ||
+            isNaN(Number(formValues.orderCount)) ||
+            Number(formValues.orderCount) <= 1
+        )
+            return false;
+
+        return true;
+    }
+
     _getBaseAssetFlags() {
         return assetUtils.getFlagBooleans(
             this.props.baseAsset.getIn(["options", "flags"]),
@@ -717,7 +754,11 @@ class ScaledOrderForm extends Component {
                         </span>
                     </Form.Item>
 
-                    <Button onClick={this.props.handleSubmit} type="primary">
+                    <Button
+                        onClick={this.props.handleSubmit}
+                        type="primary"
+                        disabled={!this.isFormValid()}
+                    >
                         {counterpart.translate(
                             isBid
                                 ? "scaled_orders.action.buy"

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -1,0 +1,9 @@
+import React, {Component} from "react";
+
+class ScaledOrderTab extends Component {
+    render() {
+        return <div>Scaled Order</div>;
+    }
+}
+
+export default ScaledOrderTab;

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -457,13 +457,21 @@ class ScaledOrderForm extends Component {
             />
         );
 
+        const formValues = this._getFormValues();
+
+        const priceLower = Number((formValues && formValues.priceLower) || 0);
+
         const priceUpperInput = getFieldDecorator("priceUpper", {
             validateFirst: true,
             validateTrigger: "onBlur",
             rules: [
                 Validation.Rules.required(),
                 Validation.Rules.number(),
-                Validation.Rules.min({min: 0, name: "Price", higherThan: true})
+                Validation.Rules.min({
+                    min: priceLower,
+                    name: "Price",
+                    higherThan: true
+                })
             ]
         })(
             <Input

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -1,6 +1,5 @@
 import React, {Component} from "react";
 import TranslateWithLinks from "../Utility/TranslateWithLinks";
-import Translate from "react-translate-component";
 import {
     Input,
     Form,

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -292,6 +292,7 @@ class ScaledOrderForm extends Component {
             !isCorrect(priceUpper) ||
             !isCorrect(amount) ||
             !isCorrect(orderCount) ||
+            orderCount <= 1 ||
             orderCount <= 0 ||
             priceLower >= priceUpper
         )
@@ -626,7 +627,11 @@ class ScaledOrderForm extends Component {
             rules: [
                 Validation.Rules.required(),
                 Validation.Rules.number(),
-                Validation.Rules.min({min: 1, name: "Orders Count"})
+                Validation.Rules.min({
+                    min: 1,
+                    name: "Orders Count",
+                    higherThan: true
+                })
             ]
         })(
             <Input

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -1,8 +1,766 @@
 import React, {Component} from "react";
+import TranslateWithLinks from "../Utility/TranslateWithLinks";
+import Translate from "react-translate-component";
+import {
+    Input,
+    Form,
+    Select,
+    Button,
+    Col,
+    Row,
+    Radio
+} from "bitshares-ui-style-guide";
+import AssetNameWrapper from "../Utility/AssetName";
+import {SCALED_ORDER_ACTION_TYPES} from "../../services/Exchange";
+import {Asset} from "../../lib/common/MarketClasses";
+import ChainStore from "bitsharesjs/es/chain/src/ChainStore";
+import counterpart from "counterpart";
+import {Validation} from "../../services/Validation/Validation";
+import assetUtils from "../../lib/common/asset_utils";
+import {checkFeeStatusAsync} from "../../lib/common/trxHelper";
+
+class ScaledOrderForm extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            orderCount: 1,
+            feeAssets: []
+        };
+    }
+
+    componentDidMount() {
+        this._checkFeeAssets();
+    }
+
+    componentDidUpdate() {
+        const orderCount = Number(this._getFormValues().orderCount || 1);
+        const stateOrderCount = Number(this.state.orderCount);
+
+        if (
+            !isNaN(stateOrderCount) &&
+            !isNaN(orderCount) &&
+            Number(this.state.orderCount) !== orderCount
+        ) {
+            this.setState(
+                {
+                    orderCount: orderCount
+                },
+                () => {
+                    this._checkFeeAssets();
+                }
+            );
+        }
+    }
+
+    _getBaseAssetFlags() {
+        return assetUtils.getFlagBooleans(
+            this.props.baseAsset.getIn(["options", "flags"]),
+            this.props.baseAsset.has("bitasset_data_id")
+        );
+    }
+
+    _getQuoteAssetFlags() {
+        return assetUtils.getFlagBooleans(
+            this.props.quoteAsset.getIn(["options", "flags"]),
+            this.props.quoteAsset.has("bitasset_data_id")
+        );
+    }
+
+    _isMarketFeeVisible() {
+        const baseAssetFlagBooleans = this._getBaseAssetFlags();
+
+        const quoteAssetFlagBooleans = this._getQuoteAssetFlags();
+
+        if (
+            this._getFormValues().action === SCALED_ORDER_ACTION_TYPES.SELL &&
+            baseAssetFlagBooleans.charge_market_fee
+        ) {
+            return true;
+        }
+
+        if (
+            this._getFormValues().action === SCALED_ORDER_ACTION_TYPES.BUY &&
+            quoteAssetFlagBooleans.charge_market_fee
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    _getFormValues() {
+        return this.props.form.getFieldsValue();
+    }
+
+    _filterFeeStatuses(feeStatuses) {
+        return feeStatuses
+            .filter(feeStatus => {
+                return (
+                    feeStatus &&
+                    feeStatus.hasPoolBalance &&
+                    feeStatus.hasBalance
+                );
+            })
+            .map(feeStatus => {
+                return {
+                    fee: feeStatus,
+                    amount:
+                        feeStatus.fee.getAmount() /
+                        Math.pow(10, feeStatus.fee.precision),
+                    asset: ChainStore.getAsset(feeStatus.fee.asset_id)
+                };
+            });
+    }
+
+    _checkFeeAssets() {
+        // get account balances, check is each balance available to pay fee
+        // for limit_order, filter only available assets and put it to local state
+
+        this._getAccountAssetsFeeStatus().then(feeStatuses => {
+            let assets = this._filterFeeStatuses(feeStatuses);
+
+            this.setState({
+                feeAssets: assets
+            });
+        });
+    }
+
+    _getAccountAssetsFeeStatus() {
+        const {currentAccount} = this.props;
+
+        const {orderCount} = this._getFormValues();
+
+        if (
+            !currentAccount ||
+            !currentAccount.get ||
+            !currentAccount.get("balances")
+        ) {
+            return false;
+        }
+
+        return new Promise(resolve => {
+            let promises = [];
+
+            currentAccount.get("balances").forEach(balance => {
+                let balanceObj = ChainStore.getObject(balance);
+
+                let promise = checkFeeStatusAsync({
+                    accountID: currentAccount.get("id"),
+                    feeID: balanceObj.get("asset_type"),
+                    type: "limit_order_create",
+                    operationsCount: orderCount
+                });
+
+                promises.push(promise);
+            });
+
+            Promise.all(promises).then(feesStatuses => {
+                resolve(feesStatuses);
+            });
+        });
+    }
+
+    _getFee() {
+        const formValues = this._getFormValues();
+
+        let amount = 0;
+
+        if (formValues && formValues.feeCurrency) {
+            this.state.feeAssets.forEach(feeAsset => {
+                if (
+                    feeAsset &&
+                    feeAsset.asset &&
+                    feeAsset.asset.get("symbol") === formValues.feeCurrency
+                ) {
+                    amount = feeAsset.amount;
+                }
+            });
+        }
+
+        return amount;
+    }
+
+    _getMarketFee() {
+        const formValues = this._getFormValues();
+
+        const base = this.props.baseAsset;
+        const quote = this.props.quoteAsset;
+
+        const quantity = Number(this._getTotal());
+        const action = formValues.action;
+
+        if (isNaN(quantity)) return null;
+
+        let asset = null;
+
+        if (action === SCALED_ORDER_ACTION_TYPES.SELL) asset = base;
+
+        if (action === SCALED_ORDER_ACTION_TYPES.BUY) asset = quote;
+
+        if (!asset || !asset.get || !asset.getIn) return null;
+
+        const maxMarketFee = new Asset({
+            amount: asset.getIn(["options", "max_market_fee"]),
+            asset_id: asset.get("asset_id"),
+            precision: asset.get("precision")
+        });
+
+        const marketFeePercent = this._getMarketFeePercentage();
+
+        return !quantity
+            ? 0
+            : Math.min(
+                  maxMarketFee.getAmount({real: true}),
+                  (quantity / 100) * marketFeePercent
+              ).toFixed(maxMarketFee.precision);
+    }
+
+    _getMarketFeePercentage() {
+        const {action} = this._getFormValues();
+
+        const base = this.props.baseAsset;
+        const quote = this.props.quoteAsset;
+
+        let asset = null;
+
+        if (action === SCALED_ORDER_ACTION_TYPES.SELL) asset = base;
+
+        if (action === SCALED_ORDER_ACTION_TYPES.BUY) asset = quote;
+
+        return Number(asset.getIn(["options", "market_fee_percent"]) / 100);
+    }
+
+    _getTotal() {
+        const formValues = this._getFormValues();
+
+        const amount = Number(formValues.amount);
+        const priceLower = Number(formValues.priceLower);
+        const priceUpper = Number(formValues.priceUpper);
+        const orderCount = Number(formValues.orderCount);
+
+        const isCorrect = value => !isNaN(value);
+
+        if (
+            !isCorrect(priceLower) ||
+            !isCorrect(priceUpper) ||
+            !isCorrect(amount) ||
+            !isCorrect(orderCount) ||
+            orderCount <= 0 ||
+            priceLower >= priceUpper
+        )
+            return 0;
+
+        const step = ((priceUpper - priceLower) / (orderCount - 1)).toFixed(6);
+
+        const amountPerOrder = amount / orderCount;
+
+        let total = 0;
+
+        for (let i = 0; i < orderCount; i += 1) {
+            total += Number(
+                (amountPerOrder * (priceLower + step * i)).toFixed(6)
+            );
+        }
+
+        return total.toFixed(6);
+    }
+
+    _getPreviewDataSource() {
+        const formValues = this._getFormValues();
+
+        const dataSource = [];
+
+        const action = formValues.action;
+        const amount = Number(formValues.amount);
+        const priceLower = Number(formValues.priceLower);
+        const priceUpper = Number(formValues.priceUpper);
+        const orderCount = Number(formValues.orderCount);
+
+        const isCorrect = value => !isNaN(value);
+
+        if (
+            !isCorrect(priceLower) ||
+            !isCorrect(priceUpper) ||
+            !isCorrect(amount) ||
+            !isCorrect(orderCount) ||
+            orderCount <= 0 ||
+            priceLower >= priceUpper
+        )
+            return [];
+
+        const step = ((priceUpper - priceLower) / (orderCount - 1)).toFixed(6);
+
+        const amountPerOrder = amount / orderCount;
+
+        for (let i = 0; i < orderCount; i += 1) {
+            dataSource.push({
+                quote: amountPerOrder.toFixed(6),
+                base: (amountPerOrder * (priceLower + step * i)).toFixed(6),
+                price: (priceLower + step * i).toFixed(6)
+            });
+        }
+
+        return action === SCALED_ORDER_ACTION_TYPES.BUY
+            ? dataSource.reverse()
+            : dataSource;
+    }
+
+    render() {
+        const {type, quoteAsset, baseAsset, currentAccount} = this.props;
+
+        const isBid = type === "bid";
+
+        const quote = quoteAsset;
+        const base = baseAsset;
+
+        const {getFieldDecorator} = this.props.form;
+
+        const marketFeeSymbol = (
+            <AssetNameWrapper name={this.props.baseAsset.get("symbol")} />
+        );
+
+        const quantitySymbol = (
+            <AssetNameWrapper name={this.props.quoteAsset.get("symbol")} />
+        );
+
+        const totalSymbol = (
+            <AssetNameWrapper name={this.props.baseAsset.get("symbol")} />
+        );
+
+        const priceSymbol = (
+            <div
+                style={{
+                    maxWidth: "110px",
+                    display: "block",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis"
+                }}
+            >
+                <AssetNameWrapper name={this.props.baseAsset.get("symbol")} />/
+                <AssetNameWrapper name={this.props.quoteAsset.get("symbol")} />
+            </div>
+        );
+
+        const formItemProps = {
+            labelCol: {span: 6},
+            wrapperCol: {span: 18}
+        };
+
+        const actionRadio = getFieldDecorator("action", {
+            initialValue: isBid
+                ? SCALED_ORDER_ACTION_TYPES.BUY
+                : SCALED_ORDER_ACTION_TYPES.SELL
+        })(
+            <Radio.Group>
+                <Radio value={SCALED_ORDER_ACTION_TYPES.BUY}>
+                    {counterpart.translate("scaled_orders.action.buy")}
+                </Radio>
+                <Radio value={SCALED_ORDER_ACTION_TYPES.SELL}>
+                    {counterpart.translate("scaled_orders.action.sell")}
+                </Radio>
+            </Radio.Group>
+        );
+
+        const priceLowerInput = getFieldDecorator("priceLower", {
+            validateFirst: true,
+            validateTrigger: "onBlur",
+            rules: [
+                Validation.Rules.required(),
+                Validation.Rules.number(),
+                Validation.Rules.min({min: 0, name: "Price", higherThan: true})
+            ]
+        })(
+            <Input
+                placeholder="0.0"
+                style={{width: "100%"}}
+                autoComplete="off"
+                addonAfter={priceSymbol}
+            />
+        );
+
+        const priceUpperInput = getFieldDecorator("priceUpper", {
+            validateFirst: true,
+            validateTrigger: "onBlur",
+            rules: [
+                Validation.Rules.required(),
+                Validation.Rules.number(),
+                Validation.Rules.min({min: 0, name: "Price", higherThan: true})
+            ]
+        })(
+            <Input
+                placeholder="0.0"
+                style={{width: "100%"}}
+                autoComplete="off"
+                addonAfter={priceSymbol}
+            />
+        );
+
+        const feeCurrencySelect = getFieldDecorator("feeCurrency", {
+            initialValue:
+                ChainStore.getAsset("1.3.0") &&
+                ChainStore.getAsset("1.3.0").get &&
+                ChainStore.getAsset("1.3.0").get("symbol")
+        })(
+            <Select
+                showSearch
+                dropdownMatchSelectWidth={false}
+                style={{minWidth: "80px", maxWidth: "120px"}}
+            >
+                {this.state.feeAssets &&
+                    this.state.feeAssets.map &&
+                    this.state.feeAssets.map(feeAsset => {
+                        return (
+                            <Select.Option
+                                key={feeAsset.asset.get("symbol")}
+                                value={`${feeAsset.asset.get("symbol")}`}
+                            >
+                                <AssetNameWrapper
+                                    name={feeAsset.asset.get("symbol")}
+                                    noTip={true}
+                                />
+                            </Select.Option>
+                        );
+                    })}
+            </Select>
+        );
+
+        const feeInput = (
+            <Input
+                disabled
+                placeholder="0.0"
+                style={{width: "100%"}}
+                autoComplete="off"
+                addonAfter={feeCurrencySelect}
+                value={this._getFee()}
+            />
+        );
+
+        const marketFeeInput = (
+            <Input
+                disabled
+                style={{width: "100%"}}
+                autoComplete="off"
+                addonAfter={marketFeeSymbol}
+                value={this._getMarketFee()}
+            />
+        );
+
+        const totalInput = (
+            <Input
+                disabled
+                style={{width: "100%"}}
+                autoComplete="off"
+                addonAfter={totalSymbol}
+                value={this._getTotal()}
+            />
+        );
+
+        const totalInputValidation = Validation.Rules.balance({
+            balance: this.props.baseAssetBalance,
+            symbol: this.props.baseAsset.get("symbol")
+        });
+
+        const totalInputValidator = totalInputValidation.validator(
+            null,
+            this._getTotal(),
+            a => a === undefined
+        );
+        const totalInputHelp =
+            isBid && !totalInputValidator ? totalInputValidation.message : null;
+        const totalInputStatus = isBid && !totalInputValidator ? "error" : "";
+
+        const quantityRules = [
+            Validation.Rules.required(),
+            Validation.Rules.number(),
+            Validation.Rules.min({min: 0, higherThan: true, name: "Quantity"})
+        ];
+
+        if (!isBid) {
+            quantityRules.push(
+                Validation.Rules.balance({
+                    balance: this.props.quoteAssetBalance,
+                    symbol: this.props.quoteAsset.get("symbol")
+                })
+            );
+        }
+
+        const quantityInput = getFieldDecorator("amount", {
+            validateFirst: true,
+            validateTrigger: "onBlur",
+            rules: quantityRules
+        })(
+            <Input
+                placeholder="0.0"
+                style={{width: "100%"}}
+                autoComplete="off"
+                addonAfter={quantitySymbol}
+            />
+        );
+
+        const orderCountInput = getFieldDecorator("orderCount", {
+            validateFirst: true,
+            rules: [
+                Validation.Rules.required(),
+                Validation.Rules.number(),
+                Validation.Rules.min({min: 1, name: "Orders Count"})
+            ]
+        })(
+            <Input style={{width: "100%"}} placeholder="0" autoComplete="off" />
+        );
+
+        return (
+            <div className="buy-sell-container" style={{padding: "5px"}}>
+                <div className="exchange-content-header exchange-content-header--buy-sell-form">
+                    <span>
+                        <TranslateWithLinks
+                            string="exchange.buysell_formatter"
+                            noLink
+                            noTip
+                            keys={[
+                                {
+                                    type: "asset",
+                                    value: quote.get("symbol"),
+                                    arg: "asset"
+                                },
+                                {
+                                    type: "translate",
+                                    value: isBid
+                                        ? "exchange.buy"
+                                        : "exchange.sell",
+                                    arg: "direction"
+                                }
+                            ]}
+                        />
+                    </span>
+                </div>
+
+                <Form
+                    className="order-form"
+                    layout="horizontal"
+                    hideRequiredMark={true}
+                    style={{padding: "8px 15px"}}
+                >
+                    <Form.Item
+                        {...formItemProps}
+                        label={counterpart.translate(
+                            "scaled_orders.price_lower"
+                        )}
+                    >
+                        {priceLowerInput}
+                    </Form.Item>
+
+                    <Form.Item
+                        {...formItemProps}
+                        label={counterpart.translate(
+                            "scaled_orders.price_upper"
+                        )}
+                    >
+                        {priceUpperInput}
+                    </Form.Item>
+
+                    <Form.Item
+                        {...formItemProps}
+                        label={counterpart.translate("scaled_orders.quantity")}
+                    >
+                        {quantityInput}
+                    </Form.Item>
+
+                    <Form.Item
+                        {...formItemProps}
+                        label={counterpart.translate(
+                            "scaled_orders.order_count"
+                        )}
+                    >
+                        {orderCountInput}
+                    </Form.Item>
+
+                    <Form.Item
+                        {...formItemProps}
+                        help={totalInputHelp}
+                        validateStatus={totalInputStatus}
+                        label={counterpart.translate("scaled_orders.total")}
+                    >
+                        {totalInput}
+                    </Form.Item>
+
+                    <Form.Item
+                        {...formItemProps}
+                        label={counterpart.translate("scaled_orders.fee")}
+                    >
+                        {feeInput}
+                    </Form.Item>
+
+                    {this._isMarketFeeVisible() ? (
+                        <Form.Item
+                            {...formItemProps}
+                            label={`${counterpart.translate(
+                                "scaled_orders.market_fee"
+                            )} ${this._getMarketFeePercentage()}%`}
+                        >
+                            {marketFeeInput}
+                        </Form.Item>
+                    ) : null}
+
+                    <Button onClick={this.props.handleSubmit}>BUY</Button>
+                </Form>
+            </div>
+        );
+    }
+}
+
+ScaledOrderForm = Form.create({})(ScaledOrderForm);
 
 class ScaledOrderTab extends Component {
+    constructor(props) {
+        super(props);
+
+        this.saveFormRef = this.saveFormRef.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleCancel = this.handleCancel.bind(this);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (
+            this.props.baseAsset &&
+            prevProps.baseAsset &&
+            this.props.baseAsset.get &&
+            prevProps.baseAsset.get &&
+            this.props.baseAsset.get("id") !== prevProps.baseAsset.get("id") &&
+            this.formRef &&
+            this.formRef.props &&
+            this.formRef.props.form
+        ) {
+            this.formRef.props.form.resetFields();
+        }
+    }
+
+    prepareOrders(values) {
+        const orders = [];
+
+        const amount = Number(values.amount);
+        const priceLower = Number(values.priceLower);
+        const priceUpper = Number(values.priceUpper);
+        const orderCount = Number(values.orderCount);
+
+        const isCorrect = value => !isNaN(value);
+
+        if (
+            !isCorrect(priceLower) ||
+            !isCorrect(priceUpper) ||
+            !isCorrect(amount) ||
+            !isCorrect(orderCount) ||
+            orderCount <= 0 ||
+            priceLower >= priceUpper
+        )
+            return [];
+
+        const step = ((priceUpper - priceLower) / (orderCount - 1)).toFixed(6);
+
+        const amountPerOrder = amount / orderCount;
+
+        const sellAsset =
+            values.action === SCALED_ORDER_ACTION_TYPES.SELL
+                ? this.props.quoteAsset
+                : this.props.baseAsset;
+        const buyAsset =
+            values.action === SCALED_ORDER_ACTION_TYPES.BUY
+                ? this.props.quoteAsset
+                : this.props.baseAsset;
+
+        const sellAmount = i =>
+            values.action === SCALED_ORDER_ACTION_TYPES.BUY
+                ? Number(
+                      (amountPerOrder * (priceLower + step * i)).toFixed(6)
+                  ) * Math.pow(10, sellAsset.get("precision"))
+                : Number(amountPerOrder.toFixed(6)) *
+                  Math.pow(10, sellAsset.get("precision"));
+
+        const buyAmount = i =>
+            values.action === SCALED_ORDER_ACTION_TYPES.SELL
+                ? Number(
+                      (amountPerOrder * (priceLower + step * i)).toFixed(6)
+                  ) * Math.pow(10, buyAsset.get("precision"))
+                : Number(amountPerOrder.toFixed(6)) *
+                  Math.pow(10, buyAsset.get("precision"));
+
+        for (let i = 0; i < orderCount; i += 1) {
+            orders.push({
+                for_sale: new Asset({
+                    asset_id: sellAsset.get("id"),
+                    precision: sellAsset.get("precision"),
+                    amount: sellAmount(i)
+                }),
+
+                to_receive: new Asset({
+                    asset_id: buyAsset.get("id"),
+                    precision: buyAsset.get("precision"),
+                    amount: buyAmount(i)
+                }),
+
+                expirationTime: new Date().getTime() + 60 * 60 * 1000
+            });
+        }
+
+        this.props.createScaledOrder(
+            orders,
+            ChainStore.getAsset(values.feeCurrency).get("id")
+        );
+
+        this.props.hideModal();
+    }
+
+    handleSubmit() {
+        const form = this.formRef.props.form;
+
+        form.validateFields((err, values) => {
+            if (err) return;
+
+            this.prepareOrders(values);
+        });
+    }
+
+    handleCancel() {
+        this.props.hideModal();
+    }
+
+    saveFormRef(ref) {
+        this.formRef = ref;
+    }
+
+    _getBalanceByAssetId(assetId) {
+        let balance = 0;
+
+        let balances = this.props.currentAccount.get("balances");
+
+        if (balances.get(assetId) !== undefined) {
+            let balanceObj = ChainStore.getObject(balances.get(assetId));
+
+            balance =
+                balanceObj.get("balance") /
+                Math.pow(10, this.props.baseAsset.get("precision"));
+        }
+
+        return balance;
+    }
+
     render() {
-        return <div>Scaled Order</div>;
+        let baseAssetBalance = this._getBalanceByAssetId(
+            this.props.baseAsset.get("id")
+        );
+        let quoteAssetBalance = this._getBalanceByAssetId(
+            this.props.quoteAsset.get("id")
+        );
+
+        return (
+            <ScaledOrderForm
+                {...this.props}
+                wrappedComponentRef={this.saveFormRef}
+                baseAssetBalance={baseAssetBalance}
+                quoteAssetBalance={quoteAssetBalance}
+                handleSubmit={this.handleSubmit}
+            />
+        );
     }
 }
 

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -598,30 +598,6 @@ class ScaledOrderForm extends Component {
 
         return (
             <div className="buy-sell-container" style={{padding: "5px"}}>
-                <div className="exchange-content-header exchange-content-header--buy-sell-form">
-                    <span>
-                        <TranslateWithLinks
-                            string="exchange.buysell_formatter"
-                            noLink
-                            noTip
-                            keys={[
-                                {
-                                    type: "asset",
-                                    value: quote.get("symbol"),
-                                    arg: "asset"
-                                },
-                                {
-                                    type: "translate",
-                                    value: isBid
-                                        ? "exchange.buy"
-                                        : "exchange.sell",
-                                    arg: "direction"
-                                }
-                            ]}
-                        />
-                    </span>
-                </div>
-
                 <Form
                     className="order-form"
                     layout="horizontal"
@@ -859,8 +835,6 @@ class ScaledOrderTab extends Component {
             orders,
             ChainStore.getAsset(values.feeCurrency).get("id")
         );
-
-        this.props.hideModal();
     }
 
     handleSubmit() {

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -734,7 +734,13 @@ class ScaledOrderForm extends Component {
                         </span>
                     </Form.Item>
 
-                    <Button onClick={this.props.handleSubmit}>BUY</Button>
+                    <Button onClick={this.props.handleSubmit} type="primary">
+                        {counterpart.translate(
+                            isBid
+                                ? "scaled_orders.action.buy"
+                                : "scaled_orders.action.sell"
+                        )}
+                    </Button>
                 </Form>
             </div>
         );

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -436,7 +436,7 @@ class ScaledOrderForm extends Component {
         const {getFieldDecorator} = this.props.form;
 
         const marketFeeSymbol = (
-            <AssetNameWrapper name={this.props.baseAsset.get("symbol")} />
+            <AssetNameWrapper name={this.props.quoteAsset.get("symbol")} />
         );
 
         const quantitySymbol = (

--- a/app/components/Exchange/ScaledOrderTab.jsx
+++ b/app/components/Exchange/ScaledOrderTab.jsx
@@ -633,6 +633,22 @@ class ScaledOrderTab extends Component {
         ) {
             this.formRef.props.form.resetFields();
         }
+
+        if (
+            this.props.lastClickedPrice &&
+            this.props.lastClickedPrice !== prevProps.lastClickedPrice
+        ) {
+            if (
+                this.formRef &&
+                this.formRef.props &&
+                this.formRef.props.form &&
+                this.formRef.props.form.setFieldsValue
+            ) {
+                this.formRef.props.form.setFieldsValue({
+                    priceLower: Number(this.props.lastClickedPrice)
+                });
+            }
+        }
     }
 
     prepareOrders(values) {

--- a/app/services/Math.js
+++ b/app/services/Math.js
@@ -1,0 +1,15 @@
+const preciseOperation = f => (a, b, decimalDigits = 6) =>
+    +f(a, b).toFixed(decimalDigits);
+
+const add = (a, b) => a + b;
+const minus = (a, b) => a - b;
+const multiply = (a, b) => a * b;
+const divide = (a, b) => a / b;
+export const preciseAdd = (a, b, decimalDigits) =>
+    preciseOperation(add)(a, b, decimalDigits);
+export const preciseMinus = (a, b, decimalDigits) =>
+    preciseOperation(minus)(a, b, decimalDigits);
+export const preciseMultiply = (a, b, decimalDigits) =>
+    preciseOperation(multiply)(a, b, decimalDigits);
+export const preciseDivide = (a, b, decimalDigits) =>
+    preciseOperation(divide)(a, b, decimalDigits);

--- a/app/services/Validation/Validation.js
+++ b/app/services/Validation/Validation.js
@@ -107,9 +107,10 @@ export const Messages = {
         return counterpart.translate(`validation.messages.oneOf`, {list: list});
     },
 
-    Balance: balance => {
+    Balance: (balance, symbol) => {
         return counterpart.translate(`validation.messages.balance`, {
-            balance: balance
+            balance: balance,
+            symbol: symbol
         });
     }
 };
@@ -235,6 +236,7 @@ export const Rules = {
      * @param {Object} props
      * @param {number} props.min
      * @param {string} [props.name]
+     * @param {boolean} props.higherThan - if (true) then check will be "value > min" instead of "value >= min"
      * @returns {{validator: validator, message: *}}
      */
 
@@ -257,7 +259,11 @@ export const Rules = {
             validator: (rule, value, callback) => {
                 value = Number(value);
 
-                if (isNaN(value) || value < min) return callback(false);
+                if (props && props.higherThan) {
+                    if (isNaN(value) || value <= min) return callback(false);
+                } else {
+                    if (isNaN(value) || value < min) return callback(false);
+                }
 
                 return callback();
             },
@@ -431,7 +437,7 @@ export const Rules = {
 
         return {
             validator: validation.validator,
-            message: Messages.Balance(props.balance)
+            message: Messages.Balance(props.balance, props.symbol)
         };
     }
 };


### PR DESCRIPTION
<h2>General</h2>
Closes #2497 

I've removed Scaled Orders modal, added "tabs" for Buy/Sell blocks. Now we have "Limit" and "Scaled" tabs. 

<h2>General</h2>

How it looks:
<img width="945" alt="Screenshot 2019-03-22 01 59 13" src="https://user-images.githubusercontent.com/35899973/54794114-19748880-4c46-11e9-9d6f-5d0ef95be5a0.png">


<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [x] Opera
- [x] Firefox
- [ ] Safari