### PR TITLE
Right align numbers in the order table

### DIFF
--- a/app/assets/stylesheets/components/_exchange.scss
+++ b/app/assets/stylesheets/components/_exchange.scss
@@ -120,13 +120,13 @@ div#CenterContent {
 
     &.fixed-table {
         table-layout: fixed;
-        text-align: left;
+        text-align: right;
     }
 
     > thead > tr > th {
         font-size: 14px;
         padding: 5px 5px;
-        text-align: left !important;
+        text-align: right !important;
     }
 
     > tbody > tr > td {

--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -1053,7 +1053,7 @@ class OrderBook extends React.Component {
                                     </span>
                                 </div>
                             </div>
-                            <div className="market-right-padding-only">
+                            <div className="market-right-padding-only" style={{ paddingRight: "0.6rem" }} >
                                 <table className="table order-table table-hover fixed-table text-right">
                                     {!flipOrderBook ? rightHeader : leftHeader}
                                 </table>
@@ -1213,7 +1213,7 @@ class OrderBook extends React.Component {
                                     </span>
                                 </div>
                             </div>
-                            <div className="market-right-padding-only">
+                            <div className="market-right-padding-only" style={{ paddingRight: "0.6rem" }} >
                                 <table className="table order-table table-hover fixed-table text-right">
                                     {flipOrderBook ? rightHeader : leftHeader}
                                 </table>


### PR DESCRIPTION
<h2>General</h2>

https://github.com/bitshares/bitshares-ui/pull/3522 was closed, but the change was included in #3378.

This PR also changes the table header to right-aligned. 

Before:
![image](https://user-images.githubusercontent.com/9946777/178564289-ad7dc777-1580-46bf-9e64-b4dc8cd495a4.png)


After:
![image](https://user-images.githubusercontent.com/9946777/178563344-6a239dcf-2e7b-41c8-99b0-9048586d7c08.png)


<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [ ] Check for unused code
- [ ] No unrelated changes are included
- [ ] None of the changed files are reformatting only
- [ ] Code is self explanatory or documented
- [ ] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [ ] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_