### PR TITLE
Issue 2570 - Cumulative Debt Column

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1990,6 +1990,7 @@
         "bond_create_offer": "Created bond offer",
         "bond_pay_collateral": "Paid collateral of",
         "borrow_amount": "Debt",
+        "cumulative_borrow_amount": "Cumulative Debt",
         "borrower": "Borrower",
         "broadcast_fail": "Failed to broadcast the transaction: %(message)s",
         "broadcast_success": "Transaction has been broadcast",

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1568,7 +1568,7 @@ class Asset extends React.Component {
                             )}
                             {sortedCollateralBids.length && ")"}
                         </th>
-                        <th>
+                        <th className="column-hide-small">
                             <Translate content="transaction.cumulative_borrow_amount" />
                             {sortedCollateralBids.length && " ("}
                             {sortedCollateralBids.length && (

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1568,6 +1568,21 @@ class Asset extends React.Component {
                             )}
                             {sortedCollateralBids.length && ")"}
                         </th>
+                        <th>
+                            <Translate content="transaction.cumulative_borrow_amount" />
+                            {sortedCollateralBids.length && " ("}
+                            {sortedCollateralBids.length && (
+                                <FormattedAsset
+                                    amount={1}
+                                    asset={
+                                        sortedCollateralBids[0].bid.quote
+                                            .asset_id
+                                    }
+                                    hide_amount
+                                />
+                            )}
+                            {sortedCollateralBids.length && ")"}
+                        </th>
                         <th
                             style={{textAlign: "right"}}
                             className="clickable column-hide-small"
@@ -1609,6 +1624,7 @@ class Asset extends React.Component {
                 </thead>
             );
 
+            let cumulativeDebt = 0;
             secondRows = sortedCollateralBids.map(c => {
                 let included = "no";
                 if (!!c.consideredIfRevived) {
@@ -1620,6 +1636,9 @@ class Asset extends React.Component {
                         included = "no";
                     }
                 }
+
+                cumulativeDebt += c.debt;
+
                 return (
                     <tr className="margin-row" key={c.id}>
                         <td>
@@ -1638,6 +1657,16 @@ class Asset extends React.Component {
                         <td style={{textAlign: "right"}} className="">
                             <FormattedAsset
                                 amount={c.bid.quote.amount}
+                                asset={c.bid.quote.asset_id}
+                                hide_asset
+                            />
+                        </td>
+                        <td
+                            style={{textAlign: "right"}}
+                            className="column-hide-small"
+                        >
+                            <FormattedAsset
+                                amount={cumulativeDebt}
                                 asset={c.bid.quote.asset_id}
                                 hide_asset
                             />


### PR DESCRIPTION
<h2>General</h2>
Closes #2570

- Add cumulative debt column to Collatoral Bids table 

- Add required translations for new column

- Add debt summation logic

<img width="1185" alt="Screen Shot 2019-04-09 at 11 02 07 AM" src="https://user-images.githubusercontent.com/13334179/55806628-058aac80-5ab7-11e9-98a5-4909e8d5b9ac.png">
