### PR TITLE
Issue 2885 - Invalid translation for missing order history

### DIFF
--- a/app/assets/locales/locale-de.json
+++ b/app/assets/locales/locale-de.json
@@ -114,6 +114,7 @@
         },
         "new_user": "Neuer Benutzer?",
         "no_orders": "Keine offenen Aufträge",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "Offene Aufträge",
         "optional": {

--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -114,6 +114,7 @@
         },
         "new_user": "New user?",
         "no_orders": "No open orders",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "Open Orders",
         "optional": {

--- a/app/assets/locales/locale-es.json
+++ b/app/assets/locales/locale-es.json
@@ -114,6 +114,7 @@
         },
         "new_user": "Nuevo usuario?",
         "no_orders": "No hay pedidos abiertos",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "Ordenes abiertas",
         "optional": {

--- a/app/assets/locales/locale-fr.json
+++ b/app/assets/locales/locale-fr.json
@@ -114,6 +114,7 @@
         },
         "new_user": "New user?",
         "no_orders": "No open orders",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "Open Orders",
         "optional": {

--- a/app/assets/locales/locale-it.json
+++ b/app/assets/locales/locale-it.json
@@ -114,6 +114,7 @@
         },
         "new_user": "Nuovo utente?",
         "no_orders": "Nessun ordine aperto",
+        "no_order_history": "No order history",
         "no_price": "Valore sconosciuto",
         "open_orders": "Ordini aperti",
         "optional": {

--- a/app/assets/locales/locale-ja.json
+++ b/app/assets/locales/locale-ja.json
@@ -114,6 +114,7 @@
         },
         "new_user": "はじめてですか？",
         "no_orders": "未処理の注文はありません",
+        "no_order_history": "No order history",
         "no_price": "不明な値",
         "open_orders": "注文中",
         "optional": {

--- a/app/assets/locales/locale-ko.json
+++ b/app/assets/locales/locale-ko.json
@@ -114,6 +114,7 @@
         },
         "new_user": "New user?",
         "no_orders": "No open orders",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "Open Orders",
         "optional": {

--- a/app/assets/locales/locale-ru.json
+++ b/app/assets/locales/locale-ru.json
@@ -114,6 +114,7 @@
         },
         "new_user": "Новый пользователь?",
         "no_orders": "Нет открытых ордеров",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "Открытые ордера",
         "optional": {

--- a/app/assets/locales/locale-tr.json
+++ b/app/assets/locales/locale-tr.json
@@ -114,6 +114,7 @@
         },
         "new_user": "New user?",
         "no_orders": "Açık emir yok",
+        "no_order_history": "No order history",
         "no_price": "Fiyat mevcut değil",
         "open_orders": "Açık Emirler",
         "optional": {

--- a/app/assets/locales/locale-zh.json
+++ b/app/assets/locales/locale-zh.json
@@ -114,6 +114,7 @@
         },
         "new_user": "新用户？",
         "no_orders": "暂无挂单",
+        "no_order_history": "No order history",
         "no_price": "--",
         "open_orders": "我的挂单",
         "optional": {

--- a/app/components/Exchange/MarketHistory.jsx
+++ b/app/components/Exchange/MarketHistory.jsx
@@ -250,7 +250,7 @@ class MarketHistory extends React.Component {
                     }}
                     colSpan="5"
                 >
-                    <Translate content="account.no_orders" />
+                    <Translate content={"account.no_order_history"} />
                 </td>
             </tr>
         );


### PR DESCRIPTION
Closes #2885 

Empty order book should not state "No open orders".
Replaced to state "No order history".