### PR TITLE
Add credit offers to top menu

### DIFF
--- a/app/components/Layout/MenuDataStructure.js
+++ b/app/components/Layout/MenuDataStructure.js
@@ -223,6 +223,7 @@ class MenuDataStructure {
                 target: "/credit-offer",
                 icon: "deployment-unit",
                 text: "header.p2p_lending",
+                inHeaderBehavior: MenuItemType.Always,
                 inDropdownBehavior: MenuItemType.WhenNotInHeader
             }),
             explorer: state => ({


### PR DESCRIPTION
It was removed here: https://github.com/bitshares/bitshares-ui/pull/3462/commits/f67d1cd0d0a14e4225843b3eaa9399054a375223#diff-d63a7b057087487c08e48334a07bc30032568fdf51b3b0f0dda62de0c57ccdfbL226