### PR TITLE
Fix TradingView dark-theme axis labels and dev routing for dotted symbols

### DIFF
--- a/app/components/Exchange/TradingViewPriceChart.jsx
+++ b/app/components/Exchange/TradingViewPriceChart.jsx
@@ -126,16 +126,16 @@ class TradingViewPriceChart extends React.Component {
             locale: props.locale,
             timezone: getTVTimezone(),
             // toolbar_bg: themeColors.bgColor,
-            // theme: (props.theme == "darkTheme") ? "dark" : "light",
+            theme: props.theme === "lightTheme" ? "light" : "dark",
             overrides: {
                 "paneProperties.background": themeColors.bgColor,
                 "paneProperties.horzGridProperties.color":
                     themeColors.axisLineColor,
                 "paneProperties.vertGridProperties.color":
-                    themeColors.axisLineColor
-                // "scalesProperties.lineColor": themeColors.axisLineColor,
-                // "scalesProperties.textColor": themeColors.textColor,
-                // "scalesProperties.backgroundColor": themeColors.bgColor,
+                    themeColors.axisLineColor,
+                "scalesProperties.lineColor": themeColors.axisLineColor,
+                "scalesProperties.textColor": themeColors.textColor,
+                "scalesProperties.backgroundColor": themeColors.bgColor
                 // "mainSeriesProperties.candleStyle.upColor": "#",
                 // "mainSeriesProperties.candleStyle.downColor": "#",
                 // "mainSeriesProperties.hollowCandleStyle.upColor": "#",
@@ -151,6 +151,7 @@ class TradingViewPriceChart extends React.Component {
         });
         this.tvWidget.onChartReady(() => {
             let widget = this.tvWidget;
+            that._applyThemeVars();
             if (__DEV__) console.log("*** Chart Ready ***");
             if (__DEV__) console.timeEnd("*** Chart load time: ");
             if (!this.props.mobile && this.props.chartTools) {
@@ -227,9 +228,16 @@ class TradingViewPriceChart extends React.Component {
             state.showSaveModal !== this.state.showSaveModal ||
             np.chartHeight !== this.props.chartHeight ||
             this.props.charts.size !== np.charts.size ||
+            np.theme !== this.props.theme ||
             !this.tvWidget ||
             np.marketReady
         );
+    }
+
+    componentDidUpdate(pp) {
+        if (pp.theme !== this.props.theme && this.tvWidget) {
+            this._applyThemeVars();
+        }
     }
 
     _onWheel(e) {
@@ -290,6 +298,59 @@ class TradingViewPriceChart extends React.Component {
                     chart.enabled
             );
         chart[0] && this.tvWidget.load(chart[0].object);
+    }
+
+    _applyThemeVars() {
+        const themeVars = {
+            lightTheme: null,
+            darkTheme: {
+                "--themed-color-text-primary": "#ffffff",
+                "--themed-color-text-secondary": "#b2b5be",
+                "--themed-color-chart-page-bg": "#2a2a2a",
+                "--themed-color-pane-bg": "#2a2a2a",
+                "--themed-color-bg-primary": "#262626",
+                "--themed-color-border": "#4a4a4a",
+                "--themed-color-divider": "#4a4a4a",
+                "--themed-color-toolbar-button-text": "#bababa"
+            },
+            midnightTheme: {
+                "--themed-color-text-primary": "#e0e0e0",
+                "--themed-color-text-secondary": "#b2b5be",
+                "--themed-color-chart-page-bg": "#191a1f",
+                "--themed-color-pane-bg": "#191a1f",
+                "--themed-color-bg-primary": "#262626",
+                "--themed-color-border": "#4a4a4a",
+                "--themed-color-divider": "#4a4a4a",
+                "--themed-color-toolbar-button-text": "#b6bab7"
+            }
+        };
+        const vars = themeVars[this.props.theme];
+
+        const container = document.getElementById("tv_chart");
+        const iframe =
+            container && container.getElementsByTagName("iframe")[0];
+        const doc =
+            iframe && (iframe.contentDocument || iframe.contentWindow.document);
+        if (!doc) return;
+
+        const existing = doc.getElementById("tv-theme-vars");
+        if (!vars) {
+            if (existing) existing.parentNode.removeChild(existing);
+            return;
+        }
+
+        let style = existing;
+        if (!style) {
+            style = doc.createElement("style");
+            style.id = "tv-theme-vars";
+            doc.head.appendChild(style);
+        }
+        style.textContent =
+            ":root{" +
+            Object.keys(vars)
+                .map(key => `${key}:${vars[key]}`)
+                .join(";") +
+            "}";
     }
 
     render() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -287,7 +287,9 @@ module.exports = function(env) {
                 directory: path.join(__dirname, "app/assets/locales"),
                 publicPath: env.prod ? "" : "/"
             },
-            historyApiFallback: true,
+            historyApiFallback: {
+                disableDotRule: true
+            },
             https: https,
             devMiddleware: {
                 index: true,


### PR DESCRIPTION
## Summary
- **TradingView axis labels on dark themes:** The vendored charting-library renders x/y axis labels as DOM elements styled by `--themed-color-text-primary` (defaults to black `#1a1a1a`) and never applies the `theme-dark` class, so the widget `theme`/`scalesProperties` options have no effect. `TradingViewPriceChart` now injects the proper `--themed-color-*` variables into the chart iframe's document on chart-ready, making axis text readable (white) on dark/midnight themes.
- **Dev-server routing:** Enabled `historyApiFallback.disableDotRule` in `webpack.config.js` so market routes containing a dot (e.g. `/market/XBTSX.USDT_BTS`) fall back to `index.html` instead of returning `Cannot GET`.

## Test plan
- Hard-reload a market page with a dotted symbol (e.g. `/market/XBTSX.USDT_BTS`) on a dark/midnight theme — axis labels should be white and the page should load.
- Verify light theme still renders dark axis labels.