### PR TITLE
Issue 2834 - AccountUpdate Proposal Operation Fixes

### DIFF
--- a/app/components/Blockchain/operations/AccountUpdate.jsx
+++ b/app/components/Blockchain/operations/AccountUpdate.jsx
@@ -111,8 +111,7 @@ export const AccountUpdate = ({op, fromComponent, collapsed}) => {
             );
             if (
                 _account.get("owner").get("weight_threshold") !==
-                    owner.weight_threshold &&
-                owner
+                owner.weight_threshold
             ) {
                 change.owner.weight_threshold = owner.weight_threshold;
             }
@@ -141,7 +140,7 @@ export const AccountUpdate = ({op, fromComponent, collapsed}) => {
                 _account.get("active").get("weight_threshold") !==
                 active.weight_threshold
             ) {
-                change.active.weight_threshold = owner.weight_threshold;
+                change.active.weight_threshold = active.weight_threshold;
             }
         }
 

--- a/app/components/Blockchain/operations/AccountUpdate.jsx
+++ b/app/components/Blockchain/operations/AccountUpdate.jsx
@@ -111,7 +111,8 @@ export const AccountUpdate = ({op, fromComponent, collapsed}) => {
             );
             if (
                 _account.get("owner").get("weight_threshold") !==
-                owner.weight_threshold
+                    owner.weight_threshold &&
+                owner
             ) {
                 change.owner.weight_threshold = owner.weight_threshold;
             }


### PR DESCRIPTION
Closes #2834

When an account has a proposed Account Update operation it can sometimes break if the account proposing doesn't have a resolved owner object. Reason for this is not known, but this fixes the main cause of the white screen of death.