### PR TITLE
Addition of depositCaching parameter for gateways

### DIFF
--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -187,7 +187,9 @@ class DepositModalContent extends DecimalChecker {
         if (
             selectedGateway &&
             selectedAsset &&
-            gatewayStatus[selectedGateway].depositCaching
+            (gatewayStatus[selectedGateway].hasOwnProperty("depositCaching")
+                ? gatewayStatus[selectedGateway].depositCaching
+                : true)
         ) {
             depositAddress = this.deposit_address_cache.getCachedInputAddress(
                 selectedGateway.toLowerCase(),

--- a/app/lib/common/gateways.js
+++ b/app/lib/common/gateways.js
@@ -92,7 +92,6 @@ export const availableGateways = {
         name: "ioxbank",
         baseAPI: ioxbankAPIs,
         isEnabled: _isEnabled("IOB"),
-        depositCaching: true,
         isSimple: true,
         selected: false,
         simpleAssetGateway: true,
@@ -179,7 +178,6 @@ export const availableGateways = {
         name: "GDEX",
         baseAPI: gdex2APIs,
         isEnabled: _isEnabled("GDEX"),
-        depositCaching: true,
         options: {
             enabled: false,
             selected: false
@@ -191,7 +189,6 @@ export const availableGateways = {
         name: "XBTS Native Chains",
         baseAPI: xbtsxAPIs,
         isEnabled: _isEnabled("XBTSX"),
-        depositCaching: true,
         isSimple: true,
         selected: false,
         addressValidatorMethod: "POST",


### PR DESCRIPTION
<h2>General</h2>

This PR adds functionality to choose whether or not a gateway allows for cached deposit addresses/memos. While being a small change (4 lines), this adds major modular improvement by allowing for gateways with unique deposit requirements. Changes have been added to each active gateway setting this parameter equal to 'true' to continue working with prior UI functionality.

<h2>Code Preparation</h2>

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [x] Opera
- [x] Firefox
- [x] Safari