### PR TITLE
Issue 2890 - Non Prediction Asset fixes

### DIFF
--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -2066,12 +2066,15 @@ class Asset extends React.Component {
                                     {this.renderFeesClaiming(asset)}
                                     {this.renderAssetOwnerUpdate(asset)}
                                     {"bitasset" in asset &&
-                                    !asset.bitasset.is_prediction_market
-                                        ? this.renderFeedPublish(asset)
-                                        : null}
+                                        !asset.bitasset.is_prediction_market &&
+                                        this.renderFeedPublish(asset)}
                                     {this.state.collateralBids.length > 0 &&
                                         this.renderCollateralBid(asset)}
-                                    {this.renderAssetResolvePrediction(asset)}
+                                    {"bitasset" in asset &&
+                                        !asset.bitasset.is_prediction_market &&
+                                        this.renderAssetResolvePrediction(
+                                            asset
+                                        )}
                                 </div>
                             </Tab>
                         </Tabs>

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -2071,7 +2071,7 @@ class Asset extends React.Component {
                                     {this.state.collateralBids.length > 0 &&
                                         this.renderCollateralBid(asset)}
                                     {"bitasset" in asset &&
-                                        !asset.bitasset.is_prediction_market &&
+                                        asset.bitasset.is_prediction_market &&
                                         this.renderAssetResolvePrediction(
                                             asset
                                         )}

--- a/app/components/Blockchain/AssetResolvePrediction.jsx
+++ b/app/components/Blockchain/AssetResolvePrediction.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import Translate from "react-translate-component";
 import BindToChainState from "../Utility/BindToChainState";
 import ChainTypes from "../Utility/ChainTypes";
-import classnames from "classnames";
 import AssetActions from "actions/AssetActions";
 import counterpart from "counterpart";
 import {Radio, Tooltip, Button, Form} from "bitshares-ui-style-guide";


### PR DESCRIPTION
Closes #2890 

Asset action crash
- Load resolve prediction only when asset is prediction bitasset.