### PR TITLE
Use BTC as default find-market search instead of OPEN

### DIFF
--- a/app/components/Exchange/MyMarkets.jsx
+++ b/app/components/Exchange/MyMarkets.jsx
@@ -354,7 +354,8 @@ class MyMarkets extends React.Component {
             nextState.activeTab === "find-market" &&
             !nextProps.searchAssets.size
         ) {
-            this._lookupAssets("BTC", true);
+            // disable auto search
+            // this._lookupAssets("BTC", true);
         }
 
         if (this.state.activeTab !== nextState.activeTab) {
@@ -419,7 +420,8 @@ class MyMarkets extends React.Component {
         this._setMinWidth();
 
         if (this.state.activeTab === "find-market") {
-            this._lookupAssets("BTC", true);
+            // disable auto search
+            // this._lookupAssets("BTC", true);
         }
 
         if (this.state.activeTab !== this.props.activeTab) {

--- a/app/components/Exchange/MyMarkets.jsx
+++ b/app/components/Exchange/MyMarkets.jsx
@@ -354,7 +354,7 @@ class MyMarkets extends React.Component {
             nextState.activeTab === "find-market" &&
             !nextProps.searchAssets.size
         ) {
-            this._lookupAssets("OPEN.", true);
+            this._lookupAssets("BTC", true);
         }
 
         if (this.state.activeTab !== nextState.activeTab) {
@@ -419,7 +419,7 @@ class MyMarkets extends React.Component {
         this._setMinWidth();
 
         if (this.state.activeTab === "find-market") {
-            this._lookupAssets("OPEN.", true);
+            this._lookupAssets("BTC", true);
         }
 
         if (this.state.activeTab !== this.props.activeTab) {


### PR DESCRIPTION
This would eliminate the behavior of reference UI pointing at defunct OPEN markets and make the default behavior gateway UIA and smartcoin MPA agnostic by pointing towards all Bitcoin markets.

I also suggest it be implemented in conjunction with:

`Use BTS as find market basic pair by froooze · Pull Request #3191`

So that then BTS is the default primary search token and all Bitcoin markets which pair to BTS are shown by default. 