### PR TITLE
Fix ActiveAccounts check

### DIFF
--- a/app/App.jsx
+++ b/app/App.jsx
@@ -374,7 +374,7 @@ class App extends React.Component {
     _ensureExternalServices() {
         setTimeout(() => {
             let hasLoggedIn =
-                AccountStore.getState().myActiveAccounts.length > 0 ||
+                AccountStore.getState().myActiveAccounts.size > 0 ||
                 !!AccountStore.getState().passwordAccount;
             if (!hasLoggedIn) {
                 this._ensureExternalServices();


### PR DESCRIPTION
In that check, a variable `myActiveAccounts` is an immutable Set instead of an array. So the proper way to check it's size is a `.size`.

This bug may lead to improper logic of Gateways coins fetch, that are available to deposit/withdraw  