### PR TITLE
#3568 Show borrow window for owner for testing purpose and prevent su…

### DIFF
--- a/app/components/Account/CreditOffer/CreditOfferPage.jsx
+++ b/app/components/Account/CreditOffer/CreditOfferPage.jsx
@@ -92,23 +92,6 @@ class CreditOfferPage extends React.Component {
     }
 
     showAcceptModal(data) {
-        // console.log("TODO:", data);
-        let {currentAccount} = this.props;
-        let account = ChainStore.getAccount(currentAccount);
-        if (account.get("id") == data.owner_account) {
-            notify.addNotification.defer({
-                children: (
-                    <Translate
-                        component="span"
-                        content="credit_offer.info_borrow_err"
-                    />
-                ),
-                level: "error",
-                autoDismiss: 3
-            });
-            return;
-        }
-
         let assetList = data.acceptable_collateral.map(v => v[0]);
         let debtAsset = data.asset_type;
         let selectAsset = assetList[0];
@@ -472,7 +455,7 @@ class CreditOfferPage extends React.Component {
         let maxReal = maxAssetAmount.getAmount({real: true});
         let maxError = amount > maxReal || maxReal <= 0;
         const isSubmitNotValid =
-            !amount || minError || maxError || !selectAsset || balanceError;
+            !amount || minError || maxError || !selectAsset || balanceError || account.get("id") == info.owner_account;
         let _error = maxError ? "has-error" : "";
         if (currentBalance && currentBalance > 0) {
             balance = (
@@ -521,6 +504,12 @@ class CreditOfferPage extends React.Component {
                 overlay={true}
                 onCancel={this.hideAcceptModal}
                 footer={[
+                    info.owner_account === info.owner_account && (
+                            <Translate
+                                component="span"
+                                content="credit_offer.info_borrow_err"
+                            />
+                    ) || null,
                     <Button
                         key={"send"}
                         disabled={isSubmitNotValid}


### PR DESCRIPTION
**Issue** #3568

**Description**
- Now user can open the Borrow dialog with no error and test the amount / see how collateral works
- Add owner error near submit button & disable submit

<img width="555" alt="Screenshot 2022-11-23 at 05 29 21" src="https://user-images.githubusercontent.com/7770343/203464260-6624c0dc-60f3-4c04-8bdd-46ccd7d2e2ce.png">


Closes #3568