### PR TITLE
Update component if ticker changed

### DIFF
--- a/app/components/Exchange/PriceStatWithLabel.jsx
+++ b/app/components/Exchange/PriceStatWithLabel.jsx
@@ -17,7 +17,7 @@ export default class PriceStatWithLabel extends React.Component {
     }
 
     shouldComponentUpdate(nextProps) {
-        if (nextProps.volume2 && nextProps.volume2 !== this.props.volume2) {
+        if ((nextProps.volume2 && nextProps.volume2 !== this.props.volume2) || (nextProps.base !== this.props.base)) {
             return true;
         }
         return (


### PR DESCRIPTION
If you change the ticker in ExchangeHeader - the volume ticker doesn't get changed in case `previous market volume === new market volume`. This PR fixes a logic of `shouldComponentUpdate` 