### PR TITLE
Fix call order status on the asset info page

### DIFF
--- a/app/lib/common/MarketClasses.js
+++ b/app/lib/common/MarketClasses.js
@@ -1002,7 +1002,7 @@ class CallOrder {
 
     getStatus() {
         const mr =
-            this.assets[this.debt_id].bitasset.current_feed
+            this.assets[this.debt_id].bitasset.median_feed
                 .maintenance_collateral_ratio / 1000;
         const cr = this.getRatio();
 


### PR DESCRIPTION
Compare order call price with median feed price but not current feed price.

Before the change, on the asset info page E.G. https://develop.bitshares.org/#/asset/CNY ,

* feed price:
![image](https://user-images.githubusercontent.com/9946777/204117090-be534806-7689-4125-bd51-4565a2e6ce57.png)

* margin positions:
![image](https://user-images.githubusercontent.com/9946777/204117108-3fbc13f0-3fd6-46f4-9eb5-5665cc76f31f.png)

After the change, the orders whose call prices are above the median of price feeds should be in red color.

Note: the numbers in the ratio column (and related data or logic elsewhere) need to be corrected with `median_feed` too, but it's much more complicated to fix.