### PR TITLE
Update endpoint and wallet URL for piratecash gateway

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -87,7 +87,7 @@ export const gdexAPIs = {
 };
 
 export const pirateCashAPIs = {
-    BASE: "https://piratecash.net/dexapi",
+    BASE: "https://pirate.cash/dexapi",
     COINS_LIST: "/coins"
 };
 

--- a/app/lib/common/gateways.js
+++ b/app/lib/common/gateways.js
@@ -198,8 +198,8 @@ export const availableGateways = {
             enabled: false,
             selected: false
         },
-        landing: "https://piratecash.net",
-        wallet: "https://wallet.piratecash.net/"
+        landing: "https://pirate.cash/",
+        wallet: "https://wallet.pirate.cash/"
     },
     XBTSX: {
         id: "XBTSX",


### PR DESCRIPTION
We're moving the API to the shorter domain pirate.cash from piratecash.net. Currently, the old domain has a proxy for /dexapi for backward compatibility and all other requests are redirected to the p.cash site. The pirate.cash domain will continue to support our DEX API.