### PR TITLE
Fix floating point rounding errors in credit offer and BSIP38 calculations

### DIFF
--- a/app/components/Account/CreditOffer/CreateModal.jsx
+++ b/app/components/Account/CreditOffer/CreateModal.jsx
@@ -389,10 +389,15 @@ class CreateModal extends React.Component {
                         quote: new Asset({
                             asset_id: v.asset_id,
                             precision: va.get("precision")
-                        }),
-                        // real: v.getAmount({real: true}),
-                        real: 1 / v.getAmount({real: true}) // Keeping it consistent with the App, this may violate Graphene's price representation convention.
+                        })
                     });
+                    let rateSat = v.getAmount();
+                    let oneDebtSat = Math.pow(10, asset.get("precision"));
+                    let g = (function gcd(a, b) {
+                        return b ? gcd(b, a % b) : a;
+                    })(rateSat, oneDebtSat);
+                    p.base.setAmount({sats: oneDebtSat / g});
+                    p.quote.setAmount({sats: rateSat / g});
                     return [v.asset_id, p.toObject()];
                 }),
                 acceptable_borrowers: whitelist.map(v => {

--- a/app/components/Account/CreditOffer/CreditDebtList.jsx
+++ b/app/components/Account/CreditOffer/CreditDebtList.jsx
@@ -23,6 +23,7 @@ import AmountSelector from "../../Utility/AmountSelectorStyleGuide";
 import FeeAssetSelector from "../../Utility/FeeAssetSelector";
 import {checkBalance} from "common/trxHelper";
 import {ChainStore} from "bitsharesjs";
+
 import {Asset} from "../../../lib/common/MarketClasses";
 import BalanceComponent from "../../Utility/BalanceComponent";
 
@@ -441,15 +442,16 @@ class CreditDebtList extends React.Component {
             feeAmount
         } = this.state;
         let {account} = this.props;
-        let fRate = parseFloat(feeRate) / FEE_RATE_DENOM;
         let cAsset = new Asset({
             asset_id: asset.get("id"),
             real: amount,
             precision: asset.get("precision")
         });
         let cAmount = cAsset.getAmount();
-        let rate = parseFloat(cAmount) / debtAmount;
-        let cfAmount = Math.ceil(fRate * debtAmount * rate);
+        let cfAmount = Math.floor(
+            (parseInt(feeRate, 10) * cAmount + FEE_RATE_DENOM - 1) /
+                FEE_RATE_DENOM
+        );
 
         let data = {
             account,

--- a/app/components/Account/CreditOffer/EditModal.jsx
+++ b/app/components/Account/CreditOffer/EditModal.jsx
@@ -486,10 +486,15 @@ class EditModal extends React.Component {
                         quote: new Asset({
                             asset_id: v.asset_id,
                             precision: v_precision
-                        }),
-                        // real: v.getAmount({real: true}),
-                        real: 1 / v.getAmount({real: true}) //Keeping it consistent with the App, this may violate Graphene's price representation convention.
+                        })
                     });
+                    let rateSat = v.getAmount();
+                    let oneDebtSat = Math.pow(10, asset_precision);
+                    let g = (function gcd(a, b) {
+                        return b ? gcd(b, a % b) : a;
+                    })(rateSat, oneDebtSat);
+                    p.base.setAmount({sats: oneDebtSat / g});
+                    p.quote.setAmount({sats: rateSat / g});
                     return [v.asset_id, p.toObject()];
                 }),
                 acceptable_borrowers: whitelist.map(v => {

--- a/app/lib/common/MarketClasses.js
+++ b/app/lib/common/MarketClasses.js
@@ -411,20 +411,25 @@ class FeedPrice extends Price {
     getSqueezePrice({real = false} = {}) {
         if (!this._squeeze_price) {
             this._squeeze_price = this.clone();
+            let squeezeFactor = new BigNumber(this.sqr)
+                .minus(this.mcfr)
+                .times(1000);
             if (this.inverted) {
-                this._squeeze_price.base.amount = Math.floor(
-                    this._squeeze_price.base.amount *
-                        (this.sqr - this.mcfr) *
-                        1000
+                this._squeeze_price.base.amount = parseInt(
+                    squeezeFactor
+                        .times(this._squeeze_price.base.amount)
+                        .toFixed(0, BigNumber.ROUND_FLOOR)
                 );
-                this._squeeze_price.quote.amount *= 1000;
+                this._squeeze_price.quote.amount =
+                    this._squeeze_price.quote.amount * 1000;
             } else if (!this.inverted) {
-                this._squeeze_price.quote.amount = Math.floor(
-                    this._squeeze_price.quote.amount *
-                        (this.sqr - this.mcfr) *
-                        1000
+                this._squeeze_price.quote.amount = parseInt(
+                    squeezeFactor
+                        .times(this._squeeze_price.quote.amount)
+                        .toFixed(0, BigNumber.ROUND_FLOOR)
                 );
-                this._squeeze_price.base.amount *= 1000;
+                this._squeeze_price.base.amount =
+                    this._squeeze_price.base.amount * 1000;
             }
         }
 
@@ -812,25 +817,18 @@ class CallOrder {
     assignMaxDebtAndCollateral() {
         if (!this.target_collateral_ratio) return;
         let match_price = this._getMatchPrice();
-        let max_debt_to_cover = this._getMaxDebtToCover(),
-            max_debt_to_cover_int;
-        /*
-         * We may calculate like this: if max_debt_to_cover has no fractional
-         * component (e.g. 5.00 as opposed to 5.23), plus it by one Satoshi;
-         * otherwise, round it up. An effectively same approach is to round
-         * down then add one Satoshi onto the result:
-         */
-        if (Math.round(max_debt_to_cover) !== max_debt_to_cover) {
-            max_debt_to_cover_int = Math.floor(max_debt_to_cover) + 1;
-        }
+        let max_debt_to_cover = this._getMaxDebtToCover();
+        let max_debt_to_cover_int = Math.floor(max_debt_to_cover) + 1;
 
         /*
          * With max_debt_to_cover_int in integer, max_amount_to_sell_int in
          * integer can be calculated as: max_amount_to_sell_int =
          * round_up(max_debt_to_cover_int / match_price)
          */
-        let max_collateral_to_sell_int = Math.ceil(
-            max_debt_to_cover_int / match_price
+        let max_collateral_to_sell_int = parseInt(
+            new BigNumber(max_debt_to_cover_int)
+                .div(match_price)
+                .toFixed(0, BigNumber.ROUND_CEIL)
         );
 
         /* Assign to Assets */

--- a/app/lib/common/accountHelper.js
+++ b/app/lib/common/accountHelper.js
@@ -1,4 +1,5 @@
 import {FetchChain} from "bitsharesjs";
+import {BigNumber} from "bignumber.js";
 import {FeedPrice, Asset} from "./MarketClasses";
 import asset_utils from "./asset_utils";
 
@@ -79,10 +80,12 @@ function checkMarginStatus(account) {
                                 assets: assetsMap
                             });
                             let current = {
-                                ratio:
-                                    collateral.getAmount({real: true}) /
-                                    (debt.getAmount({real: true}) /
-                                        price.toReal())
+                                ratio: new BigNumber(
+                                    collateral.getAmount({real: true})
+                                )
+                                    .times(price.toReal())
+                                    .div(debt.getAmount({real: true}))
+                                    .toNumber()
                             };
                             if (isNaN(current.ratio)) return null;
                             if (current.ratio < mr) {


### PR DESCRIPTION
## Summary

Fixes 5 instances where the UI uses JavaScript float arithmetic for calculations where the Graphene core uses exact integer arithmetic. These mismatches cause the UI to compute slightly wrong amounts, leading to transaction rejections (e.g. "Insufficient collateral provided") or incorrect display values.

## Changes

### 1. CreditOfferPage.jsx — Collateral calculation (high severity)
- **Before:** `Math.ceil(parseFloat(amount) * price.toReal(true) * 10^precision)` — `price.toReal(true)` rounds to 8 decimal places, then float multiplication propagates precision loss
- **After:** Integer ceiling division matching core's `multiply_and_round_up`: `(borrowSatoshis * quote.amount + base.amount - 1) / base.amount`

### 2. MarketClasses.js — BSIP38 pipeline (high severity)
- **getSqueezePrice:** `Math.floor(int * (sqr - mcfr) * 1000)` — BigNumber multiplication to avoid float precision loss in the squeeze factor
- **assignMaxDebtAndCollateral:** `Math.ceil(int / match_price)` — BigNumber ceiling division. Also fixed missing assignment of `max_debt_to_cover_int` when value was already integer.

### 3. CreditDebtList.jsx — Repay fee calculation (medium severity)
- **Before:** `Math.ceil(parseFloat(feeRate) / 1e6 * debtAmount * cAmount / debtAmount)` — intermediate float divisions compound errors
- **After:** `Math.floor((parseInt(feeRate) * cAmount + 1e6 - 1) / 1e6)` — exact integer ceiling division matching core's `ceil(repay * fee_rate / FEE_RATE_DENOM)`

### 4. CreateModal.jsx / EditModal.jsx — Price construction (high severity)
- **Before:** `real: 1 / v.getAmount({real: true})` — float inversion, then BigNumber.toFraction() produces approximate rational
- **After:** `p.base.amount = oneDebtUnit / gcd; p.quote.amount = rateInSatoshis / gcd` — exact integer ratio from user's input

### 5. accountHelper.js — Margin ratio (medium severity)
- **Before:** `collateral / (debt / price)` — cascading float divisions
- **After:** `BigNumber(collateral).times(price).div(debt)` — single pass BigNumber to reduce float error accumulation