### PR TITLE
Issue 2597 - Default empty AssetSelector message

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -1330,6 +1330,7 @@
             "close": "Close",
             "header": "Deposit to %(account_name)s",
             "header_short": "Deposit",
+            "no_assets": "No depositable assets available",
             "submit": "Deposit"
         },
         "deposit_withdraw": {
@@ -1409,6 +1410,7 @@
             "gateway_fee": "Gateway Fee",
             "header": "Withdraw",
             "memo": "Memo",
+            "no_assets": "No withdrawable assets available",
             "no_estimate": "No estimate available for this object",
             "no_gateways": "Sorry, but there are no gateways available to handle this withdrawal",
             "quantity": "Quantity",

--- a/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
+++ b/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
@@ -131,11 +131,20 @@ class DepositWithdrawAssetSelector extends React.Component {
                     user doesn't have to select a specific gateway to view
                     this information.
                 */}
-                {coinItems.map(coin => (
+
+                {coinItems.length > 0 ? coinItems.map(coin => (
                     <Select.Option key={coin.id} value={coin.label}>
                         {coin.label}
                     </Select.Option>
-                ))}
+                )) : (
+                    <Select.Option disabled key={0} value={0}>
+                        {counterpart.translate(
+                            usageContext == "withdraw"
+                                ? "modal.withdraw.no_assets"
+                                : "modal.deposit.no_assets"
+                        )}
+                    </Select.Option>
+                )}
             </Select>
         );
     }


### PR DESCRIPTION
<h2>General</h2>
Closes #2597 

<h2>Notes</h2>


Currently the user receives a message that the list has no data when user has no withdrawable assets (ie, no assets that the gateways can handle).

The user should receive a clearer message that this is the case. 

![bild](https://user-images.githubusercontent.com/12114550/56229371-12d90580-607a-11e9-9fea-c6ff4242d7ce.png)
