### PR TITLE
Disable dates less then current in DatePicker to avoid error.

### DIFF
--- a/app/components/Modal/DirectDebitModal.jsx
+++ b/app/components/Modal/DirectDebitModal.jsx
@@ -731,6 +731,10 @@ class DirectDebitModal extends React.Component {
                                     className="date-picker-width100"
                                     style={{width: "100%"}}
                                     ref={el => this.onDatepickerRef(el)}
+                                    disabledDate={current =>
+                                        current &&
+                                        current < moment().add(2, "minutes")
+                                    }
                                 />
                             </Tooltip>
                         </div>


### PR DESCRIPTION
<h2>General</h2>
Closes #2560

As FIRST PERIOD of the new debit should be later than current date, I have disabled the date that earlier than 2 minutes after "now" in the DatePicker input (the default state of the form). It will avoid entering the wrong date and getting such error:
![image](https://user-images.githubusercontent.com/28979127/56214389-778a6500-6066-11e9-96e1-df2b98ea9cd2.png)

<h2> Testing</h2>
Tested in Chrome

<h2> User interface changes</h2>
<img width="531" alt="Screen Shot 2019-04-16 at 4 47 47 PM" src="https://user-images.githubusercontent.com/28979127/56214999-9806ef00-6067-11e9-93a4-d42c20f21ecd.png">


