### PR TITLE
Update market_utils.js

### DIFF
--- a/app/lib/common/market_utils.js
+++ b/app/lib/common/market_utils.js
@@ -144,8 +144,7 @@ const MarketUtils = {
             finalPrice = fromPrice;
         }
         if (!finalPrice) return null;
-        const finalId =
-            finalPrice.base.asset_id + "_" + finalPrice.quote.asset_id;
+        const finalId = [finalPrice.base.asset_id, finalPrice.quote.asset_id];
         if (
             finalId.indexOf(toAsset.get("id")) === -1 ||
             finalId.indexOf(fromAsset.get("id")) === -1


### PR DESCRIPTION
`finalId` using string matching can cause errors in some cases. 

For example: 
- finalId id "1.3.0_1.3.18" 
- toAsset.get("id") is  "1.3.0"
- fromAsset.get("id") is"1.3.1"

We need line 148 return null, but  it will not.

because   `("1.3.0_1.3.18").indexOf("1.3.1")`  is  6.

I changed `finalId` from a string to an array to fix it.