### PR TITLE
Fix release binary file hash calculation

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -15,6 +15,8 @@ jobs:
                 node-version: [16.13.x]
 
         steps:
+            - name: Install coreutils for macOS
+              run: brew install coreutils
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
@@ -37,9 +39,9 @@ jobs:
             - name: Calc hash
               id: calc_hash
               run: |
-                  echo "::set-output name=dmghash::$(sha256sum build/binaries/*.dmg|cut -c-64)"
-                  echo "::set-output name=debhash::$(sha256sum build/binaries/*.deb|cut -c-64)"
-                  echo "::set-output name=exehash::$(sha256sum build/binaries/*.exe|cut -c-64)"
+                  echo "dmghash=$(sha256sum build/binaries/*.dmg|cut -c-64)" >> $GITHUB_OUTPUT
+                  echo "debhash=$(sha256sum build/binaries/*.deb|cut -c-64)" >> $GITHUB_OUTPUT
+                  echo "exehash=$(sha256sum build/binaries/*.exe|cut -c-64)" >> $GITHUB_OUTPUT
             - name: Create Body
               id: create_body
               uses: bitshares/generate_release_notes@v1


### PR DESCRIPTION
Closes #3535 
Closes #3585
Closes #3632 

Changes:
* Install `coreutils` which contains the `sha256sum` command for `macOS`
* replace `::set-output` with `>> $GITHUB_OUTPUT`

This is for `master` branch only.
