### PR TITLE
Fixing header's username not fully appearing

### DIFF
--- a/app/assets/stylesheets/themes/_theme-template.scss
+++ b/app/assets/stylesheets/themes/_theme-template.scss
@@ -2794,7 +2794,7 @@
     min-width: 0; /* or some value */
     .text {
         white-space: nowrap;
-        overflow: hidden;
+        overflow: visible;
         text-overflow: ellipsis;
         text-align: right;
     }


### PR DESCRIPTION
Before:

<img width="960" alt="before" src="https://user-images.githubusercontent.com/82454470/132958654-4ff79a36-09d1-468b-aded-61fe08e7f809.png">

After:

<img width="960" alt="after" src="https://user-images.githubusercontent.com/82454470/132958667-c5562458-2db0-4c46-80e3-b7f64d4be056.png">
