### PR TITLE
Issue 2317 - Multiple order cancelation on Exchange

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -489,6 +489,7 @@
         "buy_min": "Buy at least",
         "buy_sell": "Order Form",
         "buysell_formatter": "{direction} {asset}",
+        "cancel_selected_orders": "Cancel selected order(s)",
         "call": "Call Price",
         "change": "Change",
         "chart_height": "Chart height (pixels)",

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -122,7 +122,7 @@ div#CenterContent {
     > thead > tr > th {
         font-size: 14px;
         padding: 5px 5px;
-        text-align: right !important;
+        text-align: right;
     }
 
     > tbody > tr > td {

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -63,11 +63,18 @@ class TableHeader extends React.Component {
                         />
                     </th>
                     <th style={{width: "6%", textAlign: "center"}}>
-                        <input 
-                            type="checkbox" 
-                            className="order-cancel-toggle"
-                            onChange={this.props.onCancelToggle}
-                        />
+                        <Tooltip
+                            title={counterpart.translate(
+                                "exchange.cancel_selected_orders"
+                            )}
+                            placement="left"
+                        >
+                            <input
+                                type="checkbox"
+                                className="order-cancel-toggle"
+                                onChange={this.props.onCancelToggle}
+                            />
+                        </Tooltip>
                     </th>
                 </tr>
             </thead>
@@ -184,22 +191,29 @@ class OrderRow extends React.Component {
                             {isCall
                                 ? null
                                 : counterpart.localize(
-                                    new Date(order.expiration),
-                                    {
-                                        type: "date",
-                                        format: "short_custom"
-                                    }
-                                )}
+                                      new Date(order.expiration),
+                                      {
+                                          type: "date",
+                                          format: "short_custom"
+                                      }
+                                  )}
                         </div>
                     </Tooltip>
                 </td>
                 <td className="text-center" style={{width: "6%"}}>
                     {isCall ? null : (
-                        <input 
-                            type="checkbox"
-                            className="orderCancel"
-                            onChange={this.props.onCheckCancel}
-                        />
+                        <Tooltip
+                            title={counterpart.translate(
+                                "exchange.cancel_selected_orders"
+                            )}
+                            placement="left"
+                        >
+                            <input
+                                type="checkbox"
+                                className="orderCancel"
+                                onChange={this.props.onCheckCancel}
+                            />
+                        </Tooltip>
                     )}
                 </td>
             </tr>
@@ -476,7 +490,7 @@ class MyOpenOrders extends React.Component {
             selectedOrders.push(order.id);
         });
 
-        if(evt.target.checked) {
+        if (evt.target.checked) {
             this.setState({selectedOrders: selectedOrders});
         } else {
             this.setState({selectedOrders: []});
@@ -648,7 +662,10 @@ class MyOpenOrders extends React.Component {
                             base={base}
                             quote={quote}
                             onCancel={this.props.onCancel.bind(this, order.id)}
-                            onCheckCancel={this.onCheckCancel.bind(this, order.id)}
+                            onCheckCancel={this.onCheckCancel.bind(
+                                this,
+                                order.id
+                            )}
                         />
                     );
                 });
@@ -670,7 +687,10 @@ class MyOpenOrders extends React.Component {
                             base={base}
                             quote={quote}
                             onCancel={this.props.onCancel.bind(this, order.id)}
-                            onCheckCancel={this.onCheckCancel.bind(this, order.id)}
+                            onCheckCancel={this.onCheckCancel.bind(
+                                this,
+                                order.id
+                            )}
                         />
                     );
                 });
@@ -704,14 +724,13 @@ class MyOpenOrders extends React.Component {
                 </TransitionWrapper>
             );
 
-            var cancelOrderButton = 
+            var cancelOrderButton = (
                 <div style={{display: "grid"}}>
-                    <Button
-                        onClick={this.cancelSelected.bind(this)}
-                    >
+                    <Button onClick={this.cancelSelected.bind(this)}>
                         <Translate content="exchange.cancel_selected_orders" />
                     </Button>
-                </div>;
+                </div>
+            );
 
             footerContainer =
                 rowsLength > 11 ? (
@@ -727,11 +746,12 @@ class MyOpenOrders extends React.Component {
                                     rowcount={rowsLength}
                                 />
                             </a>
-                            
                         </div>
                         {selectedOrders.length > 0 ? cancelOrderButton : null}
                     </React.Fragment>
-                ) : (selectedOrders.length > 0 ? cancelOrderButton : null);
+                ) : selectedOrders.length > 0 ? (
+                    cancelOrderButton
+                ) : null;
         }
 
         {
@@ -804,7 +824,9 @@ class MyOpenOrders extends React.Component {
                                     type="sell"
                                     baseSymbol={baseSymbol}
                                     quoteSymbol={quoteSymbol}
-                                    onCancelToggle={this.onCancelToggle.bind(this)}
+                                    onCancelToggle={this.onCancelToggle.bind(
+                                        this
+                                    )}
                                 />
                             ) : (
                                 <thead>


### PR DESCRIPTION
<h2>General</h2>
Closes #2317 


The following feature will enable the same feature on exchange as available in "Open Orders" today.
Each row has a checkbox that can be selected. It's also possible to use the "global" checkbox to toggle/un-toggle all checkboxes. Once at least one checkbox is checked, the cancel button is visible. This is today limited to one OP per order that you wish to cancel.

![image](https://user-images.githubusercontent.com/12114550/55688043-6362ab80-5974-11e9-84ef-6ab19d981169.png)

