### PR TITLE
Make bridge withdrawals based on mapping data

### DIFF
--- a/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -75,8 +75,8 @@ class ButtonConversion extends React.Component {
         let feeID = balances.has(defaultFeeAssetId)
             ? defaultFeeAssetId
             : balance
-                ? balance.get("asset_type")
-                : "1.3.0";
+            ? balance.get("asset_type")
+            : "1.3.0";
         return feeID;
     }
 
@@ -421,6 +421,7 @@ class ButtonWithdraw extends React.Component {
                         asset={this.props.asset.get("id")}
                         output_coin_name={this.props.output_coin_name}
                         output_coin_symbol={this.props.output_coin_symbol}
+                        input_coin_type={this.props.input_coin_type}
                         output_coin_type={this.props.output_coin_type}
                         output_supports_memos={this.props.output_supports_memos}
                         amount_to_withdraw={this.props.amount_to_withdraw}
@@ -460,6 +461,7 @@ class ButtonWithdrawContainer extends React.Component {
                 asset={this.props.asset}
                 output_coin_name={this.props.output_coin_name}
                 output_coin_symbol={this.props.output_coin_symbol}
+                input_coin_type={this.props.input_coin_type}
                 output_coin_type={this.props.output_coin_type}
                 output_supports_memos={this.props.output_supports_memos}
                 amount_to_withdraw={this.props.amount_to_withdraw}
@@ -2413,6 +2415,9 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                                 this.state.coins_by_type[
                                     this.state.withdraw_output_coin_type
                                 ].symbol
+                            }
+                            input_coin_type={
+                                this.state.withdraw_input_coin_type
                             }
                             output_coin_type={
                                 this.state.withdraw_output_coin_type

--- a/app/components/DepositWithdraw/blocktrades/WithdrawModalBlocktrades.jsx
+++ b/app/components/DepositWithdraw/blocktrades/WithdrawModalBlocktrades.jsx
@@ -7,7 +7,11 @@ import BalanceComponent from "components/Utility/BalanceComponent";
 import counterpart from "counterpart";
 import AmountSelector from "components/Utility/AmountSelector";
 import AccountActions from "actions/AccountActions";
-import {validateAddress, WithdrawAddresses} from "common/gatewayMethods";
+import {
+    validateAddress,
+    WithdrawAddresses,
+    getMappingData
+} from "common/gatewayMethods";
 import {ChainStore} from "bitsharesjs";
 import {checkFeeStatusAsync, checkBalance} from "common/trxHelper";
 import {debounce} from "lodash-es";
@@ -272,8 +276,7 @@ class WithdrawModalBlocktrades extends React.Component {
     onSubmit() {
         if (
             !this.state.withdraw_address_check_in_progress &&
-            (this.state.withdraw_address &&
-                this.state.withdraw_address.length) &&
+            this.state.withdraw_address && this.state.withdraw_address.length &&
             this.state.withdraw_amount !== null
         ) {
             if (!this.state.withdraw_address_is_valid) {
@@ -357,20 +360,24 @@ class WithdrawModalBlocktrades extends React.Component {
                     sendAmount = balanceAmount;
                 }
 
-                AccountActions.transfer(
-                    this.props.account.get("id"),
-                    this.props.issuer.get("id"),
-                    sendAmount.getAmount(),
-                    asset.get("id"),
-                    this.props.output_coin_type +
-                        ":" +
-                        this.state.withdraw_address +
-                        (this.state.memo
-                            ? ":" + new Buffer(this.state.memo, "utf-8")
-                            : ""),
-                    null,
-                    feeAmount ? feeAmount.asset_id : "1.3.0"
-                );
+                getMappingData(
+                    this.props.input_coin_type,
+                    this.props.output_coin_type,
+                    this.state.withdraw_address
+                ).then(result => {
+                    AccountActions.transfer(
+                        this.props.account.get("id"),
+                        this.props.issuer.get("id"),
+                        sendAmount.getAmount(),
+                        asset.get("id"),
+                        result["memo"] +
+                            (this.state.memo
+                                ? ":" + new Buffer(this.state.memo, "utf-8")
+                                : ""),
+                        null,
+                        feeAmount ? feeAmount.asset_id : "1.3.0"
+                    );
+                });
 
                 this.setState({
                     empty_withdraw_value: false
@@ -419,20 +426,24 @@ class WithdrawModalBlocktrades extends React.Component {
 
         const {feeAmount, fee_asset_id} = this.state;
 
-        AccountActions.transfer(
-            this.props.account.get("id"),
-            this.props.issuer.get("id"),
-            parseInt(amount * precision, 10),
-            asset.get("id"),
-            this.props.output_coin_type +
-                ":" +
-                this.state.withdraw_address +
-                (this.state.memo
-                    ? ":" + new Buffer(this.state.memo, "utf-8")
-                    : ""),
-            null,
-            feeAmount ? feeAmount.asset_id : fee_asset_id
-        );
+        getMappingData(
+            this.props.input_coin_type,
+            this.props.output_coin_type,
+            this.state.withdraw_address
+        ).then(result => {
+            AccountActions.transfer(
+                this.props.account.get("id"),
+                this.props.issuer.get("id"),
+                parseInt(amount * precision, 10),
+                asset.get("id"),
+                result["memo"] +
+                    (this.state.memo
+                        ? ":" + new Buffer(this.state.memo, "utf-8")
+                        : ""),
+                null,
+                feeAmount ? feeAmount.asset_id : fee_asset_id
+            );
+        });
     }
 
     onDropDownList() {
@@ -602,7 +613,7 @@ class WithdrawModalBlocktrades extends React.Component {
 
         if (
             !this.state.withdraw_address_check_in_progress &&
-            (this.state.withdraw_address && this.state.withdraw_address.length)
+            this.state.withdraw_address && this.state.withdraw_address.length
         ) {
             if (!this.state.withdraw_address_is_valid) {
                 invalid_address_message = (
@@ -865,18 +876,13 @@ class WithdrawModalBlocktrades extends React.Component {
 
 WithdrawModalBlocktrades = BindToChainState(WithdrawModalBlocktrades);
 
-export default connect(
-    WithdrawModalBlocktrades,
-    {
-        listenTo() {
-            return [SettingsStore];
-        },
-        getProps(props) {
-            return {
-                fee_asset_symbol: SettingsStore.getState().settings.get(
-                    "fee_asset"
-                )
-            };
-        }
+export default connect(WithdrawModalBlocktrades, {
+    listenTo() {
+        return [SettingsStore];
+    },
+    getProps(props) {
+        return {
+            fee_asset_symbol: SettingsStore.getState().settings.get("fee_asset")
+        };
     }
-);
+});


### PR DESCRIPTION
<h2>General</h2>

Blocktrades bridge has functionality in wich users can do withdrawals. Memo information is now based on data which are getting from new mapping API call.

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [x] Firefox
- [ ] Safari

There were not changes in UI.