### PR TITLE
Use totalForSale to calculate market depth displayed in order book

### DIFF
--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -779,10 +779,10 @@ class OrderBook extends React.Component {
                     );
                 });
             } else {
-                let maxBid = tempBids.length ? tempBids[tempBids.length - 1].totalToReceive().getAmount() : 0;
+                let maxBid = tempBids.length ? tempBids[tempBids.length - 1].totalForSale().getAmount() : 0;
                 
                 bidRows = tempBids.map((order, index) => {
-                    const value = order.totalToReceive().getAmount();
+                    const value = order.totalForSale().getAmount();
                     const percentage = Math.ceil(value * 100 / maxBid);
                     return horizontal ? (
                         <OrderBookRowHorizontal
@@ -818,10 +818,10 @@ class OrderBook extends React.Component {
                     );
                 });
 
-                let maxAsk = tempAsks.length ? tempAsks[tempAsks.length - 1].totalToReceive().getAmount() : 0;
+                let maxAsk = tempAsks.length ? tempAsks[tempAsks.length - 1].totalForSale().getAmount() : 0;
                 
                 askRows = tempAsks.map((order, index) => {
-                    const value = order.totalToReceive().getAmount();
+                    const value = order.totalForSale().getAmount();
                     const percentage = Math.ceil(value * 100 / maxAsk);
                     return horizontal ? (
                         <OrderBookRowHorizontal


### PR DESCRIPTION
For better view when there are orders with extremely large amounts on the order book (I still don't think the user experience after this change is good enough).

Follow-up of https://github.com/bitshares/bitshares-ui/pull/3572.

Before the change:
![image](https://user-images.githubusercontent.com/9946777/221268345-7ba26f40-0914-4f8b-9f59-1964f9018f57.png)

![image](https://user-images.githubusercontent.com/9946777/221261215-bebd33a7-2c65-422a-8d54-f3a1a8ae1700.png)

![image](https://user-images.githubusercontent.com/9946777/221262940-47918f76-f751-4b64-93ea-52b65284ee66.png)

![image](https://user-images.githubusercontent.com/9946777/221263691-4e93438b-814c-43ef-90e4-562621765995.png)

After the change:
![image](https://user-images.githubusercontent.com/9946777/221268421-5f3f259b-0ec0-4b8e-8622-2714d278b8b0.png)

![image](https://user-images.githubusercontent.com/9946777/221261399-0ebad322-57c7-4078-9293-6e66434ac1e7.png)

![image](https://user-images.githubusercontent.com/9946777/221263160-2886f93a-d579-4956-b38a-96ba4c80cc4e.png)

![image](https://user-images.githubusercontent.com/9946777/221263978-680ceb0b-179c-48db-b761-c3b68c376daf.png)
