### PR TITLE
Destroy deposit modal cache upon closing it

### DIFF
--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -524,6 +524,7 @@ export default class DepositModal extends React.Component {
     render() {
         return (
             <Modal
+                destroyOnClose={true}
                 title={
                     this.props.account
                         ? counterpart.translate("modal.deposit.header", {


### PR DESCRIPTION
In case platform user owns multiple users and wants to deposit to thus different users; they will need to clear the browser cache every time they want to use different user for deposit modal API data.