### PR TITLE
#2902. different asset for total column (Order book)

### DIFF
--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -942,3 +942,9 @@ tbody.orderbook > tr.my-order > td {
 .tether-element {
     z-index: 100;
 }
+
+.underline-title {
+    > * {
+        text-decoration: underline;
+    }
+}

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -852,7 +852,7 @@ class OrderBook extends React.Component {
                             />
                             <a
                                 onClick={() => this.toggleTotalAsset(true)}
-                                className="header-sub-title"
+                                className="header-sub-title underline-title"
                             >
                                 {" "}
                                 (<AssetName
@@ -920,7 +920,7 @@ class OrderBook extends React.Component {
                             />
                             <a
                                 onClick={() => this.toggleTotalAsset()}
-                                className="header-sub-title"
+                                className="header-sub-title underline-title"
                             >
                                 {" "}
                                 (<AssetName

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -154,20 +154,22 @@ class OrderBookRowHorizontal extends React.Component {
                   order.amountToReceive().getAmount({real: true}),
                   base.get("precision")
               );
-        const totalValueBids = quoteTotal ?
-            order.totalToReceive() : order.totalForSale();
-        const totalValueAsks = quoteTotal ?
-            order.totalForSale() : order.totalToReceive();
+        const totalValueBids = quoteTotal
+            ? order.totalToReceive()
+            : order.totalForSale();
+        const totalValueAsks = quoteTotal
+            ? order.totalForSale()
+            : order.totalToReceive();
         const totalAsset = quoteTotal ? quote : base;
         const total = isBid
             ? utils.format_number(
-                totalValueBids.getAmount({real: true}),
-                totalAsset.get("precision")
-            )
+                  totalValueBids.getAmount({real: true}),
+                  totalAsset.get("precision")
+              )
             : utils.format_number(
-                totalValueAsks.getAmount({real: true}),
-                totalAsset.get("precision")
-            );
+                  totalValueAsks.getAmount({real: true}),
+                  totalAsset.get("precision")
+              );
 
         return (
             <tr
@@ -282,20 +284,22 @@ class GroupedOrderBookRowHorizontal extends React.Component {
                   order.amountToReceive().getAmount({real: true}),
                   base.get("precision")
               );
-        const totalValueBids = quoteTotal ?
-            order.totalToReceive() : order.totalForSale();
-        const totalValueAsks = quoteTotal ?
-            order.totalForSale() : order.totalToReceive();
+        const totalValueBids = quoteTotal
+            ? order.totalToReceive()
+            : order.totalForSale();
+        const totalValueAsks = quoteTotal
+            ? order.totalForSale()
+            : order.totalToReceive();
         const totalAsset = quoteTotal ? quote : base;
         const total = isBid
             ? utils.format_number(
-                totalValueBids.getAmount({real: true}),
-                totalAsset.get("precision")
-            )
+                  totalValueBids.getAmount({real: true}),
+                  totalAsset.get("precision")
+              )
             : utils.format_number(
-                totalValueAsks.getAmount({real: true}),
-                totalAsset.get("precision")
-            );
+                  totalValueAsks.getAmount({real: true}),
+                  totalAsset.get("precision")
+              );
 
         return (
             <tr onClick={this.props.onClick}>
@@ -855,15 +859,15 @@ class OrderBook extends React.Component {
                                 className="header-sub-title underline-title"
                             >
                                 {" "}
-                                (<AssetName
+                                <AssetName
                                     dataPlace="top"
                                     name={
-                                        !this.state.quoteTotalBids ?
-                                            baseSymbol :
-                                            quoteSymbol
+                                        !this.state.quoteTotalBids
+                                            ? baseSymbol
+                                            : quoteSymbol
                                     }
+                                    noTip
                                 />
-                                )
                             </a>
                         </th>
                         <th>
@@ -923,15 +927,15 @@ class OrderBook extends React.Component {
                                 className="header-sub-title underline-title"
                             >
                                 {" "}
-                                (<AssetName
+                                <AssetName
                                     dataPlace="top"
                                     name={
-                                        !this.state.quoteTotalAsks ?
-                                            baseSymbol :
-                                            quoteSymbol
+                                        !this.state.quoteTotalAsks
+                                            ? baseSymbol
+                                            : quoteSymbol
                                     }
+                                    noTip
                                 />
-                                )
                             </a>
                         </th>
                     </tr>


### PR DESCRIPTION
<h2>General</h2>
Closes #2902 

add possibility to change asset in total column

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_
![image](https://user-images.githubusercontent.com/42674402/61453193-2e4bf900-a966-11e9-8272-7c851f5dc252.png)

![image](https://user-images.githubusercontent.com/42674402/61453213-37d56100-a966-11e9-806c-6c082d5ab3cf.png)
