### PR TITLE
Fix #3264, get rid of warnings

### DIFF
--- a/app/components/Account/CreateAccountPassword.jsx
+++ b/app/components/Account/CreateAccountPassword.jsx
@@ -222,7 +222,7 @@ class CreateAccountPassword extends React.Component {
 
     _renderAccountCreateForm() {
         let {registrar_account} = this.state;
-        
+
         let my_accounts = AccountStore.getMyAccounts();
         let firstAccount = my_accounts.length === 0;
         let valid = this.isValid();
@@ -270,7 +270,7 @@ class CreateAccountPassword extends React.Component {
                                 title={
                                     <div
                                         dangerouslySetInnerHTML={{
-                                            __html: aboutPassword
+                                            __html: counterpart.translate("tooltip.generate")
                                         }}
                                     />
                                 }
@@ -293,9 +293,9 @@ class CreateAccountPassword extends React.Component {
                                     rows="3"
                                     readOnly
                                     disabled
-                                >
-                                    {this.state.generatedPassword}
-                                </textarea>
+                                    value={this.state.generatedPassword}
+                                />
+
                                 <CopyButton
                                     text={this.state.generatedPassword}
                                     tip="tooltip.copy_password"

--- a/app/components/Account/CreateAccountPassword.jsx
+++ b/app/components/Account/CreateAccountPassword.jsx
@@ -222,7 +222,8 @@ class CreateAccountPassword extends React.Component {
 
     _renderAccountCreateForm() {
         let {registrar_account} = this.state;
-
+        
+        let aboutPassword = counterpart.translate("tooltip.generate");
         let my_accounts = AccountStore.getMyAccounts();
         let firstAccount = my_accounts.length === 0;
         let valid = this.isValid();
@@ -267,10 +268,21 @@ class CreateAccountPassword extends React.Component {
                             <Translate content="wallet.generated" />
                             &nbsp;&nbsp;
                             <Tooltip
-                                title={counterpart.translate(
-                                    "tooltip.generate"
-                                )}
+                                title={
+                                    <div
+                                        dangerouslySetInnerHTML={{
+                                            __html: aboutPassword
+                                        }}
+                                    />
+                                }
                             >
+                                <span className="tooltip">
+                                    <Icon
+                                        name="question-circle"
+                                        title="icons.question_circle"
+                                    />
+                                </span>
+                            </Tooltip>
                                 <span className="tooltip">
                                     <Icon
                                         name="question-circle"

--- a/app/components/Account/CreateAccountPassword.jsx
+++ b/app/components/Account/CreateAccountPassword.jsx
@@ -283,13 +283,6 @@ class CreateAccountPassword extends React.Component {
                                     />
                                 </span>
                             </Tooltip>
-                                <span className="tooltip">
-                                    <Icon
-                                        name="question-circle"
-                                        title="icons.question_circle"
-                                    />
-                                </span>
-                            </Tooltip>
                         </label>
                         <div style={{paddingBottom: "0.5rem"}}>
                             <span className="inline-label">

--- a/app/components/Account/CreateAccountPassword.jsx
+++ b/app/components/Account/CreateAccountPassword.jsx
@@ -270,7 +270,7 @@ class CreateAccountPassword extends React.Component {
                                 title={
                                     <div
                                         dangerouslySetInnerHTML={{
-                                            __html: counterpart.translate("tooltip.generate")
+                                        __html: counterpart.translate("tooltip.generate")
                                         }}
                                     />
                                 }

--- a/app/components/Account/CreateAccountPassword.jsx
+++ b/app/components/Account/CreateAccountPassword.jsx
@@ -223,7 +223,6 @@ class CreateAccountPassword extends React.Component {
     _renderAccountCreateForm() {
         let {registrar_account} = this.state;
         
-        let aboutPassword = counterpart.translate("tooltip.generate");
         let my_accounts = AccountStore.getMyAccounts();
         let firstAccount = my_accounts.length === 0;
         let valid = this.isValid();

--- a/app/components/Wallet/WalletUnlockModalLib.jsx
+++ b/app/components/Wallet/WalletUnlockModalLib.jsx
@@ -165,7 +165,7 @@ export const WalletSelector = ({
         className="login-select"
     >
         <option value="" hidden>
-            <Translate content="wallet.select_wallet" />
+            {counterpart.translate("wallet.select_wallet")}
         </option>
         {walletNames.map(walletName => (
             <option
@@ -177,7 +177,7 @@ export const WalletSelector = ({
             </option>
         ))}
         <option value="upload.">
-            <Translate content="settings.backup_backup_short" />
+            {counterpart.translate("settings.backup_backup_short")}
         </option>
     </select>
 );


### PR DESCRIPTION
issue 1:
![Screenshot from 2021-07-12 22-23-39](https://user-images.githubusercontent.com/87205099/125798558-c93ff239-4851-4bf4-8479-21b1d4d1a1f8.png)


issue 2:

> Warning: Use the `defaultValue` or `value` props instead of setting children on <textarea>.
    in textarea (created by CreateAccountPassword) 