### PR TITLE
Update download-artifact to v4

### DIFF
--- a/.github/workflows/npm-build-and-deploy.yml
+++ b/.github/workflows/npm-build-and-deploy.yml
@@ -30,7 +30,7 @@ jobs:
             name: ${{ github.ref_name }}
 
         steps:
-            - uses: actions/download-artifact@v4.1.7
+            - uses: actions/download-artifact@v4
               with:
                   name: build-hash-binaries
                   path: build/hash-history


### PR DESCRIPTION
Use 'v4' tag which points to the latest and secure version.