### PR TITLE
#2747. update gateway fee after changing gateway

### DIFF
--- a/app/components/Modal/WithdrawModalNew.jsx
+++ b/app/components/Modal/WithdrawModalNew.jsx
@@ -588,7 +588,8 @@ class WithdrawModalNew extends React.Component {
 
     onGatewayChanged(selectedGateway) {
         this.setState({selectedGateway}, () => {
-            this.setState(this._getAssetPairVariables(), this.updateFee);
+            this.setState(this._getAssetPairVariables());
+            this.updateGatewayFee();
         });
     }
 
@@ -654,6 +655,24 @@ class WithdrawModalNew extends React.Component {
 
                 return backingCoin === selectedAsset;
             });
+    }
+
+    updateGatewayFee() {
+        const { selectedGateway, selectedAsset } = this.state;
+        let gateFee = 0;
+
+        if (selectedGateway && selectedAsset) {
+            this.props.backedCoins.get(selectedGateway).forEach(item => {
+                if (
+                    item.symbol === [selectedGateway, selectedAsset].join(".") ||
+                    item.backingCoinType === selectedAsset
+                ) {
+                    gateFee = item.gateFee || 0;
+                }
+            });
+        }
+
+        this.setState({ gateFee });
     }
 
     validateAddress(address) {


### PR DESCRIPTION
<h2>General</h2>
Closes #2747 

Added function updateGatewayFee which called after changing gateway. But I see that gateway fee for RUDEX.EOS = 0 (check the screenshots please)

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_

![image](https://user-images.githubusercontent.com/42674402/59265316-cbbc5a80-8c4d-11e9-8fd8-88417c100f51.png)

When you try to send 1 RUDEX.EOS
![image](https://user-images.githubusercontent.com/42674402/59265369-e1318480-8c4d-11e9-95ac-ac2db239ea13.png)

![image](https://user-images.githubusercontent.com/42674402/59265417-f7d7db80-8c4d-11e9-95ad-e6cc7042caf4.png)
