### PR TITLE
Fix immutable v4 Map toArray regressions (bump 3.8.2 -> 4.3.8)

### DIFF
--- a/app/components/Account/AccountAssets.jsx
+++ b/app/components/Account/AccountAssets.jsx
@@ -270,6 +270,7 @@ class AccountAssets extends React.Component {
                     </tr>
                 );
             })
+            .valueSeq()
             .toArray();
 
         return (

--- a/app/components/Dashboard/MarketsTable.jsx
+++ b/app/components/Dashboard/MarketsTable.jsx
@@ -49,6 +49,7 @@ class MarketsTable extends React.Component {
 
         if (props.markets && props.markets.size > 0) {
             let markets = props.markets
+                .valueSeq()
                 .toArray()
                 .map(market => {
                     let quote = ChainStore.getAsset(market.quote);

--- a/app/components/Exchange/MyMarkets.jsx
+++ b/app/components/Exchange/MyMarkets.jsx
@@ -704,6 +704,7 @@ class MyMarkets extends React.Component {
                     }
                 })
                 .filter(a => !!a)
+                .valueSeq()
                 .take(myMarketTab ? 100 : 20)
                 .toArray();
             return {otherMarkets: others.concat(otherMarkets), baseGroups};
@@ -781,6 +782,7 @@ class MyMarkets extends React.Component {
                 }
             })
             .filter(a => !!a)
+            .valueSeq()
             .toArray();
 
         bases = bases.concat(

--- a/app/components/Explorer/Assets.jsx
+++ b/app/components/Explorer/Assets.jsx
@@ -414,6 +414,7 @@ class Assets extends React.Component {
                         marketID
                     };
                 })
+                .valueSeq()
                 .toArray();
         }
 

--- a/app/components/QuickTrade/QuickTrade.jsx
+++ b/app/components/QuickTrade/QuickTrade.jsx
@@ -192,6 +192,7 @@ class QuickTrade extends Component {
         if (this.props.searchAssets !== prevProps.searchAssets) {
             this.setState({activeSearch: true});
             let filteredAssets = this.props.searchAssets
+                .valueSeq()
                 .toArray()
                 .filter(a => a.symbol.indexOf(this.state.lookupQuote) !== -1);
             this._checkAndUpdateMarketList(filteredAssets);

--- a/app/components/Wallet/BalanceClaimAssetTotal.jsx
+++ b/app/components/Wallet/BalanceClaimAssetTotal.jsx
@@ -31,6 +31,7 @@ class BalanceClaimAssetTotals extends Component {
                             />
                         </div>
                     ))
+                    .valueSeq()
                     .toArray()}
             </div>
         );

--- a/app/components/Wallet/BalanceClaimByAsset.jsx
+++ b/app/components/Wallet/BalanceClaimByAsset.jsx
@@ -68,6 +68,7 @@ class BalanceClaimByAsset extends Component {
                                 />
                             </div>
                         ))
+                        .valueSeq()
                         .toArray()}
                     {this.props.children}
                 </span>

--- a/app/components/Wallet/BalanceClaimSelector.jsx
+++ b/app/components/Wallet/BalanceClaimSelector.jsx
@@ -44,6 +44,7 @@ class BalanceClaimSelector extends Component {
                     </thead>
                     <tbody>
                         {this.props.total_by_account_asset
+                            .valueSeq()
                             .map((r, name_asset) => (
                                 <tr key={++index}>
                                     <td>


### PR DESCRIPTION
Fixes the remaining regressions caused by the Immutable.js 3.8.2 -> 4.3.8 bump (9223869ab, following the order-book fix #3822).

Under Immutable v4, `Map#toArray()` (and `Map#take()`/derived keyed collections) return `[key, value]` entries instead of values. These spots consumed Map-backed stores (AssetStore, groupBy OrderedMaps, defaultMarkets) as lists; a `.valueSeq()` restores the values.

Files fixed (9 sites):
- Exchange/MyMarkets.jsx (filter/take/toArray, and _getBases)
- Dashboard/MarketsTable.jsx
- QuickTrade/QuickTrade.jsx
- Account/AccountAssets.jsx
- Explorer/Assets.jsx
- Wallet/BalanceClaimByAsset.jsx, BalanceClaimAssetTotal.jsx, BalanceClaimSelector.jsx

Verified: Babel parse OK on all changed files.