### PR TITLE
#3352 Fix css styles for json-inspector

### DIFF
--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -88,12 +88,12 @@ h6 {
 
 .json-inspector__key {
     @include MonospaceFont;
-    text-transform: none;
+    text-transform: none !important;
 }
 
 .json-inspector__value {
     @include MonospaceFont;
-    text-transform: none;
+    text-transform: none !important;
 }
 
 button,


### PR DESCRIPTION
**Issue** #3352 

Fixed by proper css styling

<img width="598" alt="Screenshot 2023-01-30 at 14 27 21" src="https://user-images.githubusercontent.com/7770343/215476776-89da28d5-0992-4c7d-a3ac-a42628dac680.png">
