### PR TITLE
Remove an API node

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -324,14 +324,6 @@ export const settingsAPIs = {
             contact: "email:work@akawa.ink"
         },
         {
-            url: "wss://api.cnvote.vip:888/",
-            region: "Eastern Asia",
-            country: "China",
-            location: "Zhejiang",
-            operator: "Witness: ioex",
-            contact: "wechat:xiaoyuan_409"
-        },
-        {
             url: "wss://hongkong.bitshares.im/ws",
             region: "East Asia",
             country: "China",


### PR DESCRIPTION
The node has switched to another chain. `chain_id [cd931cb96d657ff0ef0226f7ae9d25175b3cc96a84490a674ed36170830324e7]`
