### PR TITLE
fix .get on undefined when loading asset directly

### DIFF
--- a/app/actions/LogsActions.js
+++ b/app/actions/LogsActions.js
@@ -10,7 +10,11 @@ class LogsActions {
     }
     getLogs() {
         return new Promise(resolve => {
-            resolve(JSON.parse(ss.get("logs", [])));
+            try {
+                resolve(JSON.parse(ss.get("logs", [])));
+            } catch (err) {
+                resolve(["Error loading logs from localStorage"]);
+            }
         });
     }
 }

--- a/app/components/Blockchain/Asset.jsx
+++ b/app/components/Blockchain/Asset.jsx
@@ -346,22 +346,22 @@ class Asset extends React.Component {
 
         // Add market link
         const core_asset = ChainStore.getAsset("1.3.0");
+        const core_asset_symbol =
+            !!core_asset && core_asset.get ? core_asset.get("symbol") : "BTS";
         let preferredMarket = description.market
             ? description.market
-            : core_asset
-                ? core_asset.get("symbol")
-                : "BTS";
+            : core_asset_symbol;
         if (asset.bitasset) {
             preferredMarket = ChainStore.getAsset(
                 asset.bitasset.options.short_backing_asset
             );
-            if (preferredMarket) {
+            if (!!preferredMarket && preferredMarket.get) {
                 preferredMarket = preferredMarket.get("symbol");
             } else {
-                preferredMarket = core_asset.get("symbol");
+                preferredMarket = core_asset_symbol;
             }
         }
-        if (asset.symbol === core_asset.get("symbol")) preferredMarket = "USD";
+        if (asset.symbol === core_asset_symbol) preferredMarket = "USD";
         if (urls && urls.length) {
             urls.forEach(url => {
                 let markdownUrl = `<a target="_blank" class="external-link" rel="noopener noreferrer" href="${url}">${url}</a>`;


### PR DESCRIPTION
for #3053

this is due to usage of chainstore.get method for lazy loading, which is unsuitable if not properly subscribed (should use fetch)

Signed-off-by: Stefan Schiessl <stefan.schiessl@blockchainprojectsbv.com>