### PR TITLE
fix bug in claim asset fees (feePoolOperations)

### DIFF
--- a/app/components/Account/FeePoolOperation.jsx
+++ b/app/components/Account/FeePoolOperation.jsx
@@ -260,7 +260,20 @@ class FeePoolOperation extends React.Component {
             this.state.claimFeesAmountAsset.getAmount() <= unclaimedBalance;
 
         let unclaimedBalanceText = (
-            <span>
+            <span
+                onClick={() => {
+                    this.state.claimFeesAmountAsset.setAmount({
+                        sats: dynamicObject.get("accumulated_fees")
+                    });
+                    this.setState({
+                        claimFeesAmount: this.state.claimFeesAmountAsset.getAmount(
+                            {
+                                real: true
+                            }
+                        )
+                    });
+                }}
+            >
                 <Translate component="span" content="transfer.available" />
                 :&nbsp;
                 <FormattedAsset


### PR DESCRIPTION
+ fix bug in claim asset fees

<h2>General</h2>
1. Go to ANY asset page: 

https://wallet.bitshares.org/#/asset/CNY (example)

2. Click to TAB "ASSET ACTIONS"
3. Click to "CLAIM ASSET FEES"
4. Click "AVAILABLE: 3,418.3899 bitCNY"

And you will see that nothing is happening - this amount is not substituted in the appropriate field for editing and generating a transaction.

![image](https://user-images.githubusercontent.com/11815105/80797551-cb50e900-8baa-11ea-8efe-f9638f58be7e.png)

and the "Claim fees" button remains inactive.

