### PR TITLE
#2838. Blocks freeze on transaction history tab

### DIFF
--- a/app/components/Account/RecentTransactions.jsx
+++ b/app/components/Account/RecentTransactions.jsx
@@ -26,6 +26,8 @@ import BlockTime from "../Blockchain/BlockTime";
 import OperationAnt from "../Blockchain/OperationAnt";
 import SettingsStore from "stores/SettingsStore";
 import {connect} from "alt-react";
+import PendingBlock from "../Utility/PendingBlock";
+
 const operation = new OperationAnt();
 
 const Option = Select.Option;
@@ -296,22 +298,9 @@ class RecentTransactions extends React.Component {
         );
         fee.amount = parseInt(fee.amount, 10);
         const dynGlobalObject = ChainStore.getObject("2.1.0");
-        let last_irreversible_block_num = dynGlobalObject.get(
+        const lastIrreversibleBlockNum = dynGlobalObject.get(
             "last_irreversible_block_num"
         );
-        let pending = null;
-        if (o.block_num > last_irreversible_block_num) {
-            pending = (
-                <span>
-                    (
-                    <Translate
-                        content="operation.pending"
-                        blocks={o.block_num - last_irreversible_block_num}
-                    />
-                    )
-                </span>
-            );
-        }
         return {
             key: o.id,
             id: o.id,
@@ -335,7 +324,8 @@ class RecentTransactions extends React.Component {
                         <span>{info.column}</span>
                     </div>
                     <div style={{fontSize: 14, paddingTop: 5}}>
-                        {pending ? <span> - {pending}</span> : null}
+                        {o.block_num > lastIrreversibleBlockNum ?
+                            <PendingBlock blockNumber={o.block_num} /> : null}
                     </div>
                 </div>
             ),

--- a/app/components/Utility/PendingBlock.jsx
+++ b/app/components/Utility/PendingBlock.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import Translate from "react-translate-component";
+import PropTypes from "prop-types";
+import Immutable from "immutable";
+import ChainTypes from "./ChainTypes";
+import BindToChainState from "./BindToChainState";
+
+class PendingBlock extends React.Component {
+    static propTypes = {
+        blockNumber: PropTypes.number.isRequired,
+        dynGlobalObject: ChainTypes.ChainObject.isRequired
+    };
+
+    static defaultProps = {
+        dynGlobalObject: "2.1.0"
+    };
+
+    shouldComponentUpdate(nextProps) {
+        return !Immutable.is(this.props.dynGlobalObject, nextProps.dynGlobalObject);
+    }
+
+    render() {
+        const { blockNumber, dynGlobalObject } = this.props;
+        const lastIrreversibleBlockNum = dynGlobalObject.get(
+            "last_irreversible_block_num"
+        );
+
+        return blockNumber > lastIrreversibleBlockNum ? (
+            <span>
+                {" - "}
+                (<Translate
+                    content="operation.pending"
+                    blocks={blockNumber - lastIrreversibleBlockNum}
+                />)
+            </span>
+        ) : null;
+    }
+}
+
+export default BindToChainState(PendingBlock);


### PR DESCRIPTION
<h2>General</h2>
Closes #2838 

Added new component which updates when last_irreversible_block_num is changed.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_