### PR TITLE
2756 - Account Selecotor Updates

### DIFF
--- a/app/assets/locales/locale-en.json
+++ b/app/assets/locales/locale-en.json
@@ -2376,7 +2376,9 @@
             "minimum_amount": "Minimum withdraw amount: %(amount)s %(symbol)s",
             "noFeeBalance": "Your balance is insufficient to pay fees using this asset, please choose another asset to pay your fees with",
             "noFunds": "No funds",
+            "unknown": "Unknown error",
             "noPoolBalance": "That asset has an insufficient fee pool balance to pay the fees with. Please inform the asset owner or select another asset for paying fees.",
+            "noPoolBalanceShort": "Fee pool empty",
             "pos": "Amount must be positive",
             "precision": "Minimum withdraw precision value: %(precision)s",
             "req": "Required field",
@@ -2397,6 +2399,7 @@
         "see": "SEE MY TRANSFERS",
         "send": "Send",
         "total": "Total: ",
+        "to": "To",
         "warn_name_unable_read_memo": "Proposed sender will be unable to read this memo!"
     },
     "trx_error": {

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -419,11 +419,11 @@ class AccountSelector extends React.Component {
 
         // Populate account search array
         this.props.myActiveAccounts.map(a => {
-            this._addToIndex(a, false);
+            this._addToIndex(a);
         });
 
         this.props.contacts.map(a => {
-            this._addToIndex(a, false);
+            this._addToIndex(a);
         });
 
         editableInput = !!lockedState

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -222,7 +222,9 @@ class AccountSelector extends React.Component {
                 ? "#" + accountResult.get("id").substring(4)
                 : accountType === "id"
                     ? accountResult.get("name")
-                    : null;
+                    : accountType == "pubkey" && this.props.allowPubKey
+                        ? "Public Key"
+                        : null;
 
         return {
             name: accountName,
@@ -266,22 +268,24 @@ class AccountSelector extends React.Component {
     }
 
     getError() {
-        let {account, accountName, allowPubKey, error} = this.props;
+        let {account, accountName, error, typeahead} = this.props;
 
-        if (this.props.typeahead) return;
+        let inputType = accountName ? this.getInputType(accountName) : null;
 
-        if (!account && accountName && accountName.length > 0) {
-            error = counterpart.translate("account.errors.unknown");
+        if (!typeahead) {
+            if (!account && accountName && inputType !== "pubkey") {
+                error = counterpart.translate("account.errors.unknown");
+            }
+        } else {
+            // Typeahead can't select an unknown account!
+            // if (
+            //     !(allowPubKey && inputType === "pubkey") &&
+            //     !error &&
+            //     accountName &&
+            //     !account
+            // )
+            //     error = counterpart.translate("account.errors.unknown");
         }
-        let inputType = account ? this.getInputType(account.get("name")) : null;
-
-        if (
-            !error &&
-            !account &&
-            accountName &&
-            (inputType !== "pubkey" || !(allowPubKey && inputType === "pubkey"))
-        )
-            error = counterpart.translate("account.errors.unknown");
 
         if (!error && account && !inputType)
             error = counterpart.translate("account.errors.invalid");

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -268,14 +268,11 @@ class AccountSelector extends React.Component {
     getError() {
         let {account, accountName, allowPubKey, error} = this.props;
 
-        // Non-typeahead error handling
-        if (!account && !this.props.typeahead) {
-            if (accountName.length > 0) {
-                return counterpart.translate("account.errors.unknown");
-            }
-            return;
-        }
+        if (this.props.typeahead) return;
 
+        if (!account && accountName && accountName.length > 0) {
+            error = counterpart.translate("account.errors.unknown");
+        }
         let inputType = account ? this.getInputType(account.get("name")) : null;
 
         if (
@@ -452,15 +449,15 @@ class AccountSelector extends React.Component {
                 searchResults && searchResults[objectIndex]
                     ? searchResults[objectIndex].data
                     : null;
-
-            disabledAction =
-                !(
-                    account ||
-                    (selectedAccount && selectedAccount.type === "pubkey")
-                ) ||
-                error ||
-                disableActionButton;
         }
+
+        disabledAction =
+            !(
+                account ||
+                (selectedAccount && selectedAccount.type === "pubkey")
+            ) ||
+            error ||
+            disableActionButton;
 
         if (selectedAccount && selectedAccount.isOwnAccount) {
             linked_status = (
@@ -635,8 +632,8 @@ class AccountSelector extends React.Component {
         ) : (
             <AccountImage
                 size={{
-                    height: this.props.size || 80,
-                    width: this.props.size || 80
+                    height: this.props.size || 33,
+                    width: this.props.size || 33
                 }}
                 account={selectedAccount ? selectedAccount.id : null}
                 custom_image={null}

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -100,16 +100,14 @@ class AccountSelector extends React.Component {
             this.onInputChanged(accountName);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
         if (this.props.focus && !!this.props.editable && !this.props.disabled) {
             this.refs.user_input.focus();
         }
-    }
 
-    componentWillReceiveProps(np) {
-        if (np.account && np.account !== this.props.account) {
+        if (prevProps.account && prevProps.account !== this.props.account) {
             if (this.props.onAccountChanged) {
-                this.props.onAccountChanged(np.account);
+                this.props.onAccountChanged(this.props.account);
             }
         }
     }
@@ -176,10 +174,7 @@ class AccountSelector extends React.Component {
 
         if (search_array.length > 0) {
             if (__DEV__)
-                console.log(
-                    "Looked for " + search_array.length + " accounts",
-                    search_array
-                );
+                console.log("Looked for " + search_array.length + " accounts");
             FetchChainObjects(
                 ChainStore.getAccount,
                 search_array,

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -81,7 +81,7 @@ class AccountSelector extends React.Component {
         let {account, accountName} = this.props;
 
         if (accountName) {
-            this._addToIndex(accountName);
+            this._addToIndex(accountName, true);
         }
 
         if (this.props.onAccountChanged && account)
@@ -105,7 +105,7 @@ class AccountSelector extends React.Component {
         }
     }
 
-    _addToIndex(accountName) {
+    _addToIndex(accountName, noDelay = false) {
         let {accountIndex} = this.state;
 
         let inAccountList = accountIndex.find(a => a.name === accountName);
@@ -119,11 +119,15 @@ class AccountSelector extends React.Component {
             });
         }
 
-        // Delay lookups for 250ms
-        clearTimeout(this.timer);
-        this.timer = setTimeout(() => {
+        if (noDelay) {
             this._fetchAccounts();
-        }, 250);
+        } else {
+            // Delay lookups for 250ms
+            clearTimeout(this.timer);
+            this.timer = setTimeout(() => {
+                this._fetchAccounts();
+            }, 250);
+        }
     }
 
     _getIndex(name, index) {

--- a/app/components/Modal/SendModal.jsx
+++ b/app/components/Modal/SendModal.jsx
@@ -586,7 +586,6 @@ class SendModal extends React.Component {
                                                 this.props.currentAccount
                                             }
                                             account={this.props.currentAccount}
-                                            size={35}
                                             typeahead={true}
                                             tabIndex={tabIndex++}
                                             locked={true}
@@ -603,7 +602,6 @@ class SendModal extends React.Component {
                                     onAccountChanged={this.onFromAccountChanged.bind(
                                         this
                                     )}
-                                    size={35}
                                     typeahead={true}
                                     tabIndex={tabIndex++}
                                     locked={!!propose ? undefined : true}
@@ -617,7 +615,6 @@ class SendModal extends React.Component {
                                     onAccountChanged={this.onToAccountChanged.bind(
                                         this
                                     )}
-                                    size={35}
                                     typeahead={true}
                                     tabIndex={tabIndex++}
                                 />

--- a/app/components/Modal/SendModal.jsx
+++ b/app/components/Modal/SendModal.jsx
@@ -676,7 +676,7 @@ class SendModal extends React.Component {
                                 <FeeAssetSelector
                                     label="transfer.fee"
                                     account={from_account}
-                                    trxInfo={{
+                                    transaction={{
                                         type: "transfer",
                                         options: ["price_per_kbyte"],
                                         data: {

--- a/app/components/Modal/SetDefaultFeeAssetModal.jsx
+++ b/app/components/Modal/SetDefaultFeeAssetModal.jsx
@@ -62,16 +62,19 @@ class SetDefaultFeeAssetModal extends React.Component {
     }
 
     _getAssetsRows(assets) {
-        return assets.filter(item => !!item).map(assetInfo => ({
-            id: assetInfo.asset.get("id"),
-            key: assetInfo.asset.get("id"),
-            asset: assetInfo.asset.get("symbol"),
-            link: `/asset/${assetInfo.asset.get("symbol")}`,
-            balance:
-                assetInfo.balance /
-                Math.pow(10, assetInfo.asset.get("precision")),
-            fee: assetInfo.fee
-        }));
+        return assets.filter(item => !!item).map(assetInfo => {
+            console.log(assetInfo);
+            return {
+                id: assetInfo.asset.get("id"),
+                key: assetInfo.asset.get("id"),
+                asset: assetInfo.asset.get("symbol"),
+                link: `/asset/${assetInfo.asset.get("symbol")}`,
+                balance:
+                    assetInfo.balance /
+                    Math.pow(10, assetInfo.asset.get("precision")),
+                fee: assetInfo.fee
+            };
+        });
     }
 
     onSubmit() {

--- a/app/components/Settings/FeeAssetSettings.jsx
+++ b/app/components/Settings/FeeAssetSettings.jsx
@@ -50,20 +50,22 @@ class FeeAssetSettings extends React.Component {
                 >
                     {counterpart.translate("settings.change_default_fee_asset")}
                 </Button>
-                <SetDefaultFeeAssetModal
-                    key="change_fee_asset_modal"
-                    className="modal"
-                    show={this.state.showModal}
-                    current_asset={this.state.current_asset}
-                    displayFees={false}
-                    forceDefault={true}
-                    onChange={value => {
-                        this.setState({current_asset: value});
-                    }}
-                    close={() => {
-                        this.setState({showModal: false});
-                    }}
-                />
+                {this.state.showModal && (
+                    <SetDefaultFeeAssetModal
+                        key="change_fee_asset_modal"
+                        className="modal"
+                        show={this.state.showModal}
+                        current_asset={this.state.current_asset}
+                        displayFees={false}
+                        forceDefault={true}
+                        onChange={value => {
+                            this.setState({current_asset: value});
+                        }}
+                        close={() => {
+                            this.setState({showModal: false});
+                        }}
+                    />
+                )}
             </div>
         );
     }

--- a/app/components/Utility/AmountSelectorStyleGuide.jsx
+++ b/app/components/Utility/AmountSelectorStyleGuide.jsx
@@ -114,18 +114,23 @@ class AmountSelector extends DecimalChecker {
                 validateStatus={this.props.validateStatus}
                 help={this.props.help}
             >
-                <Input
-                    disabled={this.props.disabled}
-                    value={value || ""}
-                    placeholder={this.props.placeholder}
-                    onChange={this._onChange.bind(this)}
-                    tabIndex={this.props.tabIndex}
-                    onPaste={this.props.onPaste || this.onPaste.bind(this)}
-                    onKeyPress={this.onKeyPress.bind(this)}
-                    addonAfter={addonAfter}
-                    addonBefore={addonBefore}
-                    className="input-group-unbordered-before"
-                />
+                <Input.Group compact>
+                    <Input
+                        disabled={this.props.disabled}
+                        value={value || ""}
+                        style={{
+                            width: "calc(100% - 130px)"
+                        }}
+                        placeholder={this.props.placeholder}
+                        onChange={this._onChange.bind(this)}
+                        tabIndex={this.props.tabIndex}
+                        onPaste={this.props.onPaste || this.onPaste.bind(this)}
+                        onKeyPress={this.onKeyPress.bind(this)}
+                        addonBefore={addonBefore}
+                        className="input-group-unbordered-before"
+                    />
+                    {addonAfter}
+                </Input.Group>
             </Form.Item>
         );
     }

--- a/app/components/Utility/AssetSelect.jsx
+++ b/app/components/Utility/AssetSelect.jsx
@@ -8,6 +8,7 @@ import ChainTypes from "../Utility/ChainTypes";
 import BindToChainState from "../Utility/BindToChainState";
 import {Map} from "immutable";
 import AssetName from "../Utility/AssetName";
+import LoadingIndicator from "../LoadingIndicator";
 
 const AssetSelectView = ({
     label,
@@ -17,26 +18,30 @@ const AssetSelectView = ({
     style,
     placeholder,
     value,
+    onDropdownVisibleChange,
     ...props
 }) => {
-    const onlyOne = assets.filter(Map.isMap).length <= 1;
+    const disableSelect =
+        assets.filter(Map.isMap).length <= 1 && !onDropdownVisibleChange;
+    // if onDropdownVisibleChange given we assume that lazy loading takes place
     const select = (
         <Select
             showSearch
-            showArrow={onlyOne ? false : undefined}
+            onDropdownVisibleChange={onDropdownVisibleChange}
+            showArrow={disableSelect ? false : undefined}
             style={selectStyle}
             placeholder={
                 <Translate
                     content={placeholder || "utility.asset_select_placeholder"}
                 />
             }
-            value={<AssetName noTip name={value} />}
+            value={value}
             {...props}
             optionFilterProp="children"
             filterOption={(input, option) =>
                 option.key.toLowerCase().indexOf(input.toLowerCase()) >= 0
             }
-            disabled={onlyOne}
+            disabled={disableSelect}
             notFoundContent={counterpart.translate("global.not_found")}
         >
             {assets.filter(Map.isMap).map(asset => {
@@ -51,6 +56,11 @@ const AssetSelectView = ({
                     </Select.Option>
                 );
             })}
+            {props.loading && (
+                <Select.Option key="loading" value="loading" disabled={true}>
+                    <LoadingIndicator type="three-bounce" />
+                </Select.Option>
+            )}
         </Select>
     );
     return (

--- a/app/components/Utility/FeeAssetSelector.jsx
+++ b/app/components/Utility/FeeAssetSelector.jsx
@@ -6,7 +6,7 @@ import AssetWrapper from "./AssetWrapper";
 import PropTypes from "prop-types";
 import {Form, Input, Button, Tooltip, Icon} from "bitshares-ui-style-guide";
 import AssetSelect from "./AssetSelect";
-import {ChainStore, FetchChain} from "bitsharesjs";
+import {FetchChain} from "bitsharesjs";
 import SetDefaultFeeAssetModal from "../Modal/SetDefaultFeeAssetModal";
 import debounceRender from "react-debounce-render";
 import {connect} from "alt-react";

--- a/app/components/Utility/FeeAssetSelector.jsx
+++ b/app/components/Utility/FeeAssetSelector.jsx
@@ -4,131 +4,145 @@ import Immutable from "immutable";
 import counterpart from "counterpart";
 import AssetWrapper from "./AssetWrapper";
 import PropTypes from "prop-types";
-import {Form, Input, Button, Tooltip} from "bitshares-ui-style-guide";
+import {Form, Input, Button, Tooltip, Icon} from "bitshares-ui-style-guide";
 import AssetSelect from "./AssetSelect";
-import {ChainStore} from "bitsharesjs";
+import {ChainStore, FetchChain} from "bitsharesjs";
 import SetDefaultFeeAssetModal from "../Modal/SetDefaultFeeAssetModal";
-import {debounce} from "lodash-es";
+import debounceRender from "react-debounce-render";
 import {connect} from "alt-react";
 import SettingsStore from "../../stores/SettingsStore";
 import {checkFeeStatusAsync} from "common/trxHelper";
 
 class FeeAssetSelector extends React.Component {
+    static propTypes = {
+        // injected
+        defaultFeeAsset: PropTypes.any,
+
+        // object wih data required for fee calculation
+        transaction: PropTypes.any,
+
+        // assets to choose from
+        assets: PropTypes.any,
+
+        // a translation key for the input label, defaults to "Fee"
+        label: PropTypes.string,
+
+        // handler for changedFee (asset, or amount)
+        onChange: PropTypes.func,
+
+        // account which pays fee
+        account: PropTypes.any,
+
+        // tab index if needed
+        tabIndex: PropTypes.number,
+
+        // do not allow to switch the asset or amount
+        disabled: PropTypes.bool
+    };
+
+    static defaultProps = {
+        label: "transfer.fee",
+        disabled: false
+    };
+
     constructor(props) {
         super(props);
 
         this.state = {
-            asset: null,
-            assets: null,
-            fee_amount: 0,
-            fee_asset_id: "1.3.0",
             feeAsset: props.defaultFeeAsset,
-            fees: {},
-            feeStatus: {},
+
+            calculatedFeeAmount: null,
+
+            assets: null,
+            assetsLoading: false,
+
             isModalVisible: false,
-            error: null,
-            assets_fetched: false,
-            last_fee_check_params: {}
+            error: null
         };
-        this._updateFee = debounce(this._updateFee.bind(this), 250);
     }
 
-    async _getFees(assets, account, trxInfo) {
-        const accountID = account.get("id");
-        let result = this.state.fees;
-        for (let asset_id of assets) {
-            const {fee} = await checkFeeStatusAsync({
-                ...trxInfo,
-                accountID,
-                feeID: asset_id
-            });
-            result[asset_id] = fee.getAmount({real: true});
+    async _calculateFee(asset = null) {
+        const {account, transaction} = this.props;
+        const setState = asset == null;
+        if (!asset) {
+            asset = this.state.feeAsset;
         }
-        this.setState({fees: result});
+        const feeID = typeof asset == "string" ? asset : asset.get("id");
+        try {
+            const {fee, hasPoolBalance} = await checkFeeStatusAsync({
+                ...transaction,
+                accountID: account.get("id"),
+                feeID
+            });
+
+            if (setState) {
+                this.setState(
+                    {
+                        calculatedFeeAmount: fee.getAmount({real: true}),
+                        error: !hasPoolBalance
+                            ? {
+                                  key: "noPoolBalanceShort",
+                                  tooltip: "noPoolBalance"
+                              }
+                            : false
+                    },
+                    () => {
+                        if (this.props.onChange) {
+                            this.props.onChange(fee);
+                        }
+                    }
+                );
+            }
+            return {
+                fee,
+                hasPoolBalance
+            };
+        } catch (err) {
+            if (setState) {
+                this.setState({
+                    calculatedFeeAmount: 0,
+                    error: {
+                        key: "unknown"
+                    }
+                });
+            }
+            console.error(err);
+            throw err;
+        }
     }
 
     shouldComponentUpdate(np, ns) {
+        const accountChanged =
+            np.account &&
+            this.props.account &&
+            np.account.get("id") !== this.props.account.get("id");
+        const transactionChanged =
+            JSON.stringify(np.transaction) !==
+            JSON.stringify(this.props.transaction);
+        if (ns.assets) {
+            if (!this.state.assets) {
+                return true;
+            }
+            if (ns.assets.length !== this.state.assets.length) {
+                return true;
+            }
+        }
+        if (ns.feeAsset) {
+            if (!this.state.feeAsset) {
+                return true;
+            }
+            if (ns.feeAsset.get("id") !== this.state.feeAsset.get("id")) {
+                return true;
+            }
+        }
         return (
-            ns.fee_amount !== this.state.fee_amount ||
-            ns.fee_asset_id !== this.state.fee_asset_id ||
+            accountChanged ||
+            transactionChanged ||
+            ns.calculatedFeeAmount !== this.state.calculatedFeeAmount ||
+            ns.assetsLoading !== this.state.assetsLoading ||
             ns.isModalVisible !== this.state.isModalVisible ||
-            ns.assets_fetched !== this.state.assets_fetched ||
-            ns.assets.length !== this.state.assets.length
+            ns.error !== this.state.error
         );
-    }
-
-    __are_equal_shallow(o1, o2) {
-        for (var p in o1) {
-            if (o1.hasOwnProperty(p)) {
-                if (o1[p] !== o2[p]) {
-                    return false;
-                }
-            }
-        }
-        for (var p in o2) {
-            if (o2.hasOwnProperty(p)) {
-                if (o1[p] !== o2[p]) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    _updateFee(
-        asset_id = null,
-        trxInfo = null,
-        onChange = null,
-        account = null
-    ) {
-        if (!asset_id) {
-            asset_id = this.state.fee_asset_id;
-        }
-        if (!trxInfo) {
-            trxInfo = this.props.trxInfo;
-        }
-        if (!onChange) {
-            onChange = this.props.onChange;
-        }
-        if (!account) {
-            account = this.props.account;
-        }
-        if (!account) return null; // not loaded yet
-
-        let feeID = asset_id;
-
-        this._getFees(this.state.assets, account, trxInfo);
-
-        const options = {
-            ...trxInfo,
-            accountID: account.get("id"),
-            feeID
-        };
-        if (
-            JSON.stringify(this.state.last_fee_check_params) !==
-            JSON.stringify(options)
-        ) {
-            checkFeeStatusAsync(options)
-                .then(({fee, hasPoolBalance}) => {
-                    this.setState({
-                        fee_amount: fee.getAmount({real: true}),
-                        fee_asset_id: fee.asset_id,
-                        error: !hasPoolBalance,
-                        last_fee_check_params: options
-                    });
-                    if (onChange) {
-                        onChange(fee);
-                    }
-                    this.setState({
-                        assets: this._getAvailableAssets(account),
-                        fee_amount: fee.getAmount({real: true}),
-                        fee_asset_id: fee.asset_id
-                    });
-                })
-                .catch(err => {
-                    console.warn(err);
-                });
-        }
     }
 
     _getAsset() {
@@ -140,59 +154,65 @@ class FeeAssetSelector extends React.Component {
                 : null;
     }
 
-    _getAvailableAssets(account = this.props.account) {
-        if (this.state.assets_fetched && this.state.assets.length > 0) {
+    _getSelectableAssets() {
+        return this.state.assets
+            ? this.state.assets
+            : [this._getAsset().get("symbol")];
+    }
+
+    async _syncAvailableAssets(opened, account = this.props.account) {
+        if (this.state.assets) {
             return this.state.assets;
         }
-        let fee_asset_types = [];
-        if (!(account && account.get("balances"))) {
-            return fee_asset_types;
-        }
-        const account_balances = account.get("balances").toJS();
-        fee_asset_types = Object.keys(account_balances).sort(utils.sortID);
-        for (let key in account_balances) {
-            let balanceObject = ChainStore.getObject(account_balances[key]);
-            if (balanceObject && balanceObject.get("balance") === 0) {
-                if (fee_asset_types.includes(key)) {
-                    fee_asset_types.splice(fee_asset_types.indexOf(key), 1);
-                }
+        this.setState({
+            assetsLoading: true
+        });
+        let possibleAssets = [this._getAsset().get("id")];
+        const accountBalances = account.get("balances").toJS();
+        const sortedKeys = Object.keys(accountBalances).sort(utils.sortID);
+        for (let i = 0, key; (key = sortedKeys[i]); i++) {
+            const balanceObject = await FetchChain(
+                "getObject",
+                accountBalances[key]
+            );
+            const requiredForFee = await this._calculateFee(key);
+            if (
+                balanceObject &&
+                balanceObject.get("balance") >=
+                    requiredForFee.fee.getAmount() &&
+                !possibleAssets.includes(key)
+            ) {
+                possibleAssets.push(key);
+                possibleAssets = possibleAssets.sort(utils.sortID);
+                this.setState({
+                    assets: possibleAssets
+                });
             }
         }
 
         this.setState({
-            balances: account_balances,
-            assets: fee_asset_types,
-            assets_fetched: true
+            assetsLoading: false
         });
-        this._updateFee(
-            this.state.fee_asset_id,
-            this.props.trxInfo,
-            this.props.onChange
-        );
-        return fee_asset_types;
     }
 
     componentDidMount() {
-        this.onAssetChange(this.state.fee_asset_id);
+        this._calculateFee();
     }
 
     componentDidUpdate(prevProps) {
-        const {fee_amount, fee_asset_id} = this.state;
-        const trxInfoChanged = !this.__are_equal_shallow(
-            prevProps.trxInfo,
-            this.props.trxInfo
-        );
-
+        const {calculatedFeeAmount} = this.state;
         const accountChanged =
             this.props.account &&
             prevProps.account.get("id") !== this.props.account.get("id");
-        const infoChanged = !this.__are_equal_shallow(
-            prevProps.trxInfo,
-            this.props.trxInfo
-        );
-        const noFeeSetYet = !fee_amount;
-        if (accountChanged || infoChanged || noFeeSetYet) {
-            this._updateFee();
+        const transactionChanged =
+            JSON.stringify(prevProps.transaction) !==
+            JSON.stringify(this.props.transaction);
+        const noFeeSetYet = !calculatedFeeAmount;
+        if (accountChanged) {
+            this.setState({assets: null});
+        }
+        if (transactionChanged || accountChanged || noFeeSetYet) {
+            this._calculateFee();
         }
     }
 
@@ -200,34 +220,40 @@ class FeeAssetSelector extends React.Component {
         // don't do async loading in componentWillReceiveProps
     }
 
-    onAssetChange(selected_asset) {
-        this.setState({fee_asset_id: selected_asset});
-        this._updateFee(
-            selected_asset,
-            this.props.trxInfo,
-            this.props.onChange
+    async onAssetChange(selectedAssetId) {
+        const asset = await FetchChain("getAsset", selectedAssetId);
+        this.setState(
+            {
+                feeAsset: asset
+            },
+            this._calculateFee.bind(this)
         );
     }
 
     render() {
         const currentAsset = this._getAsset();
-        const assets =
-            this.state.assets.length > 0
-                ? this.state.assets
-                : [currentAsset.get("id") || "1.3.0"];
-
-        let value = this.state.error
-            ? counterpart.translate("transfer.errors.insufficient")
-            : this.state.fee_amount;
+        // noPoolBalanceShort
+        let feeInputString = this.state.error
+            ? counterpart.translate("transfer.errors." + this.state.error.key)
+            : this.state.calculatedFeeAmount;
 
         const label = this.props.label ? (
             <div className="amount-selector-field--label">
                 {counterpart.translate(this.props.label)}
+                {this.state.error &&
+                    this.state.error.tooltip && (
+                        <Tooltip
+                            title={counterpart.translate(
+                                "transfer.errors." + this.state.error.tooltip
+                            )}
+                        >
+                            &nbsp; <Icon type="question-circle" />
+                        </Tooltip>
+                    )}
             </div>
         ) : null;
 
-        const canChangeFeeParams =
-            !this.props.selectDisabled && this.props.account;
+        const canChangeFeeParams = !this.props.disabled && !!this.props.account;
 
         const changeDefaultButton = (
             <Tooltip
@@ -247,7 +273,7 @@ class FeeAssetSelector extends React.Component {
             </Tooltip>
         );
 
-        const selectableAssets = assets ? assets : [currentAsset.get("symbol")];
+        const selectableAssets = this._getSelectableAssets();
 
         return (
             <div>
@@ -262,7 +288,7 @@ class FeeAssetSelector extends React.Component {
                                 width: "calc(100% - 130px)"
                             }}
                             disabled={true}
-                            value={value || ""}
+                            value={feeInputString || ""}
                             tabIndex={this.props.tabIndex}
                             suffix={
                                 this.state.error
@@ -272,33 +298,43 @@ class FeeAssetSelector extends React.Component {
                         />
 
                         <AssetSelect
+                            loading={this.state.assetsLoading}
+                            onDropdownVisibleChange={this._syncAvailableAssets.bind(
+                                this
+                            )}
                             style={{width: "130px"}}
                             selectStyle={{width: "100%"}}
                             value={currentAsset.get("symbol")}
                             assets={
-                                canChangeFeeParams ? Immutable.List(assets) : []
+                                canChangeFeeParams
+                                    ? Immutable.List(selectableAssets)
+                                    : []
                             }
                             onChange={this.onAssetChange.bind(this)}
                         />
                     </Input.Group>
                 </Form.Item>
 
-                <SetDefaultFeeAssetModal
-                    className="modal"
-                    show={this.state.isModalVisible}
-                    currentAccount={this.props.account}
-                    asset_types={this.state.assets.map(asset => ({
-                        asset,
-                        fee: this.state.fees[asset]
-                    }))}
-                    displayFees={true}
-                    forceDefault={false}
-                    current_asset={this.state.fee_asset_id}
-                    onChange={this.onAssetChange.bind(this)}
-                    close={() => {
-                        this.setState({isModalVisible: false});
-                    }}
-                />
+                {this.state.isModalVisible && (
+                    <SetDefaultFeeAssetModal
+                        className="modal"
+                        show={this.state.isModalVisible}
+                        currentAccount={this.props.account}
+                        asset_types={
+                            undefined //this.state.assets.map(asset => ({
+                            //asset,
+                            //fee: this.state.fees[asset]
+                            //}))
+                        }
+                        displayFees={true}
+                        forceDefault={false}
+                        current_asset={currentAsset.get("id")}
+                        onChange={this.onAssetChange.bind(this)}
+                        close={() => {
+                            this.setState({isModalVisible: false});
+                        }}
+                    />
+                )}
             </div>
         );
     }
@@ -308,32 +344,9 @@ class FeeAssetSelector extends React.Component {
     }
 }
 
-FeeAssetSelector.propTypes = {
-    // a translation key for the input label
-    label: PropTypes.string,
-    // account which pays fee
-    account: PropTypes.any,
-    // handler for changed Fee (asset, or amount)
-    onChange: PropTypes.func,
-    tabIndex: PropTypes.number,
-    selectDisabled: PropTypes.bool,
-    defaultFeeAsset: PropTypes.any.isRequired,
-    // Object wih data required for fee calculation
-    trxInfo: PropTypes.any
-};
-
-FeeAssetSelector.defaultProps = {
-    disabled: true,
-    tabIndex: 0,
-    selectDisabled: false,
-    label: "transfer.fee",
-    account: null,
-    trxInfo: {
-        type: "transfer",
-        options: null,
-        data: {}
-    }
-};
+FeeAssetSelector = debounceRender(FeeAssetSelector, 150, {
+    leading: false
+});
 
 FeeAssetSelector = AssetWrapper(FeeAssetSelector, {
     propNames: ["defaultFeeAsset"]


### PR DESCRIPTION
This PR closes #2756 (overrides previous PR)

This PR contains a significant larger change to the structure, most notable is the usage of `fetchChainObjects`, recurring quering even if account does not exists and a few code cleanups.

Workings are as follows
- Component mounts and adds favorites and contacts to the searchResult list through `_addToSearch`.
- User types an input and it gets added to teh searchResults list, which will hold `_fetchAccounts` for 250ms to prevent unnecessary queries while the user still inputs data.
- `_fetchAccounts` will query all accounts still missing and process them. Any remaining which have failed (produced no return due to slow node non existing account) will be queried again, up to `max_fails`.
- While query is running, a spinner will be visible at the end of the input.



### Changelog

```
+ Query List
+ Query Cache w/ max query limitor
+ Require active select on Typeahead
+ Loading indicator when query running
+ Delayed querying on input
* Condensed code
* Removed unused code
* Fetch array of objects instead of single
* Results object creation changes
* Changes to error handling
* AccountImage default sizes  