### PR TITLE
#3525 Fix exponential numbers on Exchange & MarketDepth

### DIFF
--- a/app/components/Exchange/DepthHighChart.jsx
+++ b/app/components/Exchange/DepthHighChart.jsx
@@ -8,6 +8,7 @@ import Translate from "react-translate-component";
 import colors from "assets/colors";
 import AssetName from "../Utility/AssetName";
 import {didOrdersChange} from "common/MarketClasses";
+import {numberExponentToLarge} from "../../lib/common/numberExplonentConversion";
 
 class DepthHighChart extends React.Component {
     shouldComponentUpdate(nextProps) {
@@ -192,10 +193,10 @@ class DepthHighChart extends React.Component {
                 labels: {
                     style: {
                         color: primaryText
+                    },
+                    formatter: function() {
+                        return numberExponentToLarge(this.value);
                     }
-                    // formatter: function() {
-                    //     return this.value / power;
-                    // }
                 },
                 ordinal: false,
                 lineColor: "#000000",

--- a/app/components/Exchange/Exchange.jsx
+++ b/app/components/Exchange/Exchange.jsx
@@ -43,6 +43,7 @@ import SimpleDepositBlocktradesBridge from "../Dashboard/SimpleDepositBlocktrade
 import {Notification} from "bitshares-ui-style-guide";
 import PriceAlert from "./PriceAlert";
 import counterpart from "counterpart";
+import {numberExponentToLarge} from "../../lib/common/numberExplonentConversion";
 
 class Exchange extends React.Component {
     static propTypes = {
@@ -2154,9 +2155,9 @@ class Exchange extends React.Component {
                             this,
                             "bid"
                         )}
-                        amount={bid.toReceiveText}
-                        price={bid.priceText}
-                        total={bid.forSaleText}
+                        amount={numberExponentToLarge(bid.toReceiveText)}
+                        price={numberExponentToLarge(bid.priceText)}
+                        total={numberExponentToLarge(bid.forSaleText)}
                         quote={quote}
                         base={base}
                         amountChange={this._onInputReceive.bind(
@@ -2311,9 +2312,9 @@ class Exchange extends React.Component {
                         }}
                         type="ask"
                         hideHeader={true}
-                        amount={ask.forSaleText}
-                        price={ask.priceText}
-                        total={ask.toReceiveText}
+                        amount={numberExponentToLarge(ask.forSaleText)}
+                        price={numberExponentToLarge(ask.priceText)}
+                        total={numberExponentToLarge(ask.toReceiveText)}
                         quote={quote}
                         base={base}
                         expirationType={expirationType["ask"]}

--- a/app/lib/common/numberExplonentConversion.js
+++ b/app/lib/common/numberExplonentConversion.js
@@ -1,0 +1,29 @@
+// taken from: https://stackoverflow.com/a/62124842/3930054
+
+export function numberExponentToLarge(numIn) {
+    numIn += "";                                            // To cater to numric entries
+    let sign = "";                                           // To remember the number sign
+    numIn.charAt(0) == "-" && (numIn = numIn.substring(1), sign = "-"); // remove - sign & remember it
+    let str = numIn.split(/[eE]/g);                        // Split numberic string at e or E
+    if (str.length < 2) return sign + numIn;                   // Not an Exponent Number? Exit with orginal Num back
+    let power = str[1];                                    // Get Exponent (Power) (could be + or -)
+    
+    let deciSp = 1.1.toLocaleString().substring(1, 2);  // Get Deciaml Separator
+    str = str[0].split(deciSp);                        // Split the Base Number into LH and RH at the decimal point
+    let baseRH = str[1] || "",                         // RH Base part. Make sure we have a RH fraction else ""
+        baseLH = str[0];                               // LH base part.
+    
+    if (power >= 0) {   // ------- Positive Exponents (Process the RH Base Part)
+        if (power > baseRH.length) baseRH += "0".repeat(power - baseRH.length); // Pad with "0" at RH
+        baseRH = baseRH.slice(0, power) + deciSp + baseRH.slice(power);      // Insert decSep at the correct place into RH base
+        if (baseRH.charAt(baseRH.length - 1) == deciSp) baseRH = baseRH.slice(0, -1); // If decSep at RH end? => remove it
+        
+    } else {         // ------- Negative exponents (Process the LH Base Part)
+        let num = Math.abs(power) - baseLH.length;                               // Delta necessary 0's
+        if (num > 0) baseLH = "0".repeat(num) + baseLH;                       // Pad with "0" at LH
+        baseLH = baseLH.slice(0, power) + deciSp + baseLH.slice(power);     // Insert "." at the correct place into LH base
+        if (baseLH.charAt(0) == deciSp) baseLH = "0" + baseLH;                // If decSep at LH most? => add "0"
+        
+    }
+    return sign + (baseLH + baseRH).replace(/^0*(\d+|\d+\.\d+?)\.?0*$/, "$1");
+}


### PR DESCRIPTION
**Issue** #3525 

**Description**
- Fixed exponential numbers for Exchange
- Also fixed for Market Depth

<img width="1305" alt="Screenshot 2022-11-23 at 05 18 25" src="https://user-images.githubusercontent.com/7770343/203463453-c50aa9d6-376a-4b85-83db-138869f2ce59.png">

<img width="1304" alt="Screenshot 2022-11-23 at 05 18 52" src="https://user-images.githubusercontent.com/7770343/203463437-f548c189-5cd4-4fef-b907-2e3a4bf8b4a3.png">

<img width="436" alt="Screenshot 2022-11-23 at 05 23 51" src="https://user-images.githubusercontent.com/7770343/203463482-09af9571-600a-4d88-896e-94d820c7b9eb.png">


**How to test?**
- Go to Exchange
- Click on BTS
- Find xbtsx.btc 
<img width="362" alt="Screenshot 2022-11-23 at 05 22 10" src="https://user-images.githubusercontent.com/7770343/203463377-b26f5185-7fa1-4e00-9855-d288715f2191.png">




Closes #3525 