### PR TITLE
#2930 make collateral positions easier accessable

### DIFF
--- a/app/assets/stylesheets/components/_asset.scss
+++ b/app/assets/stylesheets/components/_asset.scss
@@ -24,3 +24,11 @@ div.asset-page {
         }
     }
 }
+.asset-collapse {
+    .ant-collapse-item {
+        margin-bottom: 16px;
+        .ant-collapse-header {
+            padding-left: 40px !important;
+        }
+    }
+}

--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -2635,6 +2635,16 @@
     .modal--transaction-confirm {
         zindex: 10000; // make transaction confirm modal above another modals
     }
+
+    .asset-collapse {
+        .ant-collapse-header {
+            background: $panel-bg-color;
+            color: $primary-text-color !important;            
+            border: solid 1.2px $panel-bg-color !important;
+        }
+    }
+
+
 }
 .rc-time-picker-panel {
     z-index: 9999 !important;

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -25,8 +25,13 @@ import AssetPublishFeed from "./AssetPublishFeed";
 import AssetResolvePrediction from "./AssetResolvePrediction";
 import BidCollateralOperation from "./BidCollateralOperation";
 import {Tab, Tabs} from "../Utility/Tabs";
-import {Tooltip, Icon, Table, Tabs as AntTabs} from "bitshares-ui-style-guide";
-import {Collapse} from "antd";
+import {
+    Tooltip,
+    Icon,
+    Table,
+    Tabs as AntTabs,
+    Collapse
+} from "bitshares-ui-style-guide";
 const {Panel} = Collapse;
 // TODO: Replace remaining old style Tabs with new
 
@@ -507,20 +512,20 @@ class Asset extends React.Component {
             flagBooleans["charge_market_fee"] &&
             options.extensions &&
             options.extensions.reward_percent >= 0 ? (
-                    <tr>
-                        <td>
-                            <Tooltip
-                                title={counterpart.translate(
-                                    "account.user_issued_assets.reward_percent_tooltip"
-                                )}
-                            >
-                                <Translate content="explorer.asset.summary.market_fee_referral_reward_percent" />{" "}
-                                <Icon type="question-circle" theme="filled" />
-                            </Tooltip>
-                        </td>
-                        <td> {options.extensions.reward_percent / 100.0} % </td>
-                    </tr>
-                ) : null;
+                <tr>
+                    <td>
+                        <Tooltip
+                            title={counterpart.translate(
+                                "account.user_issued_assets.reward_percent_tooltip"
+                            )}
+                        >
+                            <Translate content="explorer.asset.summary.market_fee_referral_reward_percent" />{" "}
+                            <Icon type="question-circle" theme="filled" />
+                        </Tooltip>
+                    </td>
+                    <td> {options.extensions.reward_percent / 100.0} % </td>
+                </tr>
+            ) : null;
 
         return (
             <div className="asset-card no-padding">
@@ -869,8 +874,8 @@ class Asset extends React.Component {
                                 <td>
                                     {settlement_fund_collateral_ratio
                                         ? settlement_fund_collateral_ratio.toFixed(
-                                            6
-                                        )
+                                              6
+                                          )
                                         : "-"}
                                 </td>
                             </tr>
@@ -1010,14 +1015,14 @@ class Asset extends React.Component {
                                     {currentSettled == 0
                                         ? 100
                                         : Math.round(
-                                            100 -
+                                              100 -
                                                   (currentSettled /
                                                       (currentSupply *
                                                           (maxSettlementVolume /
                                                               10000))) *
                                                       100,
-                                            2
-                                        )}
+                                              2
+                                          )}
                                     %
                                 </td>
                             </tr>
@@ -1305,49 +1310,49 @@ class Asset extends React.Component {
                 <br />
                 {!!options.blacklist_authorities &&
                     !!options.blacklist_authorities.length && (
-                    <React.Fragment>
-                        <Translate content="explorer.asset.permissions.blacklist_authorities" />
+                        <React.Fragment>
+                            <Translate content="explorer.asset.permissions.blacklist_authorities" />
                             : &nbsp;
-                        {this.renderAuthorityList(
-                            options.blacklist_authorities
-                        )}
-                    </React.Fragment>
-                )}
+                            {this.renderAuthorityList(
+                                options.blacklist_authorities
+                            )}
+                        </React.Fragment>
+                    )}
                 {!!options.blacklist_markets &&
                     !!options.blacklist_markets.length && (
-                    <React.Fragment>
-                        <br />
-                        <Translate content="explorer.asset.permissions.blacklist_markets" />
+                        <React.Fragment>
+                            <br />
+                            <Translate content="explorer.asset.permissions.blacklist_markets" />
                             : &nbsp;
-                        {this.renderMarketList(
-                            asset,
-                            options.blacklist_markets
-                        )}
-                    </React.Fragment>
-                )}
+                            {this.renderMarketList(
+                                asset,
+                                options.blacklist_markets
+                            )}
+                        </React.Fragment>
+                    )}
                 {!!options.whitelist_authorities &&
                     !!options.whitelist_authorities.length && (
-                    <React.Fragment>
-                        <br />
-                        <Translate content="explorer.asset.permissions.whitelist_authorities" />
+                        <React.Fragment>
+                            <br />
+                            <Translate content="explorer.asset.permissions.whitelist_authorities" />
                             : &nbsp;
-                        {this.renderAuthorityList(
-                            options.whitelist_authorities
-                        )}
-                    </React.Fragment>
-                )}
+                            {this.renderAuthorityList(
+                                options.whitelist_authorities
+                            )}
+                        </React.Fragment>
+                    )}
                 {!!options.whitelist_markets &&
                     !!options.whitelist_markets.length && (
-                    <React.Fragment>
-                        <br />
-                        <Translate content="explorer.asset.permissions.whitelist_markets" />
+                        <React.Fragment>
+                            <br />
+                            <Translate content="explorer.asset.permissions.whitelist_markets" />
                             : &nbsp;
-                        {this.renderMarketList(
-                            asset,
-                            options.whitelist_markets
-                        )}
-                    </React.Fragment>
-                )}
+                            {this.renderMarketList(
+                                asset,
+                                options.whitelist_markets
+                            )}
+                        </React.Fragment>
+                    )}
             </div>
         ) : null;
 
@@ -1381,7 +1386,10 @@ class Asset extends React.Component {
                     </table>
 
                     <br />
-                    {this.renderPermissionIndicators(permissionBooleans, bitNames)}
+                    {this.renderPermissionIndicators(
+                        permissionBooleans,
+                        bitNames
+                    )}
                     <br />
 
                     {whiteLists}
@@ -2072,7 +2080,7 @@ class Asset extends React.Component {
                     {this.state.activeFeedTab == "feed"
                         ? this._renderFeedTable(asset)
                         : null}
-                </AntTabs.TabPane>                
+                </AntTabs.TabPane>
             </AntTabs>
         );
     }
@@ -2149,8 +2157,8 @@ class Asset extends React.Component {
 
                                             {this.state.showCollateralBidInInfo
                                                 ? this.renderCollateralBid(
-                                                    asset
-                                                )
+                                                      asset
+                                                  )
                                                 : null}
                                         </Collapse>
                                     </div>
@@ -2213,10 +2221,10 @@ class AssetContainer extends React.Component {
         }
         let backingAsset = this.props.asset.has("bitasset")
             ? this.props.asset.getIn([
-                "bitasset",
-                "options",
-                "short_backing_asset"
-            ])
+                  "bitasset",
+                  "options",
+                  "short_backing_asset"
+              ])
             : "1.3.0";
         return <Asset {...this.props} backingAsset={backingAsset} />;
     }

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -352,8 +352,8 @@ class Asset extends React.Component {
         let preferredMarket = description.market
             ? description.market
             : core_asset
-            ? core_asset.get("symbol")
-            : "BTS";
+                ? core_asset.get("symbol")
+                : "BTS";
         if (isPrediction) {
             preferredMarket = ChainStore.getAsset(
                 asset.bitasset.options.short_backing_asset
@@ -1525,8 +1525,8 @@ class Asset extends React.Component {
                                     median_offset > 0
                                         ? "txtlabel success"
                                         : median_offset < 0
-                                        ? "txtlabel warning"
-                                        : "txtlabel"
+                                            ? "txtlabel warning"
+                                            : "txtlabel"
                                 }
                             >
                                 {median_offset}%
@@ -2040,7 +2040,6 @@ class Asset extends React.Component {
 
         return (
             <Tabs
-                type="card"
                 onChange={this._setFeedTab.bind(this)}
                 activeKey={this.state.activeFeedTab}
             >
@@ -2110,7 +2109,6 @@ class Asset extends React.Component {
                         </div>
 
                         <Tabs
-                            type="card"
                             onChange={this._setAssetTab.bind(this)}
                             activeKey={this.state.activeAssetTab}
                             className="grid-block vertical"

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -77,7 +77,7 @@ class Asset extends React.Component {
             sortDirection: true,
             showCollateralBidInInfo: false,
             cumulativeGrouping: false,
-            activeFeedTab: "feed"
+            activeFeedTab: "margin"
         };
     }
 
@@ -2051,16 +2051,6 @@ class Asset extends React.Component {
             >
                 <AntTabs.TabPane
                     tab={counterpart.translate(
-                        "explorer.asset.price_feed_data.title"
-                    )}
-                    key="feed"
-                >
-                    {this.state.activeFeedTab == "feed"
-                        ? this._renderFeedTable(asset)
-                        : null}
-                </AntTabs.TabPane>
-                <AntTabs.TabPane
-                    tab={counterpart.translate(
                         isGlobalSettlement
                             ? "explorer.asset.collateral_bid.title"
                             : "explorer.asset.margin_positions.title"
@@ -2073,6 +2063,16 @@ class Asset extends React.Component {
                             : this._renderMarginTable()
                         : null}
                 </AntTabs.TabPane>
+                <AntTabs.TabPane
+                    tab={counterpart.translate(
+                        "explorer.asset.price_feed_data.title"
+                    )}
+                    key="feed"
+                >
+                    {this.state.activeFeedTab == "feed"
+                        ? this._renderFeedTable(asset)
+                        : null}
+                </AntTabs.TabPane>                
             </AntTabs>
         );
     }

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -24,16 +24,8 @@ import AssetOwnerUpdate from "./AssetOwnerUpdate";
 import AssetPublishFeed from "./AssetPublishFeed";
 import AssetResolvePrediction from "./AssetResolvePrediction";
 import BidCollateralOperation from "./BidCollateralOperation";
-import {Tab, Tabs} from "../Utility/Tabs";
-import {
-    Tooltip,
-    Icon,
-    Table,
-    Tabs as AntTabs,
-    Collapse
-} from "bitshares-ui-style-guide";
+import {Tooltip, Icon, Table, Tabs, Collapse} from "bitshares-ui-style-guide";
 const {Panel} = Collapse;
-// TODO: Replace remaining old style Tabs with new
 
 class AssetFlag extends React.Component {
     render() {
@@ -82,7 +74,8 @@ class Asset extends React.Component {
             sortDirection: true,
             showCollateralBidInInfo: false,
             cumulativeGrouping: false,
-            activeFeedTab: "margin"
+            activeFeedTab: "margin",
+            activeAssetTab: "info"
         };
     }
 
@@ -359,8 +352,8 @@ class Asset extends React.Component {
         let preferredMarket = description.market
             ? description.market
             : core_asset
-                ? core_asset.get("symbol")
-                : "BTS";
+            ? core_asset.get("symbol")
+            : "BTS";
         if (isPrediction) {
             preferredMarket = ChainStore.getAsset(
                 asset.bitasset.options.short_backing_asset
@@ -1113,50 +1106,42 @@ class Asset extends React.Component {
 
     renderAssetOwnerUpdate(asset) {
         return (
-            <div
-                className="grid-content small-no-padding"
-                style={{overflowY: "visible"}}
+            <Panel
+                header={
+                    <Translate content="account.user_issued_assets.update_owner" />
+                }
             >
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="account.user_issued_assets.update_owner" />
-                    </div>
-                    <Translate
-                        component="p"
-                        content="account.user_issued_assets.update_owner_text"
-                        asset={asset.symbol}
-                    />
-                    <AssetOwnerUpdate
-                        asset={asset}
-                        account={this.props.currentAccount}
-                        currentOwner={asset.issuer}
-                    />
-                </div>
-            </div>
+                <Translate
+                    component="p"
+                    content="account.user_issued_assets.update_owner_text"
+                    asset={asset.symbol}
+                />
+                <AssetOwnerUpdate
+                    asset={asset}
+                    account={this.props.currentAccount}
+                    currentOwner={asset.issuer}
+                />
+            </Panel>
         );
     }
 
     renderFeedPublish(asset) {
         return (
-            <div
-                className="grid-content small-no-padding"
-                style={{overflowY: "visible"}}
+            <Panel
+                header={
+                    <Translate content="transaction.trxTypes.asset_publish_feed" />
+                }
             >
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="transaction.trxTypes.asset_publish_feed" />
-                    </div>
-                    <Translate
-                        component="p"
-                        content="explorer.asset.feed_producer_text"
-                    />
-                    <AssetPublishFeed
-                        asset={asset.id}
-                        account={this.props.currentAccount}
-                        currentOwner={asset.issuer}
-                    />
-                </div>
-            </div>
+                <Translate
+                    component="p"
+                    content="explorer.asset.feed_producer_text"
+                />
+                <AssetPublishFeed
+                    asset={asset.id}
+                    account={this.props.currentAccount}
+                    currentOwner={asset.issuer}
+                />
+            </Panel>
         );
     }
 
@@ -1194,23 +1179,20 @@ class Asset extends React.Component {
 
     renderFeePoolFunding(asset) {
         return (
-            <div className="grid-content small-no-padding">
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="explorer.asset.fee_pool.fund" />
-                    </div>
-                    <Translate
-                        component="p"
-                        content="explorer.asset.fee_pool.fund_text"
-                        asset={asset.symbol}
-                    />
-                    <FeePoolOperation
-                        asset={asset.symbol}
-                        funderAccountName={this.props.currentAccount}
-                        hideBalance
-                    />
-                </div>
-            </div>
+            <Panel
+                header={<Translate content="explorer.asset.fee_pool.fund" />}
+            >
+                <Translate
+                    component="p"
+                    content="explorer.asset.fee_pool.fund_text"
+                    asset={asset.symbol}
+                />
+                <FeePoolOperation
+                    asset={asset.symbol}
+                    funderAccountName={this.props.currentAccount}
+                    hideBalance
+                />
+            </Panel>
         );
     }
 
@@ -1218,20 +1200,19 @@ class Asset extends React.Component {
         let dynamic = this.props.getDynamicObject(asset.dynamic_asset_data_id);
         if (dynamic) dynamic = dynamic.toJS();
         return (
-            <div className="grid-content small-no-padding">
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="explorer.asset.fee_pool.claim_balance" />
-                    </div>
-                    <FeePoolOperation
-                        asset={asset.symbol}
-                        funderAccountName={this.props.currentAccount}
-                        dynamic={dynamic}
-                        hideBalance
-                        type="claim"
-                    />
-                </div>
-            </div>
+            <Panel
+                header={
+                    <Translate content="explorer.asset.fee_pool.claim_balance" />
+                }
+            >
+                <FeePoolOperation
+                    asset={asset.symbol}
+                    funderAccountName={this.props.currentAccount}
+                    dynamic={dynamic}
+                    hideBalance
+                    type="claim"
+                />
+            </Panel>
         );
     }
 
@@ -1239,20 +1220,19 @@ class Asset extends React.Component {
         let dynamic = this.props.getDynamicObject(asset.dynamic_asset_data_id);
         if (dynamic) dynamic = dynamic.toJS();
         return (
-            <div className="grid-content small-no-padding">
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="transaction.trxTypes.asset_claim_fees" />
-                    </div>
-                    <FeePoolOperation
-                        asset={asset.symbol}
-                        dynamic={dynamic}
-                        funderAccountName={this.props.currentAccount}
-                        hideBalance
-                        type="claim_fees"
-                    />
-                </div>
-            </div>
+            <Panel
+                header={
+                    <Translate content="transaction.trxTypes.asset_claim_fees" />
+                }
+            >
+                <FeePoolOperation
+                    asset={asset.symbol}
+                    dynamic={dynamic}
+                    funderAccountName={this.props.currentAccount}
+                    hideBalance
+                    type="claim_fees"
+                />
+            </Panel>
         );
     }
 
@@ -1545,8 +1525,8 @@ class Asset extends React.Component {
                                     median_offset > 0
                                         ? "txtlabel success"
                                         : median_offset < 0
-                                            ? "txtlabel warning"
-                                            : "txtlabel"
+                                        ? "txtlabel warning"
+                                        : "txtlabel"
                                 }
                             >
                                 {median_offset}%
@@ -2039,6 +2019,12 @@ class Asset extends React.Component {
         });
     }
 
+    _setAssetTab(tab) {
+        this.setState({
+            activeAssetTab: tab
+        });
+    }
+
     renderFeedTables(asset) {
         var bitAsset = asset.bitasset;
         if (
@@ -2053,11 +2039,12 @@ class Asset extends React.Component {
         let isGlobalSettlement = bitAsset.settlement_fund > 0 ? true : false;
 
         return (
-            <AntTabs
+            <Tabs
+                type="card"
                 onChange={this._setFeedTab.bind(this)}
                 activeKey={this.state.activeFeedTab}
             >
-                <AntTabs.TabPane
+                <Tabs.TabPane
                     tab={counterpart.translate(
                         isGlobalSettlement
                             ? "explorer.asset.collateral_bid.title"
@@ -2070,8 +2057,8 @@ class Asset extends React.Component {
                             ? this._renderCollBidTable()
                             : this._renderMarginTable()
                         : null}
-                </AntTabs.TabPane>
-                <AntTabs.TabPane
+                </Tabs.TabPane>
+                <Tabs.TabPane
                     tab={counterpart.translate(
                         "explorer.asset.price_feed_data.title"
                     )}
@@ -2080,31 +2067,27 @@ class Asset extends React.Component {
                     {this.state.activeFeedTab == "feed"
                         ? this._renderFeedTable(asset)
                         : null}
-                </AntTabs.TabPane>
-            </AntTabs>
+                </Tabs.TabPane>
+            </Tabs>
         );
     }
 
     renderAssetResolvePrediction(asset) {
         return (
-            <div
-                className="grid-content small-no-padding"
-                style={{overflowY: "visible"}}
+            <Panel
+                header={
+                    <Translate content="account.user_issued_assets.resolve_prediction" />
+                }
             >
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="account.user_issued_assets.resolve_prediction" />
-                    </div>
-                    <Translate
-                        component="p"
-                        content="account.user_issued_assets.resolve_prediction_text"
-                    />
-                    <AssetResolvePrediction
-                        asset={asset}
-                        account={this.props.currentAccount}
-                    />
-                </div>
-            </div>
+                <Translate
+                    component="p"
+                    content="account.user_issued_assets.resolve_prediction_text"
+                />
+                <AssetResolvePrediction
+                    asset={asset}
+                    account={this.props.currentAccount}
+                />
+            </Panel>
         );
     }
 
@@ -2127,13 +2110,17 @@ class Asset extends React.Component {
                         </div>
 
                         <Tabs
-                            setting="assetDataTabs"
+                            type="card"
+                            onChange={this._setAssetTab.bind(this)}
+                            activeKey={this.state.activeAssetTab}
                             className="grid-block vertical"
-                            tabsClass="bordered-header content-block"
-                            contentClass="tab-no-background"
-                            segmented={false}
                         >
-                            <Tab title="explorer.asset.info">
+                            <Tabs.TabPane
+                                tab={counterpart.translate(
+                                    "explorer.asset.info"
+                                )}
+                                key="info"
+                            >
                                 <div
                                     className="grid-block vertical large-horizontal medium-up-1 large-up-2"
                                     style={{paddingTop: "1rem"}}
@@ -2164,12 +2151,14 @@ class Asset extends React.Component {
                                     </div>
                                 </div>
                                 {priceFeedData ? priceFeedData : null}
-                            </Tab>
-                            <Tab title="explorer.asset.actions">
-                                <div
-                                    className="grid-block vertical large-horizontal medium-up-1 large-up-2"
-                                    style={{paddingTop: "1rem"}}
-                                >
+                            </Tabs.TabPane>
+                            <Tabs.TabPane
+                                tab={counterpart.translate(
+                                    "explorer.asset.actions"
+                                )}
+                                key="actions"
+                            >
+                                <Collapse className="asset-collapse">
                                     {this.renderFeePoolFunding(asset)}
                                     {this.renderFeePoolClaiming(asset)}
                                     {this.renderFeesClaiming(asset)}
@@ -2184,8 +2173,8 @@ class Asset extends React.Component {
                                         this.renderAssetResolvePrediction(
                                             asset
                                         )}
-                                </div>
-                            </Tab>
+                                </Collapse>
+                            </Tabs.TabPane>
                         </Tabs>
                     </div>
                 </div>

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -26,6 +26,8 @@ import AssetResolvePrediction from "./AssetResolvePrediction";
 import BidCollateralOperation from "./BidCollateralOperation";
 import {Tab, Tabs} from "../Utility/Tabs";
 import {Tooltip, Icon, Table, Tabs as AntTabs} from "bitshares-ui-style-guide";
+import {Collapse} from "antd";
+const {Panel} = Collapse;
 // TODO: Replace remaining old style Tabs with new
 
 class AssetFlag extends React.Component {
@@ -505,20 +507,20 @@ class Asset extends React.Component {
             flagBooleans["charge_market_fee"] &&
             options.extensions &&
             options.extensions.reward_percent >= 0 ? (
-                <tr>
-                    <td>
-                        <Tooltip
-                            title={counterpart.translate(
-                                "account.user_issued_assets.reward_percent_tooltip"
-                            )}
-                        >
-                            <Translate content="explorer.asset.summary.market_fee_referral_reward_percent" />{" "}
-                            <Icon type="question-circle" theme="filled" />
-                        </Tooltip>
-                    </td>
-                    <td> {options.extensions.reward_percent / 100.0} % </td>
-                </tr>
-            ) : null;
+                    <tr>
+                        <td>
+                            <Tooltip
+                                title={counterpart.translate(
+                                    "account.user_issued_assets.reward_percent_tooltip"
+                                )}
+                            >
+                                <Translate content="explorer.asset.summary.market_fee_referral_reward_percent" />{" "}
+                                <Icon type="question-circle" theme="filled" />
+                            </Tooltip>
+                        </td>
+                        <td> {options.extensions.reward_percent / 100.0} % </td>
+                    </tr>
+                ) : null;
 
         return (
             <div className="asset-card no-padding">
@@ -576,7 +578,6 @@ class Asset extends React.Component {
     }
 
     renderPriceFeed(asset) {
-        var title = <Translate content="explorer.asset.price_feed.title" />;
         var bitAsset = asset.bitasset;
         if (!("current_feed" in bitAsset)) return <div header={title} />;
         var currentFeed = bitAsset.current_feed;
@@ -585,10 +586,15 @@ class Asset extends React.Component {
             assetUtils.extractRawFeedPrice(asset)
         );
 
-        return (
-            <div className="asset-card no-padding">
-                <div className="card-divider">{title}</div>
+        var title = (
+            <div>
+                <Translate content="explorer.asset.price_feed.title" />
+                <span className="float-right">{feedPrice}</span>
+            </div>
+        );
 
+        return (
+            <Panel header={title}>
                 <table
                     className="table key-value-table table-hover"
                     style={{padding: "1.2rem"}}
@@ -634,7 +640,7 @@ class Asset extends React.Component {
                         </tr>
                     </tbody>
                 </table>
-            </div>
+            </Panel>
         );
     }
 
@@ -674,7 +680,6 @@ class Asset extends React.Component {
     }
 
     renderSettlement(asset) {
-        var title = <Translate content="explorer.asset.settlement.title" />;
         var bitAsset = asset.bitasset;
         if (!("current_feed" in bitAsset)) return <div header={title} />;
 
@@ -793,9 +798,17 @@ class Asset extends React.Component {
             );
         }
 
+        var title = (
+            <div>
+                <Translate content="explorer.asset.settlement.title" />
+                <span className="float-right">
+                    {isGlobalSettle ? settlementPrice : settlePrice}
+                </span>
+            </div>
+        );
+
         return (
-            <div className="asset-card no-padding">
-                <div className="card-divider">{title}</div>
+            <Panel header={title}>
                 {isGlobalSettle && (
                     <Translate
                         component="p"
@@ -856,8 +869,8 @@ class Asset extends React.Component {
                                 <td>
                                     {settlement_fund_collateral_ratio
                                         ? settlement_fund_collateral_ratio.toFixed(
-                                              6
-                                          )
+                                            6
+                                        )
                                         : "-"}
                                 </td>
                             </tr>
@@ -997,21 +1010,21 @@ class Asset extends React.Component {
                                     {currentSettled == 0
                                         ? 100
                                         : Math.round(
-                                              100 -
+                                            100 -
                                                   (currentSettled /
                                                       (currentSupply *
                                                           (maxSettlementVolume /
                                                               10000))) *
                                                       100,
-                                              2
-                                          )}
+                                            2
+                                        )}
                                     %
                                 </td>
                             </tr>
                         </tbody>
                     )}
                 </table>
-            </div>
+            </Panel>
         );
     }
 
@@ -1022,61 +1035,74 @@ class Asset extends React.Component {
         const core = ChainStore.getAsset("1.3.0");
 
         return (
-            <div className="asset-card no-padding">
-                <div className="card-divider">
-                    {<Translate content="explorer.asset.fee_pool.title" />}
+            <Panel
+                header={
+                    <div>
+                        <Translate content="explorer.asset.fee_pool.title" />
+                        {dynamic ? (
+                            <span className="float-right">
+                                <FormattedAsset
+                                    asset="1.3.0"
+                                    amount={dynamic.fee_pool}
+                                />
+                            </span>
+                        ) : null}
+                    </div>
+                }
+            >
+                <div>
+                    <Translate
+                        component="p"
+                        content="explorer.asset.fee_pool.pool_text"
+                        unsafe
+                        asset={asset.symbol}
+                        core={core.get("symbol")}
+                    />
+                    <table
+                        className="table key-value-table"
+                        style={{padding: "1.2rem"}}
+                    >
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <Translate content="explorer.asset.fee_pool.core_exchange_rate" />
+                                </td>
+                                <td>
+                                    {this.formattedPrice(
+                                        options.core_exchange_rate
+                                    )}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <Translate content="explorer.asset.fee_pool.pool_balance" />
+                                </td>
+                                <td>
+                                    {dynamic ? (
+                                        <FormattedAsset
+                                            asset="1.3.0"
+                                            amount={dynamic.fee_pool}
+                                        />
+                                    ) : null}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <Translate content="explorer.asset.fee_pool.unclaimed_issuer_income" />
+                                </td>
+                                <td>
+                                    {dynamic ? (
+                                        <FormattedAsset
+                                            asset={asset.id}
+                                            amount={dynamic.accumulated_fees}
+                                        />
+                                    ) : null}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
-                <Translate
-                    component="p"
-                    content="explorer.asset.fee_pool.pool_text"
-                    unsafe
-                    asset={asset.symbol}
-                    core={core.get("symbol")}
-                />
-                <table
-                    className="table key-value-table"
-                    style={{padding: "1.2rem"}}
-                >
-                    <tbody>
-                        <tr>
-                            <td>
-                                <Translate content="explorer.asset.fee_pool.core_exchange_rate" />
-                            </td>
-                            <td>
-                                {this.formattedPrice(
-                                    options.core_exchange_rate
-                                )}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <Translate content="explorer.asset.fee_pool.pool_balance" />
-                            </td>
-                            <td>
-                                {dynamic ? (
-                                    <FormattedAsset
-                                        asset="1.3.0"
-                                        amount={dynamic.fee_pool}
-                                    />
-                                ) : null}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <Translate content="explorer.asset.fee_pool.unclaimed_issuer_income" />
-                            </td>
-                            <td>
-                                {dynamic ? (
-                                    <FormattedAsset
-                                        asset={asset.id}
-                                        amount={dynamic.accumulated_fees}
-                                    />
-                                ) : null}
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            </Panel>
         );
     }
 
@@ -1131,36 +1157,33 @@ class Asset extends React.Component {
 
     renderCollateralBid(asset) {
         return (
-            <div className="grid-content small-no-padding">
-                <div className="asset-card no-padding">
-                    <div className="card-divider">
-                        <Translate content="explorer.asset.collateral.bid" />
-                    </div>
-                    <Translate
-                        component="p"
-                        content="explorer.asset.collateral.bid_text"
-                        asset={asset.symbol}
-                    />
+            <Panel
+                header={<Translate content="explorer.asset.collateral.bid" />}
+            >
+                <Translate
+                    component="p"
+                    content="explorer.asset.collateral.bid_text"
+                    asset={asset.symbol}
+                />
 
-                    <Translate
-                        component="p"
-                        content="explorer.asset.settlement.gs_included_on_revival"
-                    />
+                <Translate
+                    component="p"
+                    content="explorer.asset.settlement.gs_included_on_revival"
+                />
 
-                    <Translate
-                        component="p"
-                        content="explorer.asset.collateral.remove_bid"
-                    />
+                <Translate
+                    component="p"
+                    content="explorer.asset.collateral.remove_bid"
+                />
 
-                    <BidCollateralOperation
-                        asset={asset.symbol}
-                        core={asset.bitasset.options.short_backing_asset}
-                        funderAccountName={this.props.currentAccount}
-                        onUpdate={this.updateOnCollateralBid.bind(this)}
-                        hideBalance
-                    />
-                </div>
-            </div>
+                <BidCollateralOperation
+                    asset={asset.symbol}
+                    core={asset.bitasset.options.short_backing_asset}
+                    funderAccountName={this.props.currentAccount}
+                    onUpdate={this.updateOnCollateralBid.bind(this)}
+                    hideBalance
+                />
+            </Panel>
         );
     }
 
@@ -1282,49 +1305,49 @@ class Asset extends React.Component {
                 <br />
                 {!!options.blacklist_authorities &&
                     !!options.blacklist_authorities.length && (
-                        <React.Fragment>
-                            <Translate content="explorer.asset.permissions.blacklist_authorities" />
+                    <React.Fragment>
+                        <Translate content="explorer.asset.permissions.blacklist_authorities" />
                             : &nbsp;
-                            {this.renderAuthorityList(
-                                options.blacklist_authorities
-                            )}
-                        </React.Fragment>
-                    )}
+                        {this.renderAuthorityList(
+                            options.blacklist_authorities
+                        )}
+                    </React.Fragment>
+                )}
                 {!!options.blacklist_markets &&
                     !!options.blacklist_markets.length && (
-                        <React.Fragment>
-                            <br />
-                            <Translate content="explorer.asset.permissions.blacklist_markets" />
+                    <React.Fragment>
+                        <br />
+                        <Translate content="explorer.asset.permissions.blacklist_markets" />
                             : &nbsp;
-                            {this.renderMarketList(
-                                asset,
-                                options.blacklist_markets
-                            )}
-                        </React.Fragment>
-                    )}
+                        {this.renderMarketList(
+                            asset,
+                            options.blacklist_markets
+                        )}
+                    </React.Fragment>
+                )}
                 {!!options.whitelist_authorities &&
                     !!options.whitelist_authorities.length && (
-                        <React.Fragment>
-                            <br />
-                            <Translate content="explorer.asset.permissions.whitelist_authorities" />
+                    <React.Fragment>
+                        <br />
+                        <Translate content="explorer.asset.permissions.whitelist_authorities" />
                             : &nbsp;
-                            {this.renderAuthorityList(
-                                options.whitelist_authorities
-                            )}
-                        </React.Fragment>
-                    )}
+                        {this.renderAuthorityList(
+                            options.whitelist_authorities
+                        )}
+                    </React.Fragment>
+                )}
                 {!!options.whitelist_markets &&
                     !!options.whitelist_markets.length && (
-                        <React.Fragment>
-                            <br />
-                            <Translate content="explorer.asset.permissions.whitelist_markets" />
+                    <React.Fragment>
+                        <br />
+                        <Translate content="explorer.asset.permissions.whitelist_markets" />
                             : &nbsp;
-                            {this.renderMarketList(
-                                asset,
-                                options.whitelist_markets
-                            )}
-                        </React.Fragment>
-                    )}
+                        {this.renderMarketList(
+                            asset,
+                            options.whitelist_markets
+                        )}
+                    </React.Fragment>
+                )}
             </div>
         ) : null;
 
@@ -1341,27 +1364,30 @@ class Asset extends React.Component {
         );
 
         return (
-            <div className="asset-card no-padding">
-                <div className="card-divider">
-                    {<Translate content="explorer.asset.permissions.title" />}
+            <Panel
+                header={
+                    <Translate content="explorer.asset.permissions.title" />
+                }
+            >
+                <div>
+                    <table
+                        className="table key-value-table table-hover"
+                        style={{padding: "1.2rem"}}
+                    >
+                        <tbody>
+                            {maxMarketFee}
+                            {maxSupply}
+                        </tbody>
+                    </table>
+
+                    <br />
+                    {this.renderPermissionIndicators(permissionBooleans, bitNames)}
+                    <br />
+
+                    {whiteLists}
+                    {whitelist_market_fee_sharing}
                 </div>
-                <table
-                    className="table key-value-table table-hover"
-                    style={{padding: "1.2rem"}}
-                >
-                    <tbody>
-                        {maxMarketFee}
-                        {maxSupply}
-                    </tbody>
-                </table>
-
-                <br />
-                {this.renderPermissionIndicators(permissionBooleans, bitNames)}
-                <br />
-
-                {whiteLists}
-                {whitelist_market_fee_sharing}
-            </div>
+            </Panel>
         );
     }
 
@@ -2107,32 +2133,27 @@ class Asset extends React.Component {
                                     <div className="grid-content small-no-padding">
                                         {this.renderSummary(asset)}
                                     </div>
+                                    <div>
+                                        <Collapse className="asset-collapse">
+                                            {this.renderPermissions(asset)}
 
-                                    <div className="grid-content small-no-padding">
-                                        {this.renderPermissions(asset)}
+                                            {this.renderFeePool(asset)}
+
+                                            {priceFeed
+                                                ? this.renderPriceFeed(asset)
+                                                : null}
+
+                                            {priceFeed
+                                                ? this.renderSettlement(asset)
+                                                : null}
+
+                                            {this.state.showCollateralBidInInfo
+                                                ? this.renderCollateralBid(
+                                                    asset
+                                                )
+                                                : null}
+                                        </Collapse>
                                     </div>
-
-                                    <div className="grid-content small-no-padding">
-                                        {this.renderFeePool(asset)}
-                                    </div>
-
-                                    {priceFeed ? (
-                                        <div className="grid-content small-no-padding">
-                                            {this.renderPriceFeed(asset)}
-                                        </div>
-                                    ) : null}
-
-                                    {priceFeed ? (
-                                        <div className="grid-content small-no-padding">
-                                            {this.renderSettlement(asset)}
-                                        </div>
-                                    ) : null}
-
-                                    {this.state.showCollateralBidInInfo ? (
-                                        <div className="grid-content small-no-padding">
-                                            {this.renderCollateralBid(asset)}
-                                        </div>
-                                    ) : null}
                                 </div>
                                 {priceFeedData ? priceFeedData : null}
                             </Tab>
@@ -2192,10 +2213,10 @@ class AssetContainer extends React.Component {
         }
         let backingAsset = this.props.asset.has("bitasset")
             ? this.props.asset.getIn([
-                  "bitasset",
-                  "options",
-                  "short_backing_asset"
-              ])
+                "bitasset",
+                "options",
+                "short_backing_asset"
+            ])
             : "1.3.0";
         return <Asset {...this.props} backingAsset={backingAsset} />;
     }


### PR DESCRIPTION
<h2>General</h2>
Closes #2930

https://github.com/blockchainprojects/bitshares-ui/pull/157

 - extended the collapsable approach to asset actions
 - played around with responsiveness on asset info
 - removed unused stylings

<h2>Bounty</h2>

Hours spent: 9
Bounty request: 3.5