### PR TITLE
Update base URL of GDEX gateway API

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -64,7 +64,7 @@ export const citadelAPIs = {
 };
 
 export const gdex2APIs = {
-    BASE: "https://api.52bts.net/adjust",
+    BASE: "https://openapi.52bts.net/adjust",
     COINS_LIST: "/coins",
     ACTIVE_WALLETS: "/active-wallets",
     TRADING_PAIRS: "/trading-pairs"


### PR DESCRIPTION
This should fix deposit/withdrawal.

BTW I guess the legacy deposit/withdrawal page for GDEX no longer works. Not tested.
