### PR TITLE
Issue 2785 - Enable TCR Margin only Update

### DIFF
--- a/app/components/Account/AccountVesting.jsx
+++ b/app/components/Account/AccountVesting.jsx
@@ -27,18 +27,23 @@ class VestingBalance extends React.Component {
         }
 
         let cvbAsset,
-            vestingPeriod,
-            earned,
             secondsPerDay = 60 * 60 * 24,
-            availablePercent,
             balance;
+        let vestingPeriod = null;
+        let earned = null;
+        let availablePercent = null;
         if (vb) {
             balance = vb.balance.amount;
             cvbAsset = ChainStore.getAsset(vb.balance.asset_id);
-            earned = vb.policy[1].coin_seconds_earned;
-            vestingPeriod = vb.policy[1].vesting_seconds;
-            availablePercent =
-                vestingPeriod === 0 ? 1 : earned / (vestingPeriod * balance);
+
+            if (vb.policy && vb.policy[0] !== 2) {
+                earned = vb.policy[1].coin_seconds_earned;
+                vestingPeriod = vb.policy[1].vesting_seconds;
+                availablePercent =
+                    vestingPeriod === 0
+                        ? 1
+                        : earned / (vestingPeriod * balance);
+            }
         }
 
         if (!cvbAsset) {
@@ -78,66 +83,81 @@ class VestingBalance extends React.Component {
                                 />
                             </td>
                         </tr>
-                        <tr>
-                            <td>
-                                <Translate content="account.member.earned" />
-                            </td>
-                            <td>
-                                {utils.format_number(
-                                    utils.get_asset_amount(
-                                        earned / secondsPerDay,
-                                        cvbAsset
-                                    ),
-                                    0
-                                )}
-                                &nbsp;
-                                <Translate content="account.member.coindays" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <Translate content="account.member.required" />
-                            </td>
-                            <td>
-                                {utils.format_number(
-                                    utils.get_asset_amount(
-                                        (vb.balance.amount * vestingPeriod) /
-                                            secondsPerDay,
-                                        cvbAsset
-                                    ),
-                                    0
-                                )}
-                                &nbsp;
-                                <Translate content="account.member.coindays" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <Translate content="account.member.remaining" />
-                            </td>
-                            <td>
-                                {utils.format_number(
-                                    (vestingPeriod * (1 - availablePercent)) /
-                                        secondsPerDay || 0,
-                                    2
-                                )}
-                                &nbsp;days
-                            </td>
-                        </tr>
+                        {earned && (
+                            <tr>
+                                <td>
+                                    <Translate content="account.member.earned" />
+                                </td>
+                                <td>
+                                    {utils.format_number(
+                                        utils.get_asset_amount(
+                                            earned / secondsPerDay,
+                                            cvbAsset
+                                        ),
+                                        0
+                                    )}
+                                    &nbsp;
+                                    <Translate content="account.member.coindays" />
+                                </td>
+                            </tr>
+                        )}
+                        {earned && (
+                            <tr>
+                                <td>
+                                    <Translate content="account.member.required" />
+                                </td>
+                                <td>
+                                    {utils.format_number(
+                                        utils.get_asset_amount(
+                                            (vb.balance.amount *
+                                                vestingPeriod) /
+                                                secondsPerDay,
+                                            cvbAsset
+                                        ),
+                                        0
+                                    )}
+                                    &nbsp;
+                                    <Translate content="account.member.coindays" />
+                                </td>
+                            </tr>
+                        )}
+                        {earned && (
+                            <tr>
+                                <td>
+                                    <Translate content="account.member.remaining" />
+                                </td>
+                                <td>
+                                    {utils.format_number(
+                                        (vestingPeriod *
+                                            (1 - availablePercent)) /
+                                            secondsPerDay || 0,
+                                        2
+                                    )}
+                                    &nbsp;days
+                                </td>
+                            </tr>
+                        )}
                         <tr>
                             <td>
                                 <Translate content="account.member.available" />
                             </td>
-                            <td>
-                                {utils.format_number(availablePercent * 100, 2)}
-                                % /{" "}
-                                <FormattedAsset
-                                    amount={
-                                        availablePercent * vb.balance.amount
-                                    }
-                                    asset={cvbAsset.get("id")}
-                                />
-                            </td>
+                            {earned ? (
+                                <td>
+                                    {utils.format_number(
+                                        availablePercent * 100,
+                                        2
+                                    )}
+                                    % /{" "}
+                                    <FormattedAsset
+                                        amount={
+                                            availablePercent * vb.balance.amount
+                                        }
+                                        asset={cvbAsset.get("id")}
+                                    />
+                                </td>
+                            ) : (
+                                <td>{utils.format_number(100, 2)}%</td>
+                            )}
                         </tr>
                         <tr>
                             <td colSpan="2" style={{textAlign: "right"}}>

--- a/app/components/Modal/BorrowModal.jsx
+++ b/app/components/Modal/BorrowModal.jsx
@@ -481,20 +481,6 @@ class BorrowModalContent extends React.Component {
 
         var tr = WalletApi.new_transaction();
         if (extensionsProp) {
-            // delta_collateral amount can not be 0
-            let delta_collateral_amount =
-                this.state.collateral != currentPosition.collateral
-                    ? parseInt(
-                          this.state.collateral * backingPrecision -
-                              currentPosition.collateral,
-                          10
-                      )
-                    : parseInt(
-                          this.state.collateral * backingPrecision -
-                              (currentPosition.collateral - 1),
-                          10
-                      );
-
             tr.add_type_operation("call_order_update", {
                 fee: {
                     amount: 0,

--- a/app/components/Modal/BorrowModal.jsx
+++ b/app/components/Modal/BorrowModal.jsx
@@ -464,6 +464,21 @@ class BorrowModalContent extends React.Component {
             };
         }
 
+        let delta_collateral_amount = parseInt(
+            this.state.collateral * backingPrecision -
+                currentPosition.collateral,
+            10
+        );
+        let delta_debt_amount = parseInt(
+            this.state.short_amount * quotePrecision - currentPosition.debt,
+            10
+        );
+
+        // Amount can not be 0
+        if (delta_collateral_amount == 0 && delta_debt_amount == 0) {
+            delta_collateral_amount = 1;
+        }
+
         var tr = WalletApi.new_transaction();
         if (extensionsProp) {
             tr.add_type_operation("call_order_update", {
@@ -473,19 +488,11 @@ class BorrowModalContent extends React.Component {
                 },
                 funding_account: this.props.account.get("id"),
                 delta_collateral: {
-                    amount: parseInt(
-                        this.state.collateral * backingPrecision -
-                            currentPosition.collateral,
-                        10
-                    ),
+                    amount: delta_collateral_amount,
                     asset_id: this.props.backing_asset.get("id")
                 },
                 delta_debt: {
-                    amount: parseInt(
-                        this.state.short_amount * quotePrecision -
-                            currentPosition.debt,
-                        10
-                    ),
+                    amount: delta_debt_amount,
                     asset_id: this.props.quote_asset.get("id")
                 },
                 extensions: extensionsProp
@@ -498,19 +505,11 @@ class BorrowModalContent extends React.Component {
                 },
                 funding_account: this.props.account.get("id"),
                 delta_collateral: {
-                    amount: parseInt(
-                        this.state.collateral * backingPrecision -
-                            currentPosition.collateral,
-                        10
-                    ),
+                    amount: delta_collateral_amount,
                     asset_id: this.props.backing_asset.get("id")
                 },
                 delta_debt: {
-                    amount: parseInt(
-                        this.state.short_amount * quotePrecision -
-                            currentPosition.debt,
-                        10
-                    ),
+                    amount: delta_debt_amount,
                     asset_id: this.props.quote_asset.get("id")
                 }
             });


### PR DESCRIPTION
Closes #2785 

When a margin position is updated without any debt/collateral change, but the user changes the TCR it will fail due to the core requires the debt/collateral to change.

This PR will make sure the collateral is changed with `1 * Collateral Asset Precision` if collateral amount and debt amount is 0 OR if user removes/adds TCR without changing debt/collateral.