### PR TITLE
#504. Add icon for external links

### DIFF
--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -467,13 +467,3 @@ section progress {
 ul > li {
     transition: background-color 0.3s ease 0s;
 }
-
-.external-link:after {
-    content: "";
-    margin-left: 5px;
-    background: url("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg' fill='rgb(224, 224, 224)' width='32' height='32' viewBox='0 0 32 32'><path d='M8 20s1.838-6 12-6v6l12-8-12-8v6c-8 0-12 4.99-12 10zm14 4H4V12h3.934c.315-.372.654-.729 1.015-1.068 1.374-1.287 3.018-2.27 4.879-2.932H.001v20h26v-8.395l-4 2.667V24z'></path></svg>") no-repeat left 2px;
-    background-size: 16px 16px;
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-}

--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -467,3 +467,13 @@ section progress {
 ul > li {
     transition: background-color 0.3s ease 0s;
 }
+
+.external-link:after {
+    content: "";
+    margin-left: 5px;
+    background: url("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg' fill='rgb(224, 224, 224)' width='32' height='32' viewBox='0 0 32 32'><path d='M8 20s1.838-6 12-6v6l12-8-12-8v6c-8 0-12 4.99-12 10zm14 4H4V12h3.934c.315-.372.654-.729 1.015-1.068 1.374-1.287 3.018-2.27 4.879-2.932H.001v20h26v-8.395l-4 2.667V24z'></path></svg>") no-repeat left 2px;
+    background-size: 16px 16px;
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+}

--- a/app/assets/stylesheets/layout/_page_layout.scss
+++ b/app/assets/stylesheets/layout/_page_layout.scss
@@ -111,3 +111,13 @@ div.bordered-header {
 .grid-content.app-tables > .content-block {
     margin-bottom: 0 !important;
 }
+
+.external-link:after {
+    content: "";
+    margin-left: 5px;
+    background: url("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg' fill='rgb(224, 224, 224)' width='32' height='32' viewBox='0 0 32 32'><path d='M8 20s1.838-6 12-6v6l12-8-12-8v6c-8 0-12 4.99-12 10zm14 4H4V12h3.934c.315-.372.654-.729 1.015-1.068 1.374-1.287 3.018-2.27 4.879-2.932H.001v20h26v-8.395l-4 2.667V24z'></path></svg>") no-repeat left 2px;
+    background-size: 16px 16px;
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+}

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -367,7 +367,7 @@ class Asset extends React.Component {
         if (asset.symbol === core_asset.get("symbol")) preferredMarket = "USD";
         if (urls && urls.length) {
             urls.forEach(url => {
-                let markdownUrl = `<a target="_blank" rel="noopener noreferrer" href="${url}">${url}</a>`;
+                let markdownUrl = `<a target="_blank" class="external-link" rel="noopener noreferrer" href="${url}">${url}</a>`;
                 desc = desc.replace(url, markdownUrl);
             });
         }

--- a/app/components/DepositWithdraw/OpenledgerGateway.jsx
+++ b/app/components/DepositWithdraw/OpenledgerGateway.jsx
@@ -245,6 +245,7 @@ class OpenledgerGateway extends React.Component {
                                             : "mailto:") + issuer.support
                                     }
                                     rel="noopener noreferrer"
+                                    className={issuer.support.indexOf("@") === -1 ? "external-link" : ""}
                                 >
                                     {issuer.support}
                                 </a>

--- a/app/components/DepositWithdraw/citadel/CitadelGateway.jsx
+++ b/app/components/DepositWithdraw/citadel/CitadelGateway.jsx
@@ -214,6 +214,7 @@ class CitadelGateway extends React.Component {
                                     href={supportUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
+                                    className="external-link"
                                 >
                                     {supportUrl}
                                 </a>

--- a/app/components/DepositWithdraw/gdex/GdexGateway.jsx
+++ b/app/components/DepositWithdraw/gdex/GdexGateway.jsx
@@ -337,6 +337,7 @@ class GdexGateway extends React.Component {
                         href={issuer.ticket}
                         target="_blank"
                         rel="noopener noreferrer"
+                        className="external-link"
                     >
                         {issuer.ticket}
                     </a>
@@ -357,6 +358,7 @@ class GdexGateway extends React.Component {
                         href={issuer.telgram}
                         target="_blank"
                         rel="noopener noreferrer"
+                        className="external-link"
                     >
                         {issuer.telgram}
                     </a>

--- a/app/components/DepositWithdraw/openledger/OpenLedgerFiatDepositWithdrawal.jsx
+++ b/app/components/DepositWithdraw/openledger/OpenLedgerFiatDepositWithdrawal.jsx
@@ -146,6 +146,7 @@ class OpenLedgerFiatDepositWithdrawCurrency extends React.Component {
                         href="https://openledger.info/v/"
                         rel="noopener noreferrer"
                         target="_blank"
+                        className="external-link"
                     >
                         here
                     </a>{" "}
@@ -196,6 +197,7 @@ class OpenLedgerFiatDepositWithdrawCurrency extends React.Component {
                         href="https://openledger.info/v/"
                         rel="noopener noreferrer"
                         target="_blank"
+                        className="external-link"
                     >
                         here
                     </a>{" "}

--- a/app/components/DepositWithdraw/rudex/RuDexGateway.jsx
+++ b/app/components/DepositWithdraw/rudex/RuDexGateway.jsx
@@ -207,6 +207,7 @@ class RuDexGateway extends React.Component {
                                     href={supportUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
+                                    className="external-link"
                                 >
                                     {supportUrl}
                                 </a>

--- a/app/components/DepositWithdraw/xbtsx/XbtsxGateway.jsx
+++ b/app/components/DepositWithdraw/xbtsx/XbtsxGateway.jsx
@@ -207,6 +207,7 @@ class XbtsxGateway extends React.Component {
                                     href={supportUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
+                                    className="external-link"
                                 >
                                     {supportUrl}
                                 </a>

--- a/app/components/Layout/Footer.jsx
+++ b/app/components/Layout/Footer.jsx
@@ -490,7 +490,7 @@ class Footer extends React.Component {
                                     {__GIT_BRANCH__ === "staging" ? (
                                         <a
                                             href={`https://github.com/bitshares/bitshares-ui/commit/${version.trim()}`}
-                                            className="version"
+                                            className="version external-link"
                                             target="_blank"
                                             rel="noopener noreferrer"
                                         >

--- a/app/components/Modal/BrowserSupportModal.jsx
+++ b/app/components/Modal/BrowserSupportModal.jsx
@@ -39,7 +39,9 @@ export default class BrowserSupportModal extends React.Component {
                     <br />
 
                     <p>
-                        <a onClick={this._openLink}>Google Chrome</a>
+                        <a className="external-link" onClick={this._openLink}>
+                            Google Chrome
+                        </a>
                     </p>
                 </div>
             </Modal>

--- a/app/components/Modal/ReportModal.jsx
+++ b/app/components/Modal/ReportModal.jsx
@@ -105,6 +105,7 @@ class ReportModal extends React.Component {
                             href="https://github.com/bitshares/bitshares-ui/issues"
                             target="_blank"
                             style={{textAlign: "center", width: "100%"}}
+                            className="external-link"
                         >
                             https://github.com/bitshares/bitshares-ui/issues
                         </a>
@@ -119,6 +120,7 @@ class ReportModal extends React.Component {
                             href="https://hackthedex.io"
                             target="_blank"
                             style={{textAlign: "center", width: "100%"}}
+                            className="external-link"
                         >
                             https://hackthedex.io
                         </a>

--- a/app/components/News.jsx
+++ b/app/components/News.jsx
@@ -33,7 +33,7 @@ const ReusableLink = ({data, url, isLink = false}) => (
         rel="noreferrer noopener"
         target="_blank"
         style={{display: "block"}}
-        className={!isLink ? "primary-text" : ""}
+        className={!isLink ? "primary-text" : "external-link"}
     >
         {sanitize(data, {
             whiteList: [], // empty, means filter out all tags

--- a/app/components/Settings/SettingsEntry.jsx
+++ b/app/components/Settings/SettingsEntry.jsx
@@ -127,6 +127,7 @@ export default class SettingsEntry extends React.Component {
                                     href="https://goo.gl/zZ7NHY"
                                     target="_blank"
                                     rel="noopener noreferrer"
+                                    className="external-link"
                                 >
                                     <Translate
                                         component="div"

--- a/app/components/Utility/HelpContent.jsx
+++ b/app/components/Utility/HelpContent.jsx
@@ -38,7 +38,7 @@ function adjust_links(str) {
         if (text.indexOf((__HASH_HISTORY__ ? "#" : "") + "/") === 0)
             return `<a href="${text}" onclick="_onClickLink(event)"`;
         if (text.indexOf("http") === 0)
-            return `<a href="${text}" rel="noopener noreferrer" target="_blank"`;
+            return `<a href="${text}" rel="noopener noreferrer" class="external-link" target="_blank"`;
         let page = endsWith(text, ".md")
             ? text.substr(0, text.length - 3)
             : text;


### PR DESCRIPTION
<h2>General</h2>
Closes #504 

class "external-link" (which adds icon after link) is added for all places, where external link is

<h2>General</h2>
lease make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at 
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [+] Check for unused code
- [+] No unrelated changes are included
- [+] None of the changed files are reformatting only
- [+] Code is self explanatory or documented
- [+] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [+] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [+] Dark
- [+] Light
- [+] Midnight

_Please provide screenshots/licecap of your changes below_

One of the places, where added

![image](https://user-images.githubusercontent.com/42674402/56203223-78fb6380-604d-11e9-897a-0d7abaa26979.png)
