### PR TITLE
Comment out the link to the GDEX ticketing system

### DIFF
--- a/app/components/DepositWithdraw/gdex/GdexGateway.jsx
+++ b/app/components/DepositWithdraw/gdex/GdexGateway.jsx
@@ -331,6 +331,7 @@ class GdexGateway extends React.Component {
                 <Translate content="gateway.support_gdex" />
                 <br />
                 <br />
+                <!--
                 <p>
                     Help:{" "}
                     <a
@@ -342,6 +343,7 @@ class GdexGateway extends React.Component {
                         {issuer.ticket}
                     </a>
                 </p>
+                -->
                 <p>
                     QQ:{" "}
                     <a


### PR DESCRIPTION
I got info that tickets are not being processed as before, so showing the link on UI does not help. In this PR I commented it out so far, probably remove it some day in the future.

The official support is on WeChat (Weixin), but it is hard to provide a link in the UI.

Don't know if the QQ group still works since I can no longer login to QQ due to KYC issues.

For the Telegram group, at least other community members (including me) can forward messages.