### PR TITLE
Rethrow error when failed to download charting lib

### DIFF
--- a/charting_library/install-charting-library.js
+++ b/charting_library/install-charting-library.js
@@ -18,6 +18,7 @@ http.get("https://bitshares.org/assets/" + outputFileName, (response) => {
 }).on("error", (err) => {
     console.error("Failed to download charting_library archive");
     console.error(err);
+    throw (err);
 });
 
 outputFile.on("finish", () => {


### PR DESCRIPTION
In one run of the CI process, the `npm ci` step went through but  `npm build` failed. Actually `npm ci` should fail.

More info: https://github.com/abitmore/bitshares-ui/pull/6/checks?check_run_id=1954163481 or https://ci.appveyor.com/project/svk31/bitshares-ui/builds/37891710
(Note: the charting lib downloading issue has been fixed, thus unable to reproduce the issue as is.  https://github.com/bitshares/bitshares-ui/pull/3342 reproduces it.)

```
Run npm ci
...
> BitShares2-light@5.0.20210216 install-charting-library /home/runner/work/bitshares-ui/bitshares-ui
> node ./charting_library/install-charting-library.js && npm run compile-tv-css

Failed to download charting_library archive
{ Error: connect ETIMEDOUT 149.28.203.167:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)
  errno: 'ETIMEDOUT',
  code: 'ETIMEDOUT',
  syscall: 'connect',
  address: '149.28.203.167',
  port: 443 }

> BitShares2-light@5.0.20210216 compile-tv-css /home/runner/work/bitshares-ui/bitshares-ui
> node-sass ./charting_library/scss/ --output ./charting_library/ --output-style compressed
...
Run npm build
...
ERROR in ./app/components/Exchange/TradingViewPriceChart.jsx
Module not found: Error: Can't resolve '../../../charting_library/charting_library.esm' in '/home/runner/work/bitshares-ui/bitshares-ui/app/components/Exchange'
...
```

With the fix (see https://ci.appveyor.com/project/svk31/bitshares-ui/builds/37894611):
```
Run npm ci
...
> BitShares2-light@5.0.20210216 install-charting-library C:\projects\bitshares-ui
> node ./charting_library/install-charting-library.js && npm run compile-tv-css
Failed to download charting_library archive
{ Error: connect ETIMEDOUT 10.255.255.1:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)
  errno: 'ETIMEDOUT',
  code: 'ETIMEDOUT',
  syscall: 'connect',
  address: '10.255.255.1',
  port: 443 }
C:\projects\bitshares-ui\charting_library\install-charting-library.js:21
    throw (err);
    ^
Error: connect ETIMEDOUT 10.255.255.1:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! BitShares2-light@5.0.20210216 install-charting-library: `node ./charting_library/install-charting-library.js && npm run compile-tv-css`
npm ERR! Exit status 1
...
```
