### PR TITLE
Hide own accounts from to field in send modal

### DIFF
--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -554,11 +554,11 @@ class AccountSelector extends React.Component {
                         >
                             {account.data.isKnownScammer ? (
                                 <AntIcon type="warning" />
-                            ) : {account.data.isContact ? (
+                            ) : (account.data.isContact ? (
                                 <AntIcon type="star" />
-                            ) : {account.data.isOwnAccount ? (
+                            ) : (account.data.isOwnAccount ? (
                                 <AntIcon type="user" />
-                            ) : null} } }
+                            ) : null) ) }
                             &nbsp;
                             {account.data.name}
                             <span style={{float: "right"}}>

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -458,18 +458,7 @@ class AccountSelector extends React.Component {
             error ||
             disableActionButton;
 
-        if (selectedAccount && selectedAccount.isOwnAccount) {
-            linked_status = (
-                <Tooltip
-                    placement="top"
-                    title={counterpart.translate("tooltip.own_account")}
-                >
-                    <span className="tooltip green">
-                        <AntIcon type="user" />
-                    </span>
-                </Tooltip>
-            );
-        } else if (selectedAccount && selectedAccount.isKnownScammer) {
+        if (selectedAccount && selectedAccount.isKnownScammer) {
             linked_status = (
                 <Tooltip
                     placement="top"
@@ -477,6 +466,17 @@ class AccountSelector extends React.Component {
                 >
                     <span className="tooltip red">
                         <AntIcon type="warning" theme="filled" />
+                    </span>
+                </Tooltip>
+            );
+        } else if (selectedAccount && selectedAccount.isOwnAccount) {
+            linked_status = (
+                <Tooltip
+                    placement="top"
+                    title={counterpart.translate("tooltip.own_account")}
+                >
+                    <span className="tooltip green">
+                        <AntIcon type="user" />
                     </span>
                 </Tooltip>
             );

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -473,17 +473,6 @@ class AccountSelector extends React.Component {
                     </span>
                 </Tooltip>
             );
-        } else if (selectedAccount && selectedAccount.isOwnAccount) {
-            linked_status = (
-                <Tooltip
-                    placement="top"
-                    title={counterpart.translate("tooltip.own_account")}
-                >
-                    <span className="tooltip green">
-                        <AntIcon type="user" />
-                    </span>
-                </Tooltip>
-            );
         } else if (selectedAccount && selectedAccount.isContact) {
             linked_status = (
                 <Tooltip
@@ -493,6 +482,17 @@ class AccountSelector extends React.Component {
                 >
                     <span className="tooltip green">
                         <AntIcon type="star" theme="filled" />
+                    </span>
+                </Tooltip>
+            );
+        } else if (selectedAccount && selectedAccount.isOwnAccount) {
+            linked_status = (
+                <Tooltip
+                    placement="top"
+                    title={counterpart.translate("tooltip.own_account")}
+                >
+                    <span className="tooltip green">
+                        <AntIcon type="user" />
                     </span>
                 </Tooltip>
             );
@@ -554,10 +554,10 @@ class AccountSelector extends React.Component {
                         >
                             {account.data.isKnownScammer ? (
                                 <AntIcon type="warning" />
-                            ) : {account.data.isOwnAccount ? (
-                                <AntIcon type="user" />
                             ) : {account.data.isContact ? (
                                 <AntIcon type="star" />
+                            ) : {account.data.isOwnAccount ? (
+                                <AntIcon type="user" />
                             ) : null} } }
                             &nbsp;
                             {account.data.name}

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -52,6 +52,7 @@ class AccountSelector extends React.Component {
         allowUppercase: PropTypes.bool, // use it if you need to allow uppercase letters
         typeahead: PropTypes.bool,
         excludeAccounts: PropTypes.array, // array of accounts to exclude from the typeahead
+        includeMyActiveAccounts: PropTypes.bool, // whether to include my active accounts in the list
         focus: PropTypes.bool,
         disabled: PropTypes.bool,
         editable: PropTypes.bool,
@@ -63,6 +64,7 @@ class AccountSelector extends React.Component {
     static defaultProps = {
         autosubscribe: false,
         excludeAccounts: [],
+        includeMyActiveAccounts: true,
         disabled: null,
         editable: null,
         locked: false,
@@ -86,9 +88,11 @@ class AccountSelector extends React.Component {
         if (accountName) {
             this._addThisToIndex(accountName);
         }
-        this.props.myActiveAccounts.map(a => {
-            this._addThisToIndex(a);
-        });
+        if (this.props.includeMyActiveAccounts) {
+            this.props.myActiveAccounts.map(a => {
+                this._addThisToIndex(a);
+            });
+        }
         this.props.contacts.map(a => {
             this._addThisToIndex(a);
         });

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -527,7 +527,7 @@ class AccountSelector extends React.Component {
                         return null;
                     }
                     if (
-                        account.data.isOwnAccount ||
+                        (this.props.includeMyActiveAccount && account.data.isOwnAccount) ||
                         (!this.props.locked && account.data.isContact) ||
                         (accountName && account.data.name === accountName)
                     ) {
@@ -552,15 +552,13 @@ class AccountSelector extends React.Component {
                             value={account.data.name}
                             disabled={account.data.disabled ? true : undefined}
                         >
-                            {account.data.isOwnAccount ? (
-                                <AntIcon type="user" />
-                            ) : null}
-                            {account.data.isContact ? (
-                                <AntIcon type="star" />
-                            ) : null}
                             {account.data.isKnownScammer ? (
                                 <AntIcon type="warning" />
-                            ) : null}
+                            ) : {account.data.isOwnAccount ? (
+                                <AntIcon type="user" />
+                            ) : {account.data.isContact ? (
+                                <AntIcon type="star" />
+                            ) : null} } }
                             &nbsp;
                             {account.data.name}
                             <span style={{float: "right"}}>

--- a/app/components/Account/AccountSelector.jsx
+++ b/app/components/Account/AccountSelector.jsx
@@ -669,11 +669,11 @@ class AccountSelector extends React.Component {
                     <label
                         className={cnames(
                             "right-label",
-                            selectedAccount.isContact ||
-                            selectedAccount.isOwnAccount
-                                ? "positive"
-                                : null,
-                            selectedAccount.isKnownScammer ? "negative" : null
+                            selectedAccount.isKnownScammer ? "negative" : (
+                                selectedAccount.isContact ||
+                                selectedAccount.isOwnAccount
+                                    ? "positive"
+                                    : null )
                         )}
                         style={{marginTop: -30}}
                     >

--- a/app/components/Modal/SendModal.jsx
+++ b/app/components/Modal/SendModal.jsx
@@ -616,6 +616,7 @@ class SendModal extends React.Component {
                                         this
                                     )}
                                     typeahead={true}
+                                    includeMyActiveAccounts={false}
                                     tabIndex={tabIndex++}
                                 />
 


### PR DESCRIPTION
<h2>General</h2>
Workaround for #3343

Add a new property `includeMyActiveAccounts` to Account Selector, enabled by default, disabled in Send Modal.

BTW updated some checks so that checking for scammers has higher priority.

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [x] Firefox
- [ ] Safari

_Please provide screenshots/licecap of your changes below_

The screenshot below was for reproducing a scenario that assumes `abit-test` is the attacker, `abit-test2` is the victim, and `abit` is in contacts.

Without this patch:
![image](https://user-images.githubusercontent.com/9946777/109127780-16964280-774f-11eb-9e34-23f4b2695662.png)

With the patch, it won't show my accounts at all, which is a bit inconvenient but safer (a test environment is temporarily available at https://pr.bts.mobi/):

![image](https://user-images.githubusercontent.com/9946777/109128317-a936e180-774f-11eb-9873-5891738a1f62.png)
