### PR TITLE
Issue 2830 - Asset Margin Table Translation error

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -1485,7 +1485,7 @@ class Asset extends React.Component {
             {
                 key: "maximum_short_squeeze_ratio",
                 title: (
-                    <Translate content="explorer.asset.price_feed_data.maintenance_collateral_ratio" />
+                    <Translate content="explorer.asset.price_feed_data.maximum_short_squeeze_ratio" />
                 ),
                 dataIndex: "maximum_short_squeeze_ratio",
                 render: item => {


### PR DESCRIPTION
Closes #2839 

An invalid translation string was used, now fixed.