### PR TITLE
Fix linear vesting policy

### DIFF
--- a/app/actions/WalletActions.js
+++ b/app/actions/WalletActions.js
@@ -277,9 +277,11 @@ class WalletActions {
 
         let balance;
         let available_percentage;
+        let available_amount;
 
         if (vb) {
             balance = vb.balance.amount;
+            available_amount = balance;
 
             // Vesting is 100% available if:
             // - policy[0] is set to 2
@@ -293,7 +295,7 @@ class WalletActions {
                     : 0;
 
             // Vesting percentage needs to be checked further
-            if (!available_percentage && vb.policy && vb.policy[0] !== 2) {
+            if (!available_percentage && vb.policy && vb.policy[0] === 1) { // cdd_vesting_policy
                 let start = Math.floor(
                     new Date(vb.policy[1].start_claim + "Z").getTime() / 1000
                 );
@@ -337,6 +339,23 @@ class WalletActions {
                     available_percentage =
                         available_percentage > 1 ? 1 : available_percentage;
                 }
+                available_amount = Math.floor(balance * available_percentage);
+            } else if (!available_percentage && vb.policy && vb.policy[0] === 0) { // linear_vesting_policy
+                let start = Math.floor(
+                    new Date(vb.policy[1].begin_timestamp + "Z").getTime() /
+                        1000
+                );
+                let now = Math.floor(new Date().getTime() / 1000);
+                let seconds_earned = Math.max(now - start, 0);
+                let seconds_period = vb.policy[1].vesting_duration_seconds;
+                let seconds_cliff = vb.policy[1].vesting_cliff_seconds;
+                let vested_percentage =
+                    seconds_earned >= seconds_period
+                        ? 1
+                        : ( (seconds_earned < seconds_cliff) ? 0 : (seconds_earned / seconds_period) );
+                let begin_balance = vb.policy[1].begin_balance;
+                let claimed_amount = begin_balance - balance;
+                available_amount = Math.max(Math.floor(begin_balance * vested_percentage) - claimed_amount, 0);
             }
         }
 
@@ -345,7 +364,7 @@ class WalletActions {
             owner: account,
             vesting_balance: vb.id,
             amount: {
-                amount: Math.floor(balance * available_percentage),
+                amount: available_amount,
                 asset_id: vb.balance.asset_id
             }
         });


### PR DESCRIPTION
<h2>General</h2>

Support claiming vesting balances with linear vesting policy.

For vesting balances with linear vesting policy, on the vesting balances page,
* fix days left of vesting period, and
* show percentage available to claim, and
* fix the amount to claim in the dialog when clicked the "claim now" button.

See screenshots below.

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [x] Check for unused code
- [x] No unrelated changes are included
- [x] None of the changed files are reformatting only
- [x] Code is self explanatory or documented
- [x] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [x] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

_Please provide screenshots/licecap of your changes below_

Before the change:
![image](https://github.com/user-attachments/assets/e78e634c-9c71-481f-9141-b9ed7e5ceb3b)
![image](https://github.com/user-attachments/assets/dc1a1f07-f9cd-4739-a3d0-eac0d6ed7cff)

After the change:
![image](https://github.com/user-attachments/assets/24db1f4b-e7d8-44dc-86ed-5f777daf446a)
![image](https://github.com/user-attachments/assets/0259ad09-93df-4667-819e-ee2e61cc7992)
