### PR TITLE
Fixing header's username not fully appearing

### DIFF
--- a/app/assets/stylesheets/vendors/foundation/_global.scss
+++ b/app/assets/stylesheets/vendors/foundation/_global.scss
@@ -96,7 +96,7 @@ $foundation-colors: (
         font-family: $body-font-family;
         font-weight: $body-font-weight;
         font-style: $body-font-style;
-        line-height: 1;
+        line-height: 1.2;
         position: relative;
 
         @if $body-antialiased {


### PR DESCRIPTION
Before:
<img width="960" alt="132958654-4ff79a36-09d1-468b-aded-61fe08e7f809" src="https://user-images.githubusercontent.com/82454470/146031305-edf6ea2c-e950-4fce-87c0-7a6f3e6422ca.png">

After:
<img width="960" alt="132958667-c5562458-2db0-4c46-80e3-b7f64d4be056" src="https://user-images.githubusercontent.com/82454470/146031369-7aad4453-68ea-44b9-b361-adfa16d3e898.png">

