### PR TITLE
Update API nodes

### DIFF
--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -145,7 +145,7 @@ export const settingsAPIs = {
             contact: "email:admin@iobanker.com"
         },
         {
-            url: "wss://api.bts.mobi/ws",
+            url: "wss://api.bitshares.dev/ws",
             region: "Northern America",
             country: "U.S.A.",
             location: "Virginia",

--- a/app/api/apiConfig.js
+++ b/app/api/apiConfig.js
@@ -168,14 +168,14 @@ export const settingsAPIs = {
             operator: "Witness: zapata42-witness",
             contact: "telegram:Zapata_42"
         },
-        {
-            url: "wss://eu.nodes.bitshares.ws",
-            region: "Western Europe",
-            country: "Germany",
-            location: "Nuremberg",
-            operator: "Witness: blocksights",
-            contact: "telegram:blocksights"
-        },
+        //{
+        //    url: "wss://eu.nodes.bitshares.ws",
+        //    region: "Western Europe",
+        //    country: "Germany",
+        //    location: "Nuremberg",
+        //    operator: "Witness: blocksights",
+        //    contact: "telegram:blocksights"
+        //},
         {
             url: "wss://public.xbts.io/ws",
             region: "Western Europe",
@@ -217,14 +217,14 @@ export const settingsAPIs = {
             contact: "telegram:brekyrself"
         },
         // Testnet
-        {
-            url: "wss://eu.nodes.testnet.bitshares.ws",
-            region: "TESTNET - Western Europe",
-            country: "Germany",
-            location: "Nuremberg",
-            operator: "Witness: blocksights",
-            contact: "telegram:blocksights"
-        },
+        //{
+        //    url: "wss://eu.nodes.testnet.bitshares.ws",
+        //    region: "TESTNET - Western Europe",
+        //    country: "Germany",
+        //    location: "Nuremberg",
+        //    operator: "Witness: blocksights",
+        //    contact: "telegram:blocksights"
+        //},
         {
             url: "wss://testnet.dex.trading/",
             region: "TESTNET - Western Europe",
@@ -251,13 +251,13 @@ export const settingsAPIs = {
         }
     ],
     ES_WRAPPER_LIST: [
-        {
-            url: "https://api.bitshares.ws/openexplorer",
-            region: "Western Europe",
-            country: "Germany",
-            operator: "blocksights.info",
-            contact: "telegram:blocksights"
-        }
+        //{
+        //    url: "https://api.bitshares.ws/openexplorer",
+        //    region: "Western Europe",
+        //    country: "Germany",
+        //    operator: "blocksights.info",
+        //    contact: "telegram:blocksights"
+        //}
     ],
     DEFAULT_FAUCET: getFaucet().url,
     TESTNET_FAUCET: getTestFaucet().url


### PR DESCRIPTION
* [Comment out bitshares.ws URLs due to domain expiration](https://github.com/bitshares/bitshares-ui/commit/05610674d721c313b957ee3ddff1b10ff7d906a9)
* [Replace bts.mobi domain with bitshares.dev](https://github.com/bitshares/bitshares-ui/commit/f81d8e832bb6f27fd39af5c3cfea755d561cbdfc)