### PR TITLE
Run build-hash instead of build in Github Actions

### DIFF
--- a/.github/workflows/npm-build-and-deploy-develop.yml
+++ b/.github/workflows/npm-build-and-deploy-develop.yml
@@ -24,12 +24,12 @@ jobs:
             - name: Create CNAME file
               uses: finnp/create-file-action@master
               env:
-                  FILE_NAME: build/dist/CNAME
+                  FILE_NAME: build/hash-history/CNAME
                   FILE_DATA: develop.bitshares.org
             - name: Deploy
               uses: s0/git-publish-subdir-action@master
               env:
                   REPO: git@github.com:bitshares/develop.bitshares.org.git
                   BRANCH: master
-                  FOLDER: build/dist
+                  FOLDER: build/hash-history
                   SSH_PRIVATE_KEY: ${{ secrets.AUTOMATION_UI_DEPLOYMENT_KEY }}

--- a/.github/workflows/npm-build-and-deploy-develop.yml
+++ b/.github/workflows/npm-build-and-deploy-develop.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm ci
-            - run: npm run build
+            - run: npm run build-hash
             - name: Create CNAME file
               uses: finnp/create-file-action@master
               env:


### PR DESCRIPTION
Fixes the deposit-withdraw page missing issue when doing auto-deployment via Github Actions (https://github.com/bitshares/bitshares-ui/issues/3302#issuecomment-766249950).

Related code:
https://github.com/bitshares/bitshares-ui/blob/df6d96e0d6b38c1c491d72d05ed0575e603e2cf2/build.sh#L14-L18

https://github.com/bitshares/bitshares-ui/blob/df6d96e0d6b38c1c491d72d05ed0575e603e2cf2/package.json#L41-L43

https://github.com/bitshares/bitshares-ui/blob/df6d96e0d6b38c1c491d72d05ed0575e603e2cf2/webpack.config.js#L208-L235