### PR TITLE
This was dropped due to a mistake

### DIFF
--- a/app/components/Account/CreditOffer/CreditOfferAccountPage.jsx
+++ b/app/components/Account/CreditOffer/CreditOfferAccountPage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {connect} from "alt-react";
 import counterpart from "counterpart";
 import {Tabs, Tab} from "../../Utility/Tabs";
-import erList from "./CreditOfferList";
+import CreditOfferList from "./CreditOfferList";
 import CreditDebtList from "./CreditDebtList";
 import CreditRightsList from "./CreditRightsList";
 


### PR DESCRIPTION
It caused the error:

ReferenceError: CreditOfferList is not defined
    at Un.render (account.cf361fa9202f7a8d1105.js:1:319940)
    at Ra (vendor.049af5c1d008aea05c6b.js:2:3628660)
    at za (vendor.049af5c1d008aea05c6b.js:2:3628455)
    at bs (vendor.049af5c1d008aea05c6b.js:2:3663936)
    at hc (vendor.049af5c1d008aea05c6b.js:2:3655411)
    at fc (vendor.049af5c1d008aea05c6b.js:2:3655336)
    at rc (vendor.049af5c1d008aea05c6b.js:2:3652366)
    at vendor.049af5c1d008aea05c6b.js:2:3604139
    at t.unstable_runWithPriority (vendor.049af5c1d008aea05c6b.js:2:4148188)
    at Ko (vendor.049af5c1d008aea05c6b.js:2:3603848)