### PR TITLE
Increase maximum collateral ratio in BorrowModalView

### DIFF
--- a/app/components/Modal/View/BorrowModalView.jsx
+++ b/app/components/Modal/View/BorrowModalView.jsx
@@ -370,7 +370,7 @@ export function BorrowModalView({
                             <Slider
                                 step={0.01}
                                 min={0}
-                                max={maintenanceRatio * 12}
+                                max={maintenanceRatio * 100}
                                 value={collateral_ratio}
                                 onChange={onRatioChange.bind(this)}
                             />


### PR DESCRIPTION
Asset `CNY16` has an `ICR` of `32` and an `MCR` of `1.003`, so users can't adjust debt positions with the current code.

![image](https://github.com/bitshares/bitshares-ui/assets/9946777/e50fe3de-f713-4179-b59e-a9265505974b)
