### PR TITLE
Issue 2561 - Add padding to order book header

### DIFF
--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -223,13 +223,13 @@ form.order-form {
 
 .buy-form {
     > div.ant-tabs-bar {
-        border-bottom: 1px solid #258a14 !important;
+        border-bottom: 1px solid #6ba583 !important;
     }
 }
 
 .sell-form {
     > div.ant-tabs-bar {
-        border-bottom: 1px solid #ea340b !important;
+        border-bottom: 1px solid #e3745b !important;
     }
 }
 
@@ -615,6 +615,13 @@ input[type="number"]::-webkit-outer-spin-button {
     padding: 10px;
 }
 
+.exchange-content-header.bid {
+    border-bottom: 1px solid #6ba583 !important;
+}
+
+.exchange-content-header.ask {
+    border-bottom: 1px solid #e3745b !important;
+}
 
 .exchange-padded {
     padding-right: 5px !important;

--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -610,6 +610,12 @@ input[type="number"]::-webkit-outer-spin-button {
     overflow: hidden;
 }
 
+.exchange-content-header.bid,
+.exchange-content-header.ask {
+    padding: 10px;
+}
+
+
 .exchange-padded {
     padding-right: 5px !important;
 }

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -2077,7 +2077,7 @@ class Exchange extends React.Component {
                             : centerContainerWidth > 800
                                 ? "medium-6"
                                 : "",
-                    "small-12 no-padding middle-content",
+                    "small-12 exchange-padded middle-content",
                     flipBuySell
                         ? `order-${buySellTop ? 2 : 3} large-order-${
                               buySellTop ? 2 : 5
@@ -2243,7 +2243,7 @@ class Exchange extends React.Component {
                             : centerContainerWidth > 800
                                 ? "medium-6"
                                 : "",
-                    "small-12 no-padding middle-content",
+                    "small-12 exchange-padded middle-content",
                     flipBuySell
                         ? `order-${buySellTop ? 1 : 2} large-order-${
                               buySellTop ? 1 : 4


### PR DESCRIPTION
<h2>General</h2>
Closes #2561 


Adds missing padding to Buy/Sell order book SCSS which probably been lost during the addition of scaled orders on Buy/Sell form.

### Full Screen

![bild](https://user-images.githubusercontent.com/12114550/56227855-b1fbfe00-6076-11e9-99b5-d07be2acdba1.png)

### Mobile Screen

![bild](https://user-images.githubusercontent.com/12114550/56227893-c809be80-6076-11e9-9d2a-70b094b81b29.png)


