### PR TITLE
Issue 2825 - Exchange Cancel Order Translations

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -515,6 +515,7 @@
         "buysell_formatter": "{direction} {asset}",
         "call": "Call Price",
         "cancel_selected_orders": "Cancel selected order(s)",
+        "cancel_order_select_all": "Select all orders",
         "change": "Change",
         "chart_height": "Chart height (pixels)",
         "chart_hide": "Hide Charts",

--- a/app/components/Exchange/MyOpenOrders.jsx
+++ b/app/components/Exchange/MyOpenOrders.jsx
@@ -27,7 +27,7 @@ class ExchangeTableHeader extends React.Component {
                     <th style={{width: "6%", textAlign: "center"}}>
                         <Tooltip
                             title={counterpart.translate(
-                                "exchange.cancel_selected_orders"
+                                "exchange.cancel_order_select_all"
                             )}
                             placement="left"
                         >
@@ -101,18 +101,11 @@ class ExchangeOrderRow extends React.Component {
             <tr key={order.id}>
                 <td className="text-center" style={{width: "6%"}}>
                     {isCall ? null : (
-                        <Tooltip
-                            title={counterpart.translate(
-                                "exchange.cancel_selected_orders"
-                            )}
-                            placement="left"
-                        >
-                            <Checkbox
-                                className="orderCancel"
-                                checked={selected}
-                                onChange={this.props.onCheckCancel}
-                            />
-                        </Tooltip>
+                        <Checkbox
+                            className="orderCancel"
+                            checked={selected}
+                            onChange={this.props.onCheckCancel}
+                        />
                     )}
                 </td>
                 <td className={tdClass} style={{paddingLeft: 10}}>


### PR DESCRIPTION
Closes #2825 

- Adds "Select all" specific tooltip
- Removed tooltip for each row