### PR TITLE
#2498. BindToChainState rendering when required prop is missing

### DIFF
--- a/app/components/Utility/BindToChainState.jsx
+++ b/app/components/Utility/BindToChainState.jsx
@@ -618,18 +618,29 @@ function BindToChainState(Component, options = {}) {
             const props = omit(this.props, this.all_chain_props);
             for (let prop of this.required_props) {
                 if (this.state[prop] === undefined) {
-                    if (typeof options !== "undefined" && options.show_loader) {
+                    if (this.hasErrored) {
+                        return (
+                            <span style={{color: "red"}}>
+                                Error rendering component, please report (see
+                                browser console for details)
+                            </span>
+                        );
+                    } else if (
+                        typeof options !== "undefined" &&
+                        options.show_loader
+                    ) {
+                        console.error(
+                            "Required prop " +
+                                prop +
+                                " isn't given, but still loading, this indicates that the rendering transitions are not well defined"
+                        );
                         return (
                             <React.Fragment>
                                 <LoadingIndicator />
-                                <h3 className="text-center">Required prop "{prop}" isn't given</h3>
+                                <span cassName="text-center">
+                                    Component re-rendering ...
+                                </span>
                             </React.Fragment>
-                        );
-                    } else if (this.hasErrored) {
-                        return (
-                            <span>
-                                Error rendering component, please report
-                            </span>
                         );
                     } else {
                         // returning a temp component of the desired type prevents invariant violation errors, notably when rendering tr components

--- a/app/components/Utility/BindToChainState.jsx
+++ b/app/components/Utility/BindToChainState.jsx
@@ -619,7 +619,12 @@ function BindToChainState(Component, options = {}) {
             for (let prop of this.required_props) {
                 if (this.state[prop] === undefined) {
                     if (typeof options !== "undefined" && options.show_loader) {
-                        return <LoadingIndicator />;
+                        return (
+                            <React.Fragment>
+                                <LoadingIndicator />
+                                <h3 className="text-center">Required prop "{prop}" isn't given</h3>
+                            </React.Fragment>
+                        );
                     } else if (this.hasErrored) {
                         return (
                             <span>


### PR DESCRIPTION
<h2>General</h2>
Closes #2498 

Added error message when required prop is missing

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [x] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_
![image](https://user-images.githubusercontent.com/42674402/62709027-41019d00-b9fd-11e9-8c8c-0d88f3313f83.png)
