### PR TITLE
139 htlc expires mismatch

### DIFF
--- a/app/components/Modal/HtlcModal.jsx
+++ b/app/components/Modal/HtlcModal.jsx
@@ -480,7 +480,10 @@ class HtlcModal extends React.Component {
                         operation.payload.conditions.hash_lock.preimage_hash[0],
                     expirationDate: moment(
                         new Date(
-                            operation.payload.conditions.time_lock.expiration
+                            utils.makeISODateString(
+                                operation.payload.conditions.time_lock
+                                    .expiration
+                            )
                         )
                     ),
                     period: null
@@ -494,7 +497,10 @@ class HtlcModal extends React.Component {
                         operation.payload.conditions.hash_lock.preimage_hash[0],
                     expirationDate: moment(
                         new Date(
-                            operation.payload.conditions.time_lock.expiration
+                            utils.makeISODateString(
+                                operation.payload.conditions.time_lock
+                                    .expiration
+                            )
                         )
                     ),
                     period: null

--- a/app/components/Modal/HtlcModal.jsx
+++ b/app/components/Modal/HtlcModal.jsx
@@ -477,7 +477,13 @@ class HtlcModal extends React.Component {
                     preimage_hash:
                         operation.payload.conditions.hash_lock.preimage_hash[1],
                     preimage_size:
-                        operation.payload.conditions.hash_lock.preimage_hash[0]
+                        operation.payload.conditions.hash_lock.preimage_hash[0],
+                    expirationDate: moment(
+                        new Date(
+                            operation.payload.conditions.time_lock.expiration
+                        )
+                    ),
+                    period: null
                 });
             } else {
                 this.setState({
@@ -485,7 +491,13 @@ class HtlcModal extends React.Component {
                     preimage_hash:
                         operation.payload.conditions.hash_lock.preimage_hash[1],
                     preimage_size:
-                        operation.payload.conditions.hash_lock.preimage_hash[0]
+                        operation.payload.conditions.hash_lock.preimage_hash[0],
+                    expirationDate: moment(
+                        new Date(
+                            operation.payload.conditions.time_lock.expiration
+                        )
+                    ),
+                    period: null
                 });
             }
         } else {

--- a/app/components/Showcases/Htlc.jsx
+++ b/app/components/Showcases/Htlc.jsx
@@ -136,9 +136,7 @@ class Htlc extends Component {
                     amount: item.transfer.amount,
                     asset_id: item.transfer.asset_id
                 };
-                const expiration = new Date(
-                    item.conditions.time_lock.expiration
-                );
+                const expiration = item.conditions.time_lock.expiration;
                 const asset = ChainStore.getAsset(amount.asset_id, false);
                 const toAccountName = ChainStore.getAccountName(to) || to;
                 const fromAccountName = ChainStore.getAccountName(from) || from;
@@ -173,10 +171,7 @@ class Htlc extends Component {
                             </span>
                         </Tooltip>
                     ),
-                    expires: counterpart.localize(expiration, {
-                        type: "date",
-                        format: "full"
-                    }),
+                    expires: expiration,
                     rawData: {
                         ...item
                     }
@@ -240,6 +235,15 @@ class Htlc extends Component {
                         : a.expires < b.expires
                             ? -1
                             : 0;
+                },
+                render: (text, record) => {
+                    return counterpart.localize(
+                        new Date(utils.makeISODateString(text)),
+                        {
+                            type: "date",
+                            format: "full"
+                        }
+                    );
                 }
             },
             {


### PR DESCRIPTION
<h2>General</h2>
Closes #2874
There was an error, when modal was not updating expiration date after syncOperation .
Noticed that after fix 'one day' period was still selected - added period unset on operation sync.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [ ] Check for unused code
- [ ] No unrelated changes are included
- [ ] None of the changed files are reformatting only
- [ ] Code is self explanatory or documented
- [ ] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [ ] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_