### PR TITLE
Switch default faucet to XBTS faucet (fix account registration)

### DIFF
--- a/app/branding.js
+++ b/app/branding.js
@@ -42,10 +42,9 @@ export function getWalletURL() {
  */
 export function getFaucet() {
     return {
-        url: "https://faucet.bitshares.eu/onboarding", // 2017-12-infrastructure worker proposal
+        url: "https://faucet.xbts.io", // XBTS faucet, see https://trade.xbts.io
         show: true,
-        editable: false,
-        referrer: "onboarding.bitshares.foundation"
+        editable: false
     };
 }
 


### PR DESCRIPTION
The old default faucet `faucet.bitshares.eu` is down (connection failures), so new-user account registration via the faucet no longer works.

Switch the default faucet to the XBTS faucet `https://faucet.xbts.io`, which is alive and is the same faucet used by https://trade.xbts.io (`faucetUrl: https://faucet.xbts.io/api/v1/accounts`).

`WalletActions.js` appends `/api/v1/accounts`, so the effective endpoint is `https://faucet.xbts.io/api/v1/accounts`.

- New users get the new default automatically.
- Users with a previously saved `faucet_address` need to reset settings to pick it up.