### PR TITLE
2860 account switch tooltip should not hide user menu

### DIFF
--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -68,6 +68,9 @@ class Header extends React.Component {
         this._closeAccountsListDropdown = this._closeAccountsListDropdown.bind(
             this
         );
+        this._closeAccountNotifications = this._closeAccountNotifications.bind(
+            this
+        );
 
         this.showDepositModal = this.showDepositModal.bind(this);
         this.hideDepositModal = this.hideDepositModal.bind(this);
@@ -198,6 +201,7 @@ class Header extends React.Component {
             }
         }
         this._closeDropdown();
+        this._closeAccountNotifications();
     }
 
     _onNavigate(route, e) {
@@ -289,7 +293,7 @@ class Header extends React.Component {
         const hasLocalWallet = !!WalletDb.getWallet();
 
         if (!hasLocalWallet) return false;
-
+        this._closeAccountNotifications();
         this.setState({
             accountsListDropdownActive: !this.state.accountsListDropdownActive
         });
@@ -308,6 +312,14 @@ class Header extends React.Component {
         this.setState({
             dropdownActive: !this.state.dropdownActive
         });
+        this._closeAccountNotifications();
+    }
+
+    _closeAccountNotifications() {
+        this.state.accountNotificationActiveKeys.map(key =>
+            Notification.close(key)
+        );
+        this.setState({accountNotificationActiveKeys: []});
     }
 
     onBodyClick(e) {

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -55,6 +55,7 @@ class Header extends React.Component {
             hasWithdrawalModalBeenShown: false
         };
 
+        this._accountNotificationActiveKeys = [];
         this.unlisten = null;
         this._toggleAccountDropdownMenu = this._toggleAccountDropdownMenu.bind(
             this
@@ -79,8 +80,6 @@ class Header extends React.Component {
 
         this.onBodyClick = this.onBodyClick.bind(this);
     }
-
-    _accountNotificationActiveKeys = [];
 
     showDepositModal() {
         this.setState({

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -52,7 +52,8 @@ class Header extends React.Component {
             isDepositModalVisible: false,
             hasDepositModalBeenShown: false,
             isWithdrawModalVisible: false,
-            hasWithdrawalModalBeenShown: false
+            hasWithdrawalModalBeenShown: false,
+            accountNotificationActiveKeys: []
         };
 
         this.unlisten = null;
@@ -258,10 +259,25 @@ class Header extends React.Component {
         ZfApi.publish("account_drop_down", "close");
         if (account_name !== this.props.currentAccount) {
             AccountActions.setCurrentAccount.defer(account_name);
+            const key = `account-notification-${Date.now()}`;
             Notification.success({
                 message: counterpart.translate("header.account_notify", {
                     account: account_name
-                })
+                }),
+                key,
+                onClose: () => {
+                    this.setState({
+                        accountNotificationActiveKeys: this.state.accountNotificationActiveKeys.filter(
+                            el => el !== key
+                        )
+                    });
+                }
+            });
+            this.setState({
+                accountNotificationActiveKeys: [
+                    ...this.state.accountNotificationActiveKeys,
+                    key
+                ]
             });
             this._closeDropdown();
         }

--- a/app/components/Layout/Header.jsx
+++ b/app/components/Layout/Header.jsx
@@ -52,8 +52,7 @@ class Header extends React.Component {
             isDepositModalVisible: false,
             hasDepositModalBeenShown: false,
             isWithdrawModalVisible: false,
-            hasWithdrawalModalBeenShown: false,
-            accountNotificationActiveKeys: []
+            hasWithdrawalModalBeenShown: false
         };
 
         this.unlisten = null;
@@ -80,6 +79,8 @@ class Header extends React.Component {
 
         this.onBodyClick = this.onBodyClick.bind(this);
     }
+
+    _accountNotificationActiveKeys = [];
 
     showDepositModal() {
         this.setState({
@@ -270,19 +271,15 @@ class Header extends React.Component {
                 }),
                 key,
                 onClose: () => {
-                    this.setState({
-                        accountNotificationActiveKeys: this.state.accountNotificationActiveKeys.filter(
-                            el => el !== key
-                        )
-                    });
+                    // Remove key of notification from notificationKeys array after close
+                    this._accountNotificationActiveKeys = this._accountNotificationActiveKeys.filter(
+                        el => el !== key
+                    );
                 }
             });
-            this.setState({
-                accountNotificationActiveKeys: [
-                    ...this.state.accountNotificationActiveKeys,
-                    key
-                ]
-            });
+
+            this._accountNotificationActiveKeys.push(key);
+
             this._closeDropdown();
         }
     }
@@ -316,10 +313,8 @@ class Header extends React.Component {
     }
 
     _closeAccountNotifications() {
-        this.state.accountNotificationActiveKeys.map(key =>
-            Notification.close(key)
-        );
-        this.setState({accountNotificationActiveKeys: []});
+        this._accountNotificationActiveKeys.map(key => Notification.close(key));
+        this._accountNotificationActiveKeys = [];
     }
 
     onBodyClick(e) {

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,7 @@ echo TRAVIS_TAG=$TRAVIS_TAG
 echo TRAVIS_BRANCH=$TRAVIS_BRANCH
 echo TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 
-if [[ "$unamestr" == 'Linux' && -n $TRAVIS_TAG && $TRAVIS_BRANCH =~ [2-9]\.[0-9]\.[0-9]{6}$ ]]
+if [[ "$unamestr" == 'Linux' && -n $TRAVIS_TAG && $TRAVIS_BRANCH =~ [2-9]\.[0-9]\.[0-9]{6}\.?[0-9]? ]]
 then
     ## wallet.bitshares.org subdomain (independent repo)
     echo "Pushing new wallet subdomain repo"

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,7 @@ echo TRAVIS_TAG=$TRAVIS_TAG
 echo TRAVIS_BRANCH=$TRAVIS_BRANCH
 echo TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 
-if [[ "$unamestr" == 'Linux' && -n $TRAVIS_TAG && $TRAVIS_BRANCH =~ [2-9]\.[0-9]\.[0-9]{6}\.?[0-9]? ]]
+if [[ "$unamestr" == 'Linux' && -n $TRAVIS_TAG && $TRAVIS_BRANCH =~ [2-9]\.[0-9]\.[0-9]{6}$ ]]
 then
     ## wallet.bitshares.org subdomain (independent repo)
     echo "Pushing new wallet subdomain repo"


### PR DESCRIPTION
<h2>General</h2>
Closes #2860

Add auto close of account notification when user open menu/account management dropdown or open account unlock modal

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [x] Opera
- [x] Firefox
- [x] Safari

Before: 
![AwesomeScreenshot-2019-7-22-1563803691410](https://user-images.githubusercontent.com/43940398/61647288-b4917380-acb5-11e9-8f41-2b106161b505.gif)

After:
![AwesomeScreenshot-2019-7-22-1563803429697](https://user-images.githubusercontent.com/43940398/61647411-fae6d280-acb5-11e9-8fd2-8c82938f2bae.gif)


