### PR TITLE
[1] Fix Export History

### DIFF
--- a/app/components/Account/RecentTransactions.jsx
+++ b/app/components/Account/RecentTransactions.jsx
@@ -1,6 +1,5 @@
 import React, {Fragment} from "react";
 import Translate from "react-translate-component";
-import {saveAs} from "file-saver";
 import ChainTypes from "../Utility/ChainTypes";
 import BindToChainState from "../Utility/BindToChainState";
 import utils from "common/utils";
@@ -18,7 +17,6 @@ import cnames from "classnames";
 import PropTypes from "prop-types";
 import PaginatedList from "../Utility/PaginatedList";
 const {operations} = grapheneChainTypes;
-import report from "bitshares-report";
 import LoadingIndicator from "../LoadingIndicator";
 import {Tooltip, Modal, Button, Select, Input} from "bitshares-ui-style-guide";
 const ops = Object.keys(operations);
@@ -275,6 +273,7 @@ class RecentTransactions extends React.Component {
                 accountHistoryError: null
             });
         } catch (err) {
+            console.log("ES Node error: " + err);
             this.setState({
                 fetchingAccountHistory: false,
                 accountHistoryError: err,

--- a/app/services/AccountHistoryExporter.js
+++ b/app/services/AccountHistoryExporter.js
@@ -68,22 +68,25 @@ class AccountHistoryExporter {
                 const type = ops[record.op.type];
                 const data = record.op.data;
 
-                switch (type) {
-                    case "vesting_balance_withdraw":
-                        data.amount = data.amount_;
-                        break;
+                // Data is sometimes null
+                if (data) {
+                    switch (type) {
+                        case "vesting_balance_withdraw":
+                            data.amount = data.amount_;
+                            break;
 
-                    case "transfer":
-                        data.amount = data.amount_;
-                        break;
-                }
-                switch (type) {
-                    default:
-                        recordData[trx_id] = {
-                            timestamp: new Date(record.block_time),
-                            type,
-                            data
-                        };
+                        case "transfer":
+                            data.amount = data.amount_;
+                            break;
+                    }
+                    switch (type) {
+                        default:
+                            recordData[trx_id] = {
+                                timestamp: new Date(record.block_time),
+                                type,
+                                data
+                            };
+                    }
                 }
             });
             start += res.length;


### PR DESCRIPTION
This PR fixes the export of account CSV issue.

When an ES node sends data back, an item can sometimes have a `{ data: null }` value, resulting in an error creating the exported file.