### PR TITLE
Fix withdraw modal search though assets

### DIFF
--- a/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
+++ b/app/components/DepositWithdraw/DepositWithdrawAssetSelector.js
@@ -97,7 +97,7 @@ class DepositWithdrawAssetSelector extends React.Component {
         let {onChange} = this.props;
         let asset = this.getSelectedAssetArray(selectedAsset);
 
-        if (onChange) {
+        if (onChange && asset && asset.id) {
             onChange(asset.id);
         }
     }
@@ -124,9 +124,9 @@ class DepositWithdrawAssetSelector extends React.Component {
                 showSearch
                 style={{width: "100%"}}
             >
-                {/* 
+                {/*
                     NOTE
-                    On Deposit, it would be useful to view Min Deposit 
+                    On Deposit, it would be useful to view Min Deposit
                     and Gateway Fee to the right of the selection so the
                     user doesn't have to select a specific gateway to view
                     this information.


### PR DESCRIPTION
When a user tries to process a search though assets in withdraw modal the component crashes. 
### How it was before
(I'm trying to type anything in the input and filtering doesn't work and input crashes)
![withdraw-modal-crash](https://user-images.githubusercontent.com/7770343/202491633-49028f15-479a-4733-988e-5f69e8d1d332.gif)

### How it works now
![withdraw-modal-fine](https://user-images.githubusercontent.com/7770343/202491695-01ed305b-26a0-4b9f-87b7-a9dbc67fae09.gif)
