### PR TITLE
Fixing Bug with Credit Fee Amount in Credit Offer

### DIFF
--- a/app/components/Account/CreditOffer/CreditDebtList.jsx
+++ b/app/components/Account/CreditOffer/CreditDebtList.jsx
@@ -398,7 +398,7 @@ class CreditDebtList extends React.Component {
         });
         let cAmount = cAsset.getAmount();
         let rate = parseFloat(cAmount) / debtAmount;
-        let cfAmount = fRate * debtAmount * rate;
+        let cfAmount = Math.ceil(fRate * debtAmount * rate);
 
         let data = {
             account,


### PR DESCRIPTION
User had reported the below error while submitting *repay credit deal operation*:

![Error](https://user-images.githubusercontent.com/37595908/192563633-800647e2-f47c-41a1-89b3-da8821025903.png)

A core check is rejecting *9* as the credit_fee amount of the operation; it was found that the determination of credit_fee amount is coming through the code equation (fRate * debtAmount * rate); it was solved by rounded up result using Math.ceil()

Testing credits to @thontron 