### PR TITLE
text align should be left

### DIFF
--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -120,7 +120,7 @@ div#CenterContent {
 
     &.fixed-table {
         table-layout: fixed;
-        text-align: right;
+        text-align: left;
     }
 
     > thead > tr > th {


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/37595908/172702277-1715af77-0fed-4f19-8a79-03a5ef70142a.png)

After:
![after](https://user-images.githubusercontent.com/37595908/172702330-abc9f48d-f2d4-4838-ad25-a0db5592349c.png)

